### PR TITLE
Implementation for locking the mouse under linux

### DIFF
--- a/Backends/Linux/Sources/Kore/Input/Mouse.cpp
+++ b/Backends/Linux/Sources/Kore/Input/Mouse.cpp
@@ -55,7 +55,6 @@ bool Mouse::canLock(){
 
 void Mouse::show(bool truth){
 	//TODO
-    log(Info, "show called");
 }
 
 void Mouse::setPosition(int x, int y){
@@ -79,7 +78,6 @@ void Mouse::getPosition(int& x, int& y){
     Window inwin;      /* root window the pointer is in */
     Window inchildwin; /* child win the pointer is in */
     int rootx, rooty; /* relative to the "root" window; */
-    Atom atom_type_prop;
     unsigned int mask;
 
     /* Open a connection with X11 server and get the root window */

--- a/Backends/Linux/Sources/Kore/Input/Mouse.cpp
+++ b/Backends/Linux/Sources/Kore/Input/Mouse.cpp
@@ -3,9 +3,6 @@
 #include <Kore/Log.h>
 #include <Kore/System.h>
 
-#include <stdio.h>
-#include <stdlib.h>
-
 #include <GL/glx.h>
 #include <GL/gl.h>
 

--- a/Backends/Linux/Sources/Kore/Input/Mouse.cpp
+++ b/Backends/Linux/Sources/Kore/Input/Mouse.cpp
@@ -1,5 +1,15 @@
 #include "../pch.h"
 #include <Kore/Input/Mouse.h>
+#include <Kore/Log.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <GL/glx.h>
+#include <GL/gl.h>
+
+#include <X11/X.h>
+#include <X11/keysym.h>
 
 using namespace Kore;
 
@@ -9,18 +19,50 @@ void Mouse::_lock(bool truth){
 
 
 bool Mouse::canLock(){
-	return false; //FOR NOW
+	return true; //FOR NOW
 }
 
 
 void Mouse::show(bool truth){
 	//TODO
+    log(Info, "show called");
 }
 
 void Mouse::setPosition(int x, int y){
-	//TODO
+
+    log(Info, "setPosition");
+    /*
+	Display *dpy;
+    Window root_window;
+
+    dpy = XOpenDisplay(0);
+    root_window = XRootWindow(dpy, 0);
+    XSelectInput(dpy, root_window, KeyReleaseMask);
+    XWarpPointer(dpy, None, root_window, 0, 0, 0, 0, 100, 100);
+    XFlush(dpy); // Flushes the output buffer, therefore updates the cursor's position. Thanks to Achernar.*/
 }
 
 void Mouse::getPosition(int& x, int& y){
-	//TODO
+	Display *dpy;
+    Window inwin;      /* root window the pointer is in */
+    Window inchildwin; /* child win the pointer is in */
+    int rootx, rooty; /* relative to the "root" window; */
+    Atom atom_type_prop;
+    int actual_format;   /* should be 32 after the call */
+    unsigned int mask;   /* status of the buttons */
+    unsigned long n_items, bytes_after_ret;
+    Window *props;
+
+    /* default DISPLAY */
+    dpy = XOpenDisplay(NULL);
+
+    (void)XGetWindowProperty(dpy, DefaultRootWindow(dpy),
+               XInternAtom(dpy, "_NET_ACTIVE_WINDOW", True),
+               0, 1, False, AnyPropertyType,
+               &atom_type_prop, &actual_format,
+               &n_items, &bytes_after_ret, (unsigned char**)&props);
+
+    XQueryPointer(dpy, props[0], &inwin,  &inchildwin,
+        &rootx, &rooty, &x, &y, &mask);
+    int i = 0;
 }

--- a/Backends/Linux/Sources/Kore/Input/Mouse.cpp
+++ b/Backends/Linux/Sources/Kore/Input/Mouse.cpp
@@ -15,12 +15,41 @@
 using namespace Kore;
 
 void Mouse::_lock(bool truth){
-	//TODO
+    show(!truth);
+    if (truth) {
+        int width = System::screenWidth(),
+            height = System::screenHeight(),
+            x,y, newX, newY;
+        getPosition(x, y);
+
+        // Guess the new position of X and Y
+        newX = x;
+        newY = y;
+
+        // Correct the position of the X coordinate
+        // if the mouse is out the window
+        if (x < 0) {
+            newX -= x;
+        } else if (x > width) {
+            newX -= x - width;
+        }
+
+        // Correct the position of the Y coordinate
+        // if the mouse is out the window
+        if (y < 0) {
+            newY -= y;
+        } else if (y > height){
+            newY -= y - height;
+        }
+
+        // Force the mouse to stay inside the window
+        setPosition(newX, newY);
+    }
 }
 
 
 bool Mouse::canLock(){
-	return true; //FOR NOW
+	return true;
 }
 
 
@@ -33,12 +62,15 @@ void Mouse::setPosition(int x, int y){
 
 	Display *dpy;
     Window win;
+
     /* Open a connection with X11 server and get the root window */
     dpy = XOpenDisplay(0);
     win = System::getWindow();
     /* Set the pointer position */
     XWarpPointer(dpy, None, win, 0, 0, 0, 0, x, y);
     XFlush(dpy); // Flushes the output buffer, therefore updates the cursor's position.
+    // Close the opened connection
+    XCloseDisplay(dpy);
 }
 
 void Mouse::getPosition(int& x, int& y){

--- a/Backends/Linux/Sources/Kore/Input/Mouse.cpp
+++ b/Backends/Linux/Sources/Kore/Input/Mouse.cpp
@@ -1,6 +1,7 @@
 #include "../pch.h"
 #include <Kore/Input/Mouse.h>
 #include <Kore/Log.h>
+#include <Kore/System.h>
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -30,39 +31,32 @@ void Mouse::show(bool truth){
 
 void Mouse::setPosition(int x, int y){
 
-    log(Info, "setPosition");
-    /*
 	Display *dpy;
-    Window root_window;
-
+    Window win;
+    /* Open a connection with X11 server and get the root window */
     dpy = XOpenDisplay(0);
-    root_window = XRootWindow(dpy, 0);
-    XSelectInput(dpy, root_window, KeyReleaseMask);
-    XWarpPointer(dpy, None, root_window, 0, 0, 0, 0, 100, 100);
-    XFlush(dpy); // Flushes the output buffer, therefore updates the cursor's position. Thanks to Achernar.*/
+    win = System::getWindow();
+    /* Set the pointer position */
+    XWarpPointer(dpy, None, win, 0, 0, 0, 0, x, y);
+    XFlush(dpy); // Flushes the output buffer, therefore updates the cursor's position.
 }
 
 void Mouse::getPosition(int& x, int& y){
 	Display *dpy;
+    Window win; /* Window used by the application */
     Window inwin;      /* root window the pointer is in */
     Window inchildwin; /* child win the pointer is in */
     int rootx, rooty; /* relative to the "root" window; */
     Atom atom_type_prop;
-    int actual_format;   /* should be 32 after the call */
-    unsigned int mask;   /* status of the buttons */
-    unsigned long n_items, bytes_after_ret;
-    Window *props;
+    unsigned int mask;
 
-    /* default DISPLAY */
+    /* Open a connection with X11 server and get the root window */
     dpy = XOpenDisplay(NULL);
+    win = System::getWindow();
 
-    (void)XGetWindowProperty(dpy, DefaultRootWindow(dpy),
-               XInternAtom(dpy, "_NET_ACTIVE_WINDOW", True),
-               0, 1, False, AnyPropertyType,
-               &atom_type_prop, &actual_format,
-               &n_items, &bytes_after_ret, (unsigned char**)&props);
-
-    XQueryPointer(dpy, props[0], &inwin,  &inchildwin,
+    XQueryPointer(dpy, win, &inwin,  &inchildwin,
         &rootx, &rooty, &x, &y, &mask);
-    int i = 0;
+
+    // Close the opened connection
+    XCloseDisplay(dpy);
 }

--- a/Backends/Linux/Sources/Kore/System.cpp
+++ b/Backends/Linux/Sources/Kore/System.cpp
@@ -11,7 +11,6 @@
 #include <GL/glx.h>
 #include <GL/gl.h>
 
-#include <X11/X.h>
 #include <X11/keysym.h>
 
 //apt-get install mesa-common-dev
@@ -227,6 +226,10 @@ bool System::handleMessages() {
 
 const char* Kore::System::systemId() {
     return "Linux";
+}
+
+Window Kore::System::getWindow() {
+    return win;
 }
 
 void Kore::System::swapBuffers() {

--- a/Sources/Kore/Input/Mouse.cpp
+++ b/Sources/Kore/Input/Mouse.cpp
@@ -81,12 +81,11 @@ bool Mouse::isLocked(){
 }
 
 void Mouse::lock(){
-	/*if (!canLock()){
+	if (!canLock()){
 		return;
 	}
 	locked = true;
 	_lock(true);
-*/ // comment just for dev
 	getPosition(lockX, lockY);
 	centerX = Application::the()->width() / 2;
 	centerY = Application::the()->height() / 2;

--- a/Sources/Kore/Input/Mouse.cpp
+++ b/Sources/Kore/Input/Mouse.cpp
@@ -2,7 +2,7 @@
 #include "Mouse.h"
 #include <Kore/Application.h>
 #include <Kore/System.h>
-
+#include <Kore/Log.h>
 
 using namespace Kore;
 
@@ -14,7 +14,7 @@ Mouse* Mouse::the() {
 	return &mouse;
 }
 
-Mouse::Mouse() 
+Mouse::Mouse()
 : lastX(0)
 , lastY(0)
 , lockX(0)
@@ -41,7 +41,7 @@ void Mouse::_move(int x, int y) {
 		movementY = y - lastY;
 	}
 	moved = true;
-	
+
 	lastX = x;
 	lastY = y;
 	if (Move != nullptr && (movementX != 0 || movementY != 0)) {
@@ -76,17 +76,19 @@ void Mouse::_activated(bool truth){
 
 
 bool Mouse::isLocked(){
+    log(Info, "mouse locked");
 	return locked;
 }
 
 void Mouse::lock(){
-	if (!canLock()){
+	/*if (!canLock()){
 		return;
 	}
 	locked = true;
 	_lock(true);
+*/ // comment just for dev
 	getPosition(lockX, lockY);
-	centerX = Application::the()->width() / 2; 
+	centerX = Application::the()->width() / 2;
 	centerY = Application::the()->height() / 2;
 	setPosition(centerX, centerY);
 }
@@ -98,5 +100,5 @@ void Mouse::unlock(){
 	moved = false;
 	locked = false;
 	_lock(false);
-	setPosition(lockX, lockY); 
+	setPosition(lockX, lockY);
 }

--- a/Sources/Kore/System.h
+++ b/Sources/Kore/System.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Kore/Math/Vector.h>
+#include <X11/X.h>
 
 namespace Kore {
 	namespace System {
@@ -24,6 +25,7 @@ namespace Kore {
 		const char** videoFormats();
 		void showWindow();
 		void swapBuffers();
+        Window getWindow();
 
 		typedef unsigned long long ticks;
 


### PR DESCRIPTION
Here is my proposition for implementing the lock function on linux target.

The methods : 

``` cpp
void Mouse::setPosition(int x, int y);

void Mouse::getPosition(int& x, int& y);
```

do the same thing as on windows.

But the method :

``` cpp
void Mouse::_lock(bool truth)
```

is actually just trying to keep the mouse inside the window if it detect it going outside.
We still can exit the window with the mouse and lose the `lock control` but it's actually difficult to do it. 

I tested it on a 800*600 window and using a trackball (so I could roll the ball really quickly), I have to really insist on it to exit the window.

In regard with the current code and some others implementation used by others library like SDL we should register to the mouse movement event and cancel the propagation for the outside world of our window. But this is the risky implementation discuss with @RobDangerous and @wighawag. 
