### PR TITLE
Added support for OS X gamepads & Improved gamepads

### DIFF
--- a/Backends/OSX/Sources/Kore/Gamepad/MacHIDManager.cpp
+++ b/Backends/OSX/Sources/Kore/Gamepad/MacHIDManager.cpp
@@ -1,0 +1,457 @@
+#include <Kore/Gamepad/MacHIDManager.h>
+#include <Kore/Gamepad/MacJoyStick.h>
+#include <Kore/Input/Gamepad.h>
+#include <Kore/Log.h>
+
+#include <iostream>
+using namespace std;
+
+using namespace Kore;
+
+//------------------------------------------------------------------------------------------------------//
+//------------------------------------------------------------------------------------------------------//
+template<typename T>
+T getDictionaryItemAsRef(CFDictionaryRef dict, const char* keyName)
+{
+	return CFDictionaryGetValue(dict, Kore_CFString(keyName));
+}
+
+template<>
+CFArrayRef getDictionaryItemAsRef(CFDictionaryRef dict, const char* keyName)
+{
+	CFTypeRef temp = CFDictionaryGetValue(dict, Kore_CFString(keyName));
+	
+	if(temp && CFGetTypeID(temp) == CFArrayGetTypeID())
+		return (CFArrayRef)temp;
+	else
+		return 0;
+}
+
+template<>
+CFStringRef getDictionaryItemAsRef(CFDictionaryRef dict, const char* keyName)
+{
+	CFTypeRef temp = CFDictionaryGetValue(dict, Kore_CFString(keyName));
+	
+	if(temp && CFGetTypeID(temp) == CFStringGetTypeID())
+		return (CFStringRef)temp;
+	else
+		return 0;
+}
+
+template<>
+CFNumberRef getDictionaryItemAsRef(CFDictionaryRef dict, const char* keyName)
+{
+	CFTypeRef temp = CFDictionaryGetValue(dict, Kore_CFString(keyName));
+	
+	if(temp && CFGetTypeID(temp) == CFNumberGetTypeID())
+		return (CFNumberRef)temp;
+	else
+		return 0;
+}
+
+//------------------------------------------------------------------------------------------------------//
+//------------------------------------------------------------------------------------------------------//
+template<typename T>
+T getArrayItemAsRef(CFArrayRef array, CFIndex idx)
+{
+	return CFArrayGetValueAtIndex(array, idx);
+}
+
+template<>
+CFDictionaryRef getArrayItemAsRef(CFArrayRef array, CFIndex idx)
+{
+	CFTypeRef temp = CFArrayGetValueAtIndex(array, idx);
+	
+	if(temp && CFGetTypeID(temp) == CFDictionaryGetTypeID())
+		return (CFDictionaryRef)temp;
+	else
+		return 0;
+}
+
+//------------------------------------------------------------------------------------------------------//
+int getInt32(CFNumberRef ref)
+{
+	int r = 0;
+	if (r) 
+		CFNumberGetValue(ref, kCFNumberIntType, &r);
+	return r;
+}
+
+//--------------------------------------------------------------------------------//
+MacHIDManager::MacHIDManager()
+{
+}
+
+//--------------------------------------------------------------------------------//
+MacHIDManager::~MacHIDManager()
+{
+	mJoyStickList.clear();
+}
+
+//------------------------------------------------------------------------------------------------------//
+void MacHIDManager::initialize()
+{
+	//Make the search more specific by adding usage flags
+	int usage = kHIDUsage_GD_Joystick;
+	int page = kHIDPage_GenericDesktop;
+	
+	io_iterator_t iterator = lookUpDevices(usage, page);
+	
+	if(iterator)
+		iterateAndOpenDevices(iterator);
+	
+	//Doesn't support multiple usage flags, iterate twice
+	usage = kHIDUsage_GD_GamePad;
+	iterator = lookUpDevices(usage, page);
+	
+	if(iterator)
+		iterateAndOpenDevices(iterator);
+	
+	// Initialize all joisticks
+	int joystickCount = totalDevices();
+	for(int i = 0; i < joystickCount; i++) {
+		MacJoyStick* joystick = create(true);
+
+		if(joystick != NULL) {
+			// Initialize the joystick
+			joystick->_initialize();
+			
+			// Get the vendor info
+			GamepadInfo* info = &Gamepad::get(joystickCount)->info;
+			size_t size = joystick->mVendor->size();
+			info->vendor = new wchar_t[size]();
+			mbstowcs(info->vendor, joystick->mVendor->c_str(), size);
+			info->devId = joystickCount++;
+			
+			// Add the joystick to the list
+			Kore::log(Kore::LogLevel::Info, "Added new joystick '%s'", (char*)joystick->mVendor->c_str());
+			mJoyStickList.push_back(joystick);
+		}
+	}
+}
+
+//------------------------------------------------------------------------------------------------------//
+io_iterator_t MacHIDManager::lookUpDevices(int usage, int page)
+{
+	CFMutableDictionaryRef deviceLookupMap = IOServiceMatching(kIOHIDDeviceKey);
+    if(!deviceLookupMap) {
+		Kore::log(Kore::LogLevel::Info, "Could not setup HID device search parameters");
+    }
+	
+	CFNumberRef usageRef = CFNumberCreate(kCFAllocatorDefault, kCFNumberIntType, &usage);
+	CFNumberRef pageRef  = CFNumberCreate(kCFAllocatorDefault, kCFNumberIntType, &page);
+	
+	CFDictionarySetValue(deviceLookupMap, CFSTR(kIOHIDPrimaryUsageKey), usageRef);
+	CFDictionarySetValue(deviceLookupMap, CFSTR(kIOHIDPrimaryUsagePageKey), pageRef);
+	
+	//IOServiceGetMatchingServices consumes the map so we do not have to release it ourself
+	io_iterator_t iterator = 0;
+	IOReturn result = IOServiceGetMatchingServices(kIOMasterPortDefault, deviceLookupMap, &iterator);
+	
+	CFRelease(usageRef);
+	CFRelease(pageRef);
+	
+	if(result == kIOReturnSuccess) {
+		return iterator;
+	} else {
+		//TODO: Throw exception instead?
+		return 0;
+	}
+}
+
+//------------------------------------------------------------------------------------------------------//
+void MacHIDManager::iterateAndOpenDevices(io_iterator_t iterator)
+{
+	io_object_t hidDevice = 0;
+	while ((hidDevice = IOIteratorNext(iterator)) !=0)
+	{
+		//Get the current registry items property map
+		CFMutableDictionaryRef propertyMap = 0;
+		if (IORegistryEntryCreateCFProperties(hidDevice, &propertyMap, kCFAllocatorDefault, kNilOptions) == KERN_SUCCESS && propertyMap)
+		{
+			//Go through device to find all needed info
+			HidInfo* hid = enumerateDeviceProperties(propertyMap);
+			
+			if(hid)
+			{
+				//todo - we need to hold an open interface so we do not have to enumerate again later
+				//should be able to watch for device removals also
+				
+				// Testing opening / closing interface
+				IOCFPlugInInterface **pluginInterface = NULL;
+				SInt32 score = 0;
+				if (IOCreatePlugInInterfaceForService(hidDevice, kIOHIDDeviceUserClientTypeID, kIOCFPlugInInterfaceID, &pluginInterface, &score) == kIOReturnSuccess)
+				{
+					IOHIDDeviceInterface **interface;
+					
+					HRESULT pluginResult = (*pluginInterface)->QueryInterface(pluginInterface, CFUUIDGetUUIDBytes(kIOHIDDeviceInterfaceID), (void **)&(interface));
+					
+                    if(pluginResult != S_OK) {
+						Kore::log(Kore::LogLevel::Info, "Not able to create plugin interface");
+                    }
+					
+					IODestroyPlugInInterface(pluginInterface);
+					
+					hid->interface = interface;
+					
+					//Check for duplicates - some devices have multiple usage
+					if(std::find(mDeviceList.begin(), mDeviceList.end(), hid) == mDeviceList.end())
+						mDeviceList.push_back(hid);
+				}
+			}
+		}
+	}
+	
+	IOObjectRelease(iterator);
+}
+
+const char* getCString(CFStringRef cfString) {
+	const char *useUTF8StringPtr = NULL;
+	UInt8 *freeUTF8StringPtr = NULL;
+
+	CFIndex stringLength = CFStringGetLength(cfString), usedBytes = 0L;
+
+	if ((useUTF8StringPtr = CFStringGetCStringPtr(cfString,	kCFStringEncodingUTF8)) == NULL) {
+		if ((freeUTF8StringPtr = (UInt8*)malloc(stringLength + 1L)) != NULL) {
+			CFStringGetBytes(cfString, CFRangeMake(0L, stringLength),
+					kCFStringEncodingUTF8, '?', false, freeUTF8StringPtr,
+					stringLength, &usedBytes);
+			freeUTF8StringPtr[usedBytes] = 0;
+			useUTF8StringPtr = (const char *) freeUTF8StringPtr;
+		}
+	}
+
+	return useUTF8StringPtr;
+}
+
+//------------------------------------------------------------------------------------------------------//
+HidInfo* MacHIDManager::enumerateDeviceProperties(CFMutableDictionaryRef propertyMap)
+{
+	HidInfo* info = new HidInfo();
+
+	CFStringRef str = getDictionaryItemAsRef<CFStringRef>(propertyMap, kIOHIDManufacturerKey);
+	if (str) {
+		const char* str_c = getCString(str);
+		if(str_c) {
+			info->vendor = str_c;
+			free((char*)str_c);
+		} else {
+			info->vendor = "Unknown Vendor";
+		}
+	}
+
+	str = getDictionaryItemAsRef<CFStringRef>(propertyMap, kIOHIDProductKey);
+	if (str) {
+		const char* str_c = getCString(str);
+		if(str_c) {
+			info->productKey = str_c;
+            // mzechner: we leak this so packr packaged apps
+            // works. I have no idea why this would fail in
+            // case of packr. My guess it register allocation
+            // and aliasing with str_c above.
+			//free((char*)str_c);
+		} else {
+			info->productKey = "Unknown Product";
+		}
+	}
+
+	info->combinedKey = info->vendor + " " + info->productKey;
+
+	//Go through all items in this device (i.e. buttons, hats, sticks, axes, etc)
+	CFArrayRef array = getDictionaryItemAsRef<CFArrayRef>(propertyMap, kIOHIDElementKey);
+	if (array)
+		for (int i = 0; i < CFArrayGetCount(array); i++)
+			parseDeviceProperties(getArrayItemAsRef<CFDictionaryRef>(array, i));
+	
+	return info;
+}
+
+//------------------------------------------------------------------------------------------------------//
+void MacHIDManager::parseDeviceProperties(CFDictionaryRef properties)
+{
+	if(!properties)
+		return;
+	
+	CFArrayRef array = getDictionaryItemAsRef<CFArrayRef>(properties, kIOHIDElementKey);
+	if (array)
+	{
+		for (int i = 0; i < CFArrayGetCount(array); i++)
+		{
+			CFDictionaryRef element = getArrayItemAsRef<CFDictionaryRef>(array, i);
+			if (element)
+			{
+				if(getInt32(getDictionaryItemAsRef<CFNumberRef>(element, kIOHIDElementTypeKey)) == kIOHIDElementTypeCollection) 
+				{	//Check if we need to recurse further intoi another collection
+					if(getInt32(getDictionaryItemAsRef<CFNumberRef>(element, kIOHIDElementUsagePageKey)) == kHIDPage_GenericDesktop)
+						parseDeviceProperties(element);
+				}
+				else
+				{
+					switch(getInt32(getDictionaryItemAsRef<CFNumberRef>(element, kIOHIDElementUsagePageKey)))
+					{
+						case kHIDPage_GenericDesktop:
+							switch(getInt32(getDictionaryItemAsRef<CFNumberRef>(element, kIOHIDElementUsageKey)))
+						{
+							case kHIDUsage_GD_Pointer:
+								cout << "\tkHIDUsage_GD_Pointer\n";
+								parseDevicePropertiesGroup(element);
+								break;
+							case kHIDUsage_GD_X:
+							case kHIDUsage_GD_Y:
+							case kHIDUsage_GD_Z:
+							case kHIDUsage_GD_Rx:
+							case kHIDUsage_GD_Ry:
+							case kHIDUsage_GD_Rz:
+								cout << "\tAxis\n";
+								break;
+							case kHIDUsage_GD_Slider:
+							case kHIDUsage_GD_Dial:
+							case kHIDUsage_GD_Wheel:
+								cout << "\tUnsupported kHIDUsage_GD_Wheel\n";
+								break;
+							case kHIDUsage_GD_Hatswitch:
+								cout << "\tUnsupported - kHIDUsage_GD_Hatswitch\n";
+								break;
+						}
+							break;
+						case kHIDPage_Button:
+							cout << "\tkHIDPage_Button\n";
+							break;
+					}
+				}
+			}
+		}
+	}
+}
+
+//------------------------------------------------------------------------------------------------------//
+void MacHIDManager::parseDevicePropertiesGroup(CFDictionaryRef properties)
+{
+	if(!properties)
+		return;
+	
+	CFArrayRef array = getDictionaryItemAsRef<CFArrayRef>(properties, kIOHIDElementKey);
+	if(array)
+	{
+		for (int i = 0; i < CFArrayGetCount(array); i++)
+		{
+			CFDictionaryRef element = getArrayItemAsRef<CFDictionaryRef>(array, i);
+			if (element)
+			{
+				switch(getInt32(getDictionaryItemAsRef<CFNumberRef>(element, kIOHIDElementUsagePageKey)))
+				{
+					case kHIDPage_GenericDesktop:
+						switch(getInt32(getDictionaryItemAsRef<CFNumberRef>(element, kIOHIDElementUsageKey)))
+					{
+						case kHIDUsage_GD_X:
+						case kHIDUsage_GD_Y:
+						case kHIDUsage_GD_Z:
+						case kHIDUsage_GD_Rx:
+						case kHIDUsage_GD_Ry:
+						case kHIDUsage_GD_Rz:
+							cout << "\t\tAxis\n";
+							break;
+						case kHIDUsage_GD_Slider:
+						case kHIDUsage_GD_Dial:
+						case kHIDUsage_GD_Wheel:
+							cout << "\tUnsupported - kHIDUsage_GD_Wheel\n";
+							break;
+						case kHIDUsage_GD_Hatswitch:
+							cout << "\tUnsupported - kHIDUsage_GD_Hatswitch\n";
+							break;
+					}
+						break;
+					case kHIDPage_Button:
+						break;
+				}
+			}
+		}
+	}
+}
+
+//--------------------------------------------------------------------------------//
+DeviceList MacHIDManager::freeDeviceList()
+{
+	DeviceList ret;
+	HidInfoList::iterator it = mDeviceList.begin(), end = mDeviceList.end();
+	for(; it != end; ++it)
+	{
+		if((*it)->inUse == false)
+			ret.push_back((*it)->combinedKey);
+	}
+	
+	return ret;
+}
+
+//--------------------------------------------------------------------------------//
+int MacHIDManager::totalDevices()
+{
+	return (int)mDeviceList.size();
+}
+
+//--------------------------------------------------------------------------------//
+int MacHIDManager::freeDevices()
+{
+	int ret = 0;
+	HidInfoList::iterator it = mDeviceList.begin(), end = mDeviceList.end();
+	
+	for(; it != end; ++it)
+	{
+		if((*it)->inUse == false)
+			ret++;
+	}
+	
+	return ret;
+}
+
+//--------------------------------------------------------------------------------//
+bool MacHIDManager::vendorExist(const std::string & vendor)
+{
+	HidInfoList::iterator it = mDeviceList.begin(), end = mDeviceList.end();
+	
+	for(; it != end; ++it)
+	{
+		if((*it)->combinedKey == vendor)
+			return true;
+	}
+	
+	return false;
+}
+
+//--------------------------------------------------------------------------------//
+MacJoyStick* MacHIDManager::create(bool bufferMode, const std::string & vendor)
+{
+	MacJoyStick* obj = 0;
+	
+	HidInfoList::iterator it = mDeviceList.begin(), end = mDeviceList.end();
+	for(; it != end; ++it)
+	{
+		if((*it)->inUse == false && (vendor == "" || (*it)->combinedKey == vendor))
+		{
+			int totalDevs = totalDevices();
+			int freeDevs = freeDevices();
+			int devID = totalDevs - freeDevs;
+
+			obj = new MacJoyStick((*it)->combinedKey, bufferMode, *it, devID);
+			(*it)->inUse = true;
+			return obj;
+        }
+	}
+	
+	return obj;
+}
+
+//--------------------------------------------------------------------------------//
+void MacHIDManager::destroy(MacJoyStick* obj)
+{
+	delete obj;
+}
+
+//--------------------------------------------------------------------------------//
+void MacHIDManager::update()
+{
+	for(int i = 0; i < mJoyStickList.size(); i++) {
+		mJoyStickList[i]->capture();
+	}
+}
+

--- a/Backends/OSX/Sources/Kore/Gamepad/MacHIDManager.h
+++ b/Backends/OSX/Sources/Kore/Gamepad/MacHIDManager.h
@@ -1,0 +1,127 @@
+#pragma once
+
+
+#include <vector>
+#include <string>
+#include <map>
+#include <list>
+
+#include <CoreFoundation/CoreFoundation.h>
+#import <CoreFoundation/CFString.h>
+#import <IOKit/IOKitLib.h>
+#import <IOKit/IOCFPlugIn.h>
+#import <IOKit/hid/IOHIDLib.h>
+#import <IOKit/hid/IOHIDKeys.h>
+#import <Kernel/IOKit/hidsystem/IOHIDUsageTables.h>
+
+namespace Kore
+{
+    class MacJoyStick;
+
+    //! Map of device objects connected and their respective vendors
+    typedef std::vector<std::string> DeviceList;
+    
+    /**
+     Simple wrapper class for CFString which will create a valid CFString and retain ownership until class instance is outof scope
+     To Access the CFStringRef instance, simply cast to void*, pass into a function expecting a void* CFStringRef object, or access via cf_str() method
+     */
+    class Kore_CFString
+    {
+    public:
+        Kore_CFString() { m_StringRef = CFStringCreateWithCString(NULL, "", kCFStringEncodingUTF8); }
+        Kore_CFString(const char* c_str) { m_StringRef = CFStringCreateWithCString(NULL, c_str, kCFStringEncodingUTF8); }
+        Kore_CFString(const std::string &s_str) { m_StringRef = CFStringCreateWithCString(NULL, s_str.c_str(), kCFStringEncodingUTF8); }
+        ~Kore_CFString() { CFRelease(m_StringRef); }
+        
+        //Allow this class to be autoconverted to base class of StringRef (void*)
+        operator void*() { return (void*)m_StringRef; }
+        CFStringRef cf_str() { return m_StringRef; }
+        
+    private:
+        CFStringRef m_StringRef;
+    };
+    
+	//Information needed to create Mac HID Devices
+	class HidInfo
+	{
+	public:
+		HidInfo() : numButtons(0), numHats(0), numAxes(0), inUse(false), interface(0)
+		{
+		}
+
+		//Useful tracking information
+		std::string vendor;
+		std::string productKey;
+		std::string combinedKey;
+
+		//Retain some count information for recreating devices without having to reparse
+		int numButtons;
+		int numHats;
+		int numAxes;
+		bool inUse;
+
+		//Used for opening a read/write/tracking interface to device
+		IOHIDDeviceInterface **interface;
+	};
+
+	typedef std::vector<HidInfo*> HidInfoList;
+		
+	class MacHIDManager
+	{
+	public:
+		MacHIDManager();
+		~MacHIDManager();
+
+		void initialize();
+		
+		void iterateAndOpenDevices(io_iterator_t iterator);
+		io_iterator_t lookUpDevices(int usage, int page);
+
+        /**
+         @remarks Return a list of all unused devices the factory maintains
+         */
+        DeviceList freeDeviceList();
+
+        /**
+         @remarks Number of devices
+         */
+        int totalDevices();
+
+        /**
+         @remarks Number of free devices
+         */
+        int freeDevices();
+
+        /**
+         @remarks Does a device exist with the given vendor name
+         @param vendor Vendor name to test
+         */
+        bool vendorExist(const std::string & vendor);
+
+        /**
+         @remarks Creates the object
+         @param bufferMode True to setup for buffered events
+         @param vendor Create a device with the vendor name, "" means vendor name is unimportant
+         */
+        MacJoyStick* create(bool bufferMode, const std::string & vendor = "");
+
+        /**
+         @remarks Destroys object
+         @param obj Object to destroy
+         */
+        void destroy(MacJoyStick* obj);
+        
+        /**
+         @remarks Update all joysticks
+         */
+        void update();
+
+	private:
+		HidInfo* enumerateDeviceProperties(CFMutableDictionaryRef propertyMap);
+		void parseDeviceProperties(CFDictionaryRef properties);
+		void parseDevicePropertiesGroup(CFDictionaryRef properties);
+
+		HidInfoList mDeviceList;
+        std::vector<MacJoyStick*> mJoyStickList;
+	};
+}

--- a/Backends/OSX/Sources/Kore/Gamepad/MacJoyStick.cpp
+++ b/Backends/OSX/Sources/Kore/Gamepad/MacJoyStick.cpp
@@ -1,0 +1,285 @@
+#include <Kore/Gamepad/MacJoyStick.h>
+#include <Kore/Gamepad/MacHIDManager.h>
+#include <Kore/Input/Gamepad.h>
+#include <Kore/Log.h>
+
+#include <cassert>
+
+using namespace Kore;
+
+//--------------------------------------------------------------------------------------------------//
+MacJoyStick::MacJoyStick(const std::string &vendor, bool buffered, HidInfo* info, int devID) :
+mBuffered(buffered), mDevID(devID), mInfo(info)
+{
+    mVendor =  new std::string(vendor);
+}
+
+//--------------------------------------------------------------------------------------------------//
+MacJoyStick::~MacJoyStick()
+{
+	//TODO: check if the queue has been started first?
+	//(*mQueue)->stop(mQueue); 
+	(*mQueue)->dispose(mQueue); 
+	(*mQueue)->Release(mQueue); 
+	
+    if(mVendor != nullptr) {
+        delete mVendor;
+        mVendor = nullptr;
+    }
+	
+	//TODO: check if the interface has been opened first?
+	(*mInfo->interface)->close(mInfo->interface);
+	(*mInfo->interface)->Release(mInfo->interface); 
+}
+
+//--------------------------------------------------------------------------------------------------//
+void MacJoyStick::_initialize()
+{
+	assert(mInfo != 0);
+	assert(mInfo->interface != 0);
+	
+	//TODO: Is this necessary?
+	//Clear old state
+	mState.mAxes.clear();
+	
+    if ((*mInfo->interface)->open(mInfo->interface, 0) != KERN_SUCCESS) {
+        Kore::log(Kore::LogLevel::Info, "MacJoyStick::_initialize() >> Could not initialize joy device!");
+        return;
+    }
+    
+	mState.clear();
+	
+	_enumerateCookies();
+	
+	mState.mButtons.resize(mInfo->numButtons);
+	mState.mAxes.resize(mInfo->numAxes);
+	
+    mQueue = _createQueue();
+}
+
+class FindAxisCookie : public std::unary_function<std::pair<IOHIDElementCookie, AxisInfo>&, bool>
+{
+public:
+	FindAxisCookie(IOHIDElementCookie cookie) : m_Cookie(cookie) {}
+	bool operator()(const std::pair<IOHIDElementCookie, AxisInfo>& pair) const
+	{
+		return pair.first == m_Cookie;
+	}
+private:
+	IOHIDElementCookie m_Cookie;
+};
+
+//--------------------------------------------------------------------------------------------------//
+void MacJoyStick::capture()
+{
+ 	assert(mQueue != 0);
+	
+	AbsoluteTime zeroTime = {0,0}; 
+	
+	IOHIDEventStruct event; 
+	IOReturn result = (*mQueue)->getNextEvent(mQueue, &event, zeroTime, 0);
+    
+	while(result == kIOReturnSuccess)
+	{
+		switch(event.type)
+		{
+			case kIOHIDElementTypeInput_Button:
+			{
+				std::vector<IOHIDElementCookie>::iterator buttonIt = std::find(mCookies.buttonCookies.begin(), mCookies.buttonCookies.end(), event.elementCookie);
+				int button = (int)std::distance(mCookies.buttonCookies.begin(), buttonIt);
+				mState.mButtons[button] = (event.value == 1);
+				
+                if(mBuffered && Gamepad::get(mDevID)->Button != nullptr)
+				{
+					if(event.value == 1)
+						Gamepad::get(mDevID)->Button(button, 1.0f);
+					else if(event.value == 0)
+                        Gamepad::get(mDevID)->Button(button, 0.0f);
+				}
+				break;
+			}
+			case kIOHIDElementTypeInput_Misc:
+				//TODO: It's an axis! - kind of - for gamepads - or should this be a pov?
+			case kIOHIDElementTypeInput_Axis:
+				std::map<IOHIDElementCookie, AxisInfo>::iterator axisIt = std::find_if(mCookies.axisCookies.begin(), mCookies.axisCookies.end(), FindAxisCookie(event.elementCookie));
+				int axis = (int)std::distance(mCookies.axisCookies.begin(), axisIt);
+				
+				const AxisInfo& axisInfo = axisIt->second;
+				float proportion = (float) (event.value - axisInfo.max) / (float) (axisInfo.min - axisInfo.max);
+				mState.mAxes[axis].abs = -MacJoyStick::MIN_AXIS - (MacJoyStick::MAX_AXIS * 2 * proportion);
+				
+                if(mBuffered && Gamepad::get(mDevID)->Axis != nullptr)
+                    Gamepad::get(mDevID)->Axis(axis, mState.mAxes[axis].abs);
+				break;
+		}
+		
+		result = (*mQueue)->getNextEvent(mQueue, &event, zeroTime, 0);
+	}
+}
+
+//--------------------------------------------------------------------------------------------------//
+void MacJoyStick::setBuffered(bool buffered)
+{
+	mBuffered = buffered;
+}
+
+//--------------------------------------------------------------------------------------------------//
+void MacJoyStick::_enumerateCookies()
+{
+	assert(mInfo != 0);
+	assert(mInfo->interface != 0);
+	
+	CFTypeRef                               object; 
+	long                                    number; 
+	IOHIDElementCookie                      cookie; 
+	long                                    usage; 
+	long                                    usagePage;
+	int										min;
+	int										max;
+
+	CFDictionaryRef                         element; 
+	
+	// Copy all elements, since we're grabbing most of the elements 
+	// for this device anyway, and thus, it's faster to iterate them 
+	// ourselves. When grabbing only one or two elements, a matching 
+	// dictionary should be passed in here instead of NULL. 
+	CFArrayRef elements; 
+	IOReturn success = reinterpret_cast<IOHIDDeviceInterface122*>(*mInfo->interface)->copyMatchingElements(mInfo->interface, NULL, &elements); 
+	
+	if (success == kIOReturnSuccess)
+	{ 
+		const CFIndex numOfElements = CFArrayGetCount(elements);
+		for (CFIndex i = 0; i < numOfElements; ++i) 
+		{ 
+			element = static_cast<CFDictionaryRef>(CFArrayGetValueAtIndex(elements, i));
+			
+			//Get cookie 
+			object = (CFDictionaryGetValue(element, 
+										   CFSTR(kIOHIDElementCookieKey))); 
+			if (object == 0 || CFGetTypeID(object) != CFNumberGetTypeID()) 
+				continue; 
+			if(!CFNumberGetValue((CFNumberRef) object, kCFNumberLongType, 
+								 &number)) 
+				continue; 
+			cookie = (IOHIDElementCookie) number; 
+			
+			//Get usage 
+			object = CFDictionaryGetValue(element, 
+										  CFSTR(kIOHIDElementUsageKey)); 
+			if (object == 0 || CFGetTypeID(object) != CFNumberGetTypeID()) 
+				continue; 
+			if (!CFNumberGetValue((CFNumberRef) object, kCFNumberLongType, 
+								  &number)) 
+				continue; 
+			usage = number; 
+			
+			//Get min
+			object = CFDictionaryGetValue(element,
+										  CFSTR(kIOHIDElementMinKey)); // kIOHIDElementMinKey or kIOHIDElementScaledMinKey?, no idea ...
+			if (object == 0 || CFGetTypeID(object) != CFNumberGetTypeID())
+				continue;
+			if (!CFNumberGetValue((CFNumberRef) object, kCFNumberIntType,
+								  &number))
+				continue;
+			min = (int)number;
+			
+			//Get max
+			object = CFDictionaryGetValue(element,
+										  CFSTR(kIOHIDElementMaxKey)); // kIOHIDElementMaxKey or kIOHIDElementScaledMaxKey?, no idea ...
+			if (object == 0 || CFGetTypeID(object) != CFNumberGetTypeID())
+				continue;
+			if (!CFNumberGetValue((CFNumberRef) object, kCFNumberIntType,
+								  &number))
+				continue;
+			max = (int)number;
+			
+			//Get usage page 
+			object = CFDictionaryGetValue(element, 
+										  CFSTR(kIOHIDElementUsagePageKey)); 
+			
+			if (object == 0 || CFGetTypeID(object) != CFNumberGetTypeID()) 
+				continue; 
+			
+			if (!CFNumberGetValue((CFNumberRef) object, kCFNumberLongType, 
+								  &number)) 
+				continue; 
+			
+			usagePage = number;
+			switch(usagePage)
+			{
+				case kHIDPage_GenericDesktop:
+					switch(usage)
+				{
+					case kHIDUsage_GD_Pointer:
+						break;
+					case kHIDUsage_GD_X:
+					case kHIDUsage_GD_Y:
+					case kHIDUsage_GD_Z:
+					case kHIDUsage_GD_Rx:
+					case kHIDUsage_GD_Ry:
+					case kHIDUsage_GD_Rz:
+						mCookies.axisCookies.insert(std::make_pair(cookie, AxisInfo(min, max)));
+						break;
+					case kHIDUsage_GD_Slider:
+					case kHIDUsage_GD_Dial:
+					case kHIDUsage_GD_Wheel:
+						break;
+					case kHIDUsage_GD_Hatswitch:
+						break;
+				}
+					break;
+				case kHIDPage_Button:
+					mCookies.buttonCookies.push_back(cookie);
+					break;
+			}		
+		}
+		
+		mInfo->numButtons = (int)mCookies.buttonCookies.size();
+		mInfo->numAxes = (int)mCookies.axisCookies.size();
+
+	} else {
+        Kore::log(Kore::LogLevel::Info, "JoyStick elements could not be copied: copyMatchingElements failed with error: %d", success);
+	}
+	
+}
+
+//--------------------------------------------------------------------------------------------------//
+IOHIDQueueInterface** MacJoyStick::_createQueue(unsigned int depth)
+{	
+	assert(mInfo != 0);
+	assert(mInfo->interface != 0);
+	
+	IOHIDQueueInterface** queue = (*mInfo->interface)->allocQueue(mInfo->interface); 
+	
+	if (queue)  {
+		//create the queue 
+		IOReturn result = (*queue)->create(queue, 0, depth); 
+		
+		if(result == kIOReturnSuccess) {
+			//add elements to the queue
+			std::map<IOHIDElementCookie, AxisInfo>::iterator axisIt = mCookies.axisCookies.begin();
+			for(; axisIt != mCookies.axisCookies.end(); ++axisIt) {
+				result = (*queue)->addElement(queue, axisIt->first, 0);
+			}
+			
+			std::vector<IOHIDElementCookie>::iterator buttonIt = mCookies.buttonCookies.begin();
+			for(; buttonIt != mCookies.buttonCookies.end(); ++buttonIt) {
+				result = (*queue)->addElement(queue, (*buttonIt), 0);
+			}
+
+			//start data delivery to queue 
+			result = (*queue)->start(queue); 
+			if(result == kIOReturnSuccess) {
+				return queue;
+			} else {
+				Kore::log(Kore::LogLevel::Info, "Queue could not be started.");
+			}
+		} else {
+				Kore::log(Kore::LogLevel::Info, "Queue could not be created.");
+		}
+	} else {
+        Kore::log(Kore::LogLevel::Info, "Queue allocation failed.");
+	}
+    
+    return 0;
+}

--- a/Backends/OSX/Sources/Kore/Gamepad/MacJoyStick.h
+++ b/Backends/OSX/Sources/Kore/Gamepad/MacJoyStick.h
@@ -1,0 +1,173 @@
+#pragma once
+
+#include <Kore/Gamepad/MacHIDManager.h>
+#include <Kore/Math/Vector.h>
+
+namespace Kore
+{
+    //! Axis component
+    class Axis
+    {
+    public:
+        Axis() : abs(0), rel(0), absOnly(false) {};
+        
+        //! Absoulte and Relative value components
+        int abs, rel;
+        
+        //! Indicates if this Axis only supports Absoulte (ie JoyStick)
+        bool absOnly;
+        
+        //! Used internally by OIS
+        void clear()
+        {
+            abs = rel = 0;
+        }
+    };
+    
+    //! POV / HAT Joystick component
+    class Pov
+    {
+    public:
+        Pov() : direction(0) {}
+        
+        static const int Centered  = 0x00000000;
+        static const int North     = 0x00000001;
+        static const int South     = 0x00000010;
+        static const int East      = 0x00000100;
+        static const int West      = 0x00001000;
+        static const int NorthEast = 0x00000101;
+        static const int SouthEast = 0x00000110;
+        static const int NorthWest = 0x00001001;
+        static const int SouthWest = 0x00001010;
+        
+        int direction;
+    };
+    
+    //! A sliding axis - only used in Win32 Right Now
+    class Slider
+    {
+    public:
+        Slider() : abX(0), abY(0) {};
+        //! true if pushed, false otherwise
+        int abX, abY;
+    };
+    
+	struct AxisInfo
+	{
+		int min;
+		int max;
+		
+		AxisInfo(int min, int max)
+			: min(min), max(max) {}
+	};
+	
+	typedef struct cookie_struct 
+	{ 
+		std::map<IOHIDElementCookie, AxisInfo> axisCookies; 			
+		std::vector<IOHIDElementCookie> buttonCookies; 
+	} cookie_struct_t;
+	
+	/**
+		Represents the state of the joystick
+		All members are valid for both buffered and non buffered mode
+		Sticks with zero values are not present on the device
+	 */
+	class JoyStickState
+	{
+	public:
+		//! Constructor
+		JoyStickState() { clear(); }
+		
+		//! Represents all the buttons (uses a bitset)
+		std::vector<bool> mButtons;
+		
+		//! Represents all the single axes on the device
+		std::vector<Axis> mAxes;
+		
+		//! Represents the value of a POV. Maximum of 4
+		Pov mPOV[4];
+		
+		//! Represent the max sliders
+		Slider mSliders[4];
+		
+		//! Represents all Vector type controls the device exports
+		std::vector<vec3> mVectors;
+		
+		//! internal method to reset all variables to initial values
+		void clear()
+		{
+			for( std::vector<bool>::iterator i = mButtons.begin(), e = mButtons.end(); i != e; ++i )
+			{
+				(*i) = false;
+			}
+			
+			for( std::vector<Axis>::iterator i = mAxes.begin(), e = mAxes.end(); i != e; ++i )
+			{
+				i->absOnly = true; //Currently, joysticks only report Absolute values
+				i->clear();
+			}
+			
+			for( std::vector<vec3>::iterator i = mVectors.begin(), e = mVectors.end(); i != e; ++i )
+			{
+				i->set(0, 0, 0);
+			}
+			
+			for( int i = 0; i < 4; ++i )
+			{
+				mPOV[i].direction = Pov::Centered;
+				mSliders[i].abX = mSliders[i].abY = 0;
+			}
+		}
+	};
+	
+	//class HidDeviceInfo
+	
+	class MacJoyStick
+	{
+	public:
+		MacJoyStick(const std::string& vendor, bool buffered, HidInfo* info, int devID);
+		
+		virtual ~MacJoyStick();
+		
+		/** @copydoc Object::setBuffered */
+		virtual void setBuffered(bool buffered);
+		
+		/** @copydoc Object::capture */
+		virtual void capture();
+				
+		/** @copydoc Object::_initialize */
+		virtual void _initialize();
+		
+		void _enumerateCookies();
+        
+        //! Vendor name if applicable/known
+        std::string* mVendor;
+        
+		IOHIDQueueInterface** _createQueue(unsigned int depth = 8);
+	protected:
+		HidInfo* mInfo;
+		cookie_struct_t mCookies;
+		IOHIDQueueInterface** mQueue;
+		
+        //! Buffered flag
+        bool mBuffered;
+        
+        //! Not fully implemented yet
+        int mDevID;
+        
+		//! Number of sliders
+		int mSliders;
+		
+		//! Number of POVs
+		int mPOVs;
+		
+		//! The minimal axis value
+		static const int MIN_AXIS = -32768;
+		
+		//! The maximum axis value
+		static const int MAX_AXIS = 32767;
+		
+		//! The JoyStickState structure (contains all component values)
+		JoyStickState mState;
+	};
+}

--- a/Backends/OSX/Sources/Kore/System.mm
+++ b/Backends/OSX/Sources/Kore/System.mm
@@ -2,6 +2,8 @@
 #include <Kore/System.h>
 #include <Kore/Application.h>
 #include <Kore/Input/Keyboard.h>
+#include <Kore/Gamepad/MacHIDManager.h>
+#include <Kore/Log.h>
 #import <Cocoa/Cocoa.h>
 #import "BasicOpenGLView.h"
 
@@ -35,6 +37,7 @@ namespace {
 	NSWindow* window;
 	BasicOpenGLView* view;
 	MyAppDelegate* delegate;
+	MacHIDManager* im;
 }
 
 bool System::handleMessages() {
@@ -43,6 +46,8 @@ bool System::handleMessages() {
 		[myapp sendEvent:event];
 		[myapp updateWindows];
 	}
+	if(im != nullptr)
+		im->update();
 	return true;
 }
 
@@ -124,12 +129,19 @@ int main(int argc, char** argv) {
 	return 0;
 }
 
+void loadGamepadInfo()
+{
+	im = new MacHIDManager();
+	im->initialize();
+}
+
 @implementation MyApplication
 
 - (void)run {
 	@autoreleasepool {
 		[self finishLaunching];
 		//try {
+			loadGamepadInfo();
 			kore(0, nullptr);
 		//}
 		//catch (Kt::Exception& ex) {
@@ -140,6 +152,8 @@ int main(int argc, char** argv) {
 
 - (void)terminate:(id)sender {
 	Application::the()->stop();
+	delete im;
+	im = nullptr;
 }
 
 @end
@@ -148,6 +162,8 @@ int main(int argc, char** argv) {
 
 - (void)windowWillClose:(NSNotification *)notification {
 	Application::the()->stop();
+	delete im;
+	im = nullptr;
 }
 
 @end

--- a/Sources/Kore/Input/Gamepad.h
+++ b/Sources/Kore/Input/Gamepad.h
@@ -1,6 +1,15 @@
 #pragma once
 
 namespace Kore {
+	// Information about the gamepad
+	class GamepadInfo {
+	public:
+		GamepadInfo() : devId(-1), vendor(nullptr), producName(nullptr) {};
+		int devId;
+		wchar_t* vendor;
+		wchar_t* producName;
+	};
+
 	class Gamepad {
 	public:
 		static Gamepad* get(int num);
@@ -10,5 +19,7 @@ namespace Kore {
 		//called by backend
 		void _axis(int axis, float value);
 		void _button(int button, float value);
+
+		GamepadInfo info;
 	};
 }

--- a/korefile.js
+++ b/korefile.js
@@ -70,6 +70,7 @@ else if (platform === Platform.OSX) {
 	addBackend('OSX');
 	addBackend('OpenGL2');
 	project.addDefine('OPENGL');
+	project.addLib('IOKit');
 	project.addLib('Cocoa');
 	project.addLib('AppKit');
 	project.addLib('CoreAudio');


### PR DESCRIPTION
Added a small gamepad info.
This should allow to identify the type of controller we have, in Windows platforms this may not be needed because all gamepads normally map to XBox one's, but on OS X and Linux this should allow users to know which key was pressed depending on the controller product name / vendor

Added support for OS X gamepads as well, OS X code was taken from OIS system.

I still need to add support for & Linux, will do in the following days!
