### PR TITLE
Refactoring: kha.Image.createRenderTarget() uses the DepthStencilFormat enum now instead of a bool

### DIFF
--- a/Backends/Direct3D11/Sources/Kore/RenderTargetImpl.cpp
+++ b/Backends/Direct3D11/Sources/Kore/RenderTargetImpl.cpp
@@ -3,10 +3,11 @@
 #include "RenderTargetImpl.h"
 #include <Kore/Graphics/Graphics.h>
 #include <Kore/WinError.h>
+#include <Kore/Log.h>
 
 using namespace Kore;
 
-RenderTarget::RenderTarget(int width, int height, bool zBuffer, bool antialiasing, RenderTargetFormat format) {
+RenderTarget::RenderTarget(int width, int height, int depthBufferBits, bool antialiasing, RenderTargetFormat format, int stencilBufferBits) {
 	this->texWidth = this->width = width;
 	this->texHeight = this->height = height;
 
@@ -21,6 +22,11 @@ RenderTarget::RenderTarget(int width, int height, bool zBuffer, bool antialiasin
 	desc.BindFlags = D3D11_BIND_RENDER_TARGET | D3D11_BIND_SHADER_RESOURCE;
 	desc.CPUAccessFlags = 0;//D3D11_CPU_ACCESS_WRITE;
 	desc.MiscFlags = 0;
+
+#if defined(_DEBUG)
+	log(Info, "depthBufferBits not implemented yet, using target defaults");
+	log(Info, "stencilBufferBits not implemented yet, using target defaults");
+#endif
 
 	texture = nullptr;
 	affirm(device->CreateTexture2D(&desc, nullptr, &texture));

--- a/Backends/Direct3D12/Sources/Kore/RenderTargetImpl.cpp
+++ b/Backends/Direct3D12/Sources/Kore/RenderTargetImpl.cpp
@@ -3,6 +3,7 @@
 #include "RenderTargetImpl.h"
 #include <Kore/Graphics/Graphics.h>
 #include <Kore/WinError.h>
+#include <Kore/Log.h>
 #include "d3dx12.h"
 
 using namespace Kore;
@@ -22,12 +23,17 @@ namespace {
 	}
 }
 
-RenderTarget::RenderTarget(int width, int height, bool zBuffer, bool antialiasing, RenderTargetFormat format) {
+RenderTarget::RenderTarget(int width, int height, int depthBufferBits, bool antialiasing, RenderTargetFormat format, int stencilBufferBits) {
 	this->texWidth = this->width = width;
 	this->texHeight = this->height = height;
 
 	device->CreateCommittedResource(&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT), D3D12_HEAP_FLAG_NONE, &CD3DX12_RESOURCE_DESC::Tex2D(DXGI_FORMAT_R8G8B8A8_UNORM_SRGB, texWidth, texHeight, 1, 1, 1, 0, D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET),
 		D3D12_RESOURCE_STATE_COMMON, nullptr, IID_PPV_ARGS(&renderTarget));
+
+#if defined(_DEBUG)
+	log(Info, "depthBufferBits not implemented yet, using target defaults");
+	log(Info, "stencilBufferBits not implemented yet, using target defaults");
+#endif
 
 	D3D12_RENDER_TARGET_VIEW_DESC view;
 	const D3D12_RESOURCE_DESC resourceDesc = renderTarget->GetDesc();

--- a/Backends/Direct3D9/Sources/Kore/RenderTargetImpl.cpp
+++ b/Backends/Direct3D9/Sources/Kore/RenderTargetImpl.cpp
@@ -1,11 +1,12 @@
 #include "pch.h"
 #include "RenderTargetImpl.h"
 #include <Kore/WinError.h>
+#include <Kore/Log.h>
 #include "Direct3D9.h"
 
 using namespace Kore;
 
-RenderTarget::RenderTarget(int width, int height, bool zBuffer, bool antialiasing, RenderTargetFormat format) : width(width), height(height), texWidth(width), texHeight(height) {
+RenderTarget::RenderTarget(int width, int height, int depthBufferBits, bool antialiasing, RenderTargetFormat format, int stencilBufferBits) : width(width), height(height), texWidth(width), texHeight(height) {
 	this->antialiasing = antialiasing;
 	D3DFORMAT d3dformat;
 	switch (format) {
@@ -19,6 +20,12 @@ RenderTarget::RenderTarget(int width, int height, bool zBuffer, bool antialiasin
 		d3dformat = D3DFMT_R32F;
 		break;
 	}
+
+#if defined(_DEBUG)
+	log(Info, "depthBufferBits not implemented yet, using defaults (D3DFMT_D24S8)");
+	log(Info, "stencilBufferBits not implemented yet, using defaults (D3DFMT_D24S8)");
+#endif
+
 	if (antialiasing) {
 		affirm(device->CreateRenderTarget(width, height, d3dformat, D3DMULTISAMPLE_8_SAMPLES, 0, FALSE, &colorSurface, nullptr));
 		affirm(device->CreateDepthStencilSurface(width, height, D3DFMT_D24S8, D3DMULTISAMPLE_8_SAMPLES, 0, TRUE, &depthSurface, nullptr));

--- a/Backends/Metal/Sources/Kore/RenderTargetImpl.cpp
+++ b/Backends/Metal/Sources/Kore/RenderTargetImpl.cpp
@@ -17,7 +17,7 @@ namespace {
 	}
 }
 
-RenderTarget::RenderTarget(int width, int height, bool zBuffer, bool antialiasing, RenderTargetFormat format) : width(width), height(height) {
+RenderTarget::RenderTarget(int width, int height, int depthBufferBits, bool antialiasing, RenderTargetFormat format, int stencilBufferBits) : width(width), height(height) {
 	texWidth = getPower2(width);
 	texHeight = getPower2(height);
 	

--- a/Sources/Kore/Graphics/Graphics.h
+++ b/Sources/Kore/Graphics/Graphics.h
@@ -120,7 +120,7 @@ namespace Kore {
 
 	class RenderTarget : public RenderTargetImpl {
 	public:
-		RenderTarget(int width, int height, bool depthBuffer, bool antialiasing = false, RenderTargetFormat format = Target32Bit);
+		RenderTarget(int width, int height, int depthBufferBits, bool antialiasing = false, RenderTargetFormat format = Target32Bit, int stencilBufferBits = -1);
 		int width;
 		int height;
 		int texWidth;


### PR DESCRIPTION
changes:

old:

``` haxe
RenderTarget::RenderTarget( ... bool zBuffer... )
```

new:

``` haxe
RenderTaget::RenderTarget( ... int depthBufferBits, ..., int stencilBufferBits )
```

I implemented the changes in the OpenGL Backend, as i don't have experience on how to do it for other targets, i only added a log message in _DEBUG builds for them.

This PR requires the one for Kha https://github.com/KTXSoftware/Kha/pull/239
