### PR TITLE
Remove 'mouse locked' log

### DIFF
--- a/Sources/Kore/Input/Mouse.cpp
+++ b/Sources/Kore/Input/Mouse.cpp
@@ -76,7 +76,6 @@ void Mouse::_activated(bool truth){
 
 
 bool Mouse::isLocked(){
-    log(Info, "mouse locked");
 	return locked;
 }
 


### PR DESCRIPTION
Was traced on every mouse move, i.e. a lot :)
