### PR TITLE
Support stencil buffering on iOS/OSX

### DIFF
--- a/Backends/OSX/Sources/Kore/BasicOpenGLView.mm
+++ b/Backends/OSX/Sources/Kore/BasicOpenGLView.mm
@@ -20,6 +20,7 @@ namespace {
 			NSOpenGLPFASupersample,
 			NSOpenGLPFASampleBuffers, (NSOpenGLPixelFormatAttribute)1,
 			NSOpenGLPFASamples, (NSOpenGLPixelFormatAttribute)aa,
+            NSOpenGLPFAStencilSize, (NSOpenGLPixelFormatAttribute)8,
 			(NSOpenGLPixelFormatAttribute)nil
 		};
 		return [[[NSOpenGLPixelFormat alloc] initWithAttributes:attributes] autorelease];
@@ -29,6 +30,7 @@ namespace {
 			NSOpenGLPFADoubleBuffer,
 			NSOpenGLPFADepthSize, (NSOpenGLPixelFormatAttribute)24, // 16 bit depth buffer
 			NSOpenGLPFAOpenGLProfile, NSOpenGLProfileVersion3_2Core,
+            NSOpenGLPFAStencilSize, (NSOpenGLPixelFormatAttribute)8,
 			(NSOpenGLPixelFormatAttribute)nil
 		};
 		return [[[NSOpenGLPixelFormat alloc] initWithAttributes:attributes] autorelease];

--- a/Backends/OpenGL2/Sources/Kore/RenderTargetImpl.cpp
+++ b/Backends/OpenGL2/Sources/Kore/RenderTargetImpl.cpp
@@ -4,6 +4,12 @@
 #include <Kore/Log.h>
 #include "ogl.h"
 
+#if defined(SYS_IOS) || defined(SYS_ANDROID)
+    #define USE_GLES_DS_BUFFERS
+#else
+    #define USE_GL2_DS_BUFFERS
+#endif
+
 using namespace Kore;
 
 namespace {
@@ -18,7 +24,7 @@ namespace {
 			if (pow(power) >= i) return pow(power);
 	}
     
-#if defined(SYS_IOS)
+#if defined(USE_GLES_DS_BUFFERS)
     void setup_gles_buffers( int depthBufferBits, int stencilBufferBits, int width, int height ) {
         if (depthBufferBits > 0 && stencilBufferBits > 0) {
             GLuint depthStencilBuffer;
@@ -46,7 +52,7 @@ namespace {
     
 #endif
     
-#if !defined(SYS_IOS)
+#if defined(USE_GL2_DS_BUFFERS)
     void setup_gl2_buffers( int depthBufferBits, int stencilBufferBits, int width, int height ) {
         if (depthBufferBits > 0 && stencilBufferBits > 0) {
             GLenum internalFormat;
@@ -147,9 +153,11 @@ RenderTarget::RenderTarget(int width, int height, int depthBufferBits, bool anti
 	glBindFramebuffer(GL_FRAMEBUFFER, _framebuffer);
 	glCheckErrors();
 
-#if defined(SYS_IOS)
+#if defined(USE_GLES_DS_BUFFERS)
     setup_gles_buffers(depthBufferBits, stencilBufferBits, texWidth, texHeight);
-#else
+#endif
+    
+#if defined(USE_GL2_DS_BUFFERS)
     setup_gl2_buffers(depthBufferBits, stencilBufferBits, texWidth, texHeight);
 #endif
 

--- a/Backends/OpenGL2/Sources/Kore/RenderTargetImpl.cpp
+++ b/Backends/OpenGL2/Sources/Kore/RenderTargetImpl.cpp
@@ -17,6 +17,94 @@ namespace {
 		for (int power = 0; ; ++power)
 			if (pow(power) >= i) return pow(power);
 	}
+    
+#if defined(SYS_IOS)
+    void setup_gles_buffers( int depthBufferBits, int stencilBufferBits, int width, int height ) {
+        if (depthBufferBits > 0 && stencilBufferBits > 0) {
+            GLuint depthStencilBuffer;
+            glGenRenderbuffers(1, &depthStencilBuffer);
+            glCheckErrors();
+            glBindRenderbuffer(GL_RENDERBUFFER, depthStencilBuffer);
+            glCheckErrors();
+            glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH24_STENCIL8_OES, width, height);
+            glCheckErrors();
+            glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, depthStencilBuffer);
+            glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_STENCIL_ATTACHMENT, GL_RENDERBUFFER, depthStencilBuffer);
+            glCheckErrors();
+        } else if (depthBufferBits > 0) {
+            GLuint depthBuffer;
+            glGenRenderbuffers(1, &depthBuffer);
+            glCheckErrors();
+            glBindRenderbuffer(GL_RENDERBUFFER, depthBuffer);
+            glCheckErrors();
+            glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH_COMPONENT, width, height);
+            glCheckErrors();
+            glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, depthBuffer);
+            glCheckErrors();
+        }
+    }
+    
+#endif
+    
+#if !defined(SYS_IOS)
+    void setup_gl2_buffers( int depthBufferBits, int stencilBufferBits, int width, int height ) {
+        if (depthBufferBits > 0 && stencilBufferBits > 0) {
+            GLenum internalFormat;
+            
+            switch (depthBufferBits) {
+                default:
+#if defined(_DEBUG)
+                    log(Info, "RenderTarget: depthBufferBits not set, defaulting to 24");
+#endif
+                    // break; // fall through
+                    case 24: {
+                        switch (stencilBufferBits) {
+                            default:
+#if defined(_DEBUG)
+                                log(Info, "RenderTarget: stencilBufferBits not set, defaulting to 8");
+#endif
+                                // break; // fall through
+                                case 8: internalFormat = GL_DEPTH24_STENCIL8;
+                                break;
+                        }
+                    } break;
+                    case 32: {
+                        switch (stencilBufferBits) {
+                            default:
+#if defined(_DEBUG)
+                                log(Info, "RenderTarget: stencilBufferBits not set, defaulting to 8");
+#endif
+                                // break; // fall through
+                                case 8: internalFormat = GL_DEPTH32F_STENCIL8;
+                                break;
+                        }
+                    } break;
+            }
+            
+            GLuint dsBuffer;
+            glGenRenderbuffers(1, &dsBuffer);
+            glCheckErrors();
+            glBindRenderbuffer(GL_RENDERBUFFER, dsBuffer);
+            glCheckErrors();
+            glRenderbufferStorage(GL_RENDERBUFFER, internalFormat, width, height);
+            glCheckErrors();
+            glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_RENDERBUFFER, dsBuffer);
+            glCheckErrors();
+        } else if (depthBufferBits > 0) {
+            GLuint depthBuffer;
+            glGenRenderbuffers(1, &depthBuffer);
+            glCheckErrors();
+            glBindRenderbuffer(GL_RENDERBUFFER, depthBuffer);
+            glCheckErrors();
+            glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH_COMPONENT, width, height);
+            glCheckErrors();
+            glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, depthBuffer);
+            glCheckErrors();
+        }
+    }
+    
+#endif
+    
 }
 
 RenderTarget::RenderTarget(int width, int height, int depthBufferBits, bool antialiasing, RenderTargetFormat format, int stencilBufferBits) : width(width), height(height) {
@@ -58,60 +146,12 @@ RenderTarget::RenderTarget(int width, int height, int depthBufferBits, bool anti
 	glCheckErrors();
 	glBindFramebuffer(GL_FRAMEBUFFER, _framebuffer);
 	glCheckErrors();
-	
-	if (depthBufferBits > 0 && stencilBufferBits > 0) {
-		GLenum internalFormat;
 
-		switch (depthBufferBits) {
-			default:
-#ifdef _DEBUG
-				log(Info, "RenderTarget: depthBufferBits not set, defaulting to 24");
+#if defined(SYS_IOS)
+    setup_gles_buffers(depthBufferBits, stencilBufferBits, texWidth, texHeight);
+#else
+    setup_gl2_buffers(depthBufferBits, stencilBufferBits, texWidth, texHeight);
 #endif
-			// break; // fall through
-			case 24: {
-				switch (stencilBufferBits) {
-					default:
-#ifdef _DEBUG
-						log(Info, "RenderTarget: stencilBufferBits not set, defaulting to 8");
-#endif
-					// break; // fall through
-					case 8: internalFormat = GL_DEPTH24_STENCIL8;
-						break;
-				}
-			} break;
-			case 32: {
-				switch (stencilBufferBits) {
-					default:
-#ifdef _DEBUG
-						log(Info, "RenderTarget: stencilBufferBits not set, defaulting to 8");
-#endif
-					// break; // fall through
-					case 8: internalFormat = GL_DEPTH32F_STENCIL8;
-						break;
-				}
-			} break;
-		}
-
-		GLuint dsBuffer;
-		glGenRenderbuffers(1, &dsBuffer);
-		glCheckErrors();
-		glBindRenderbuffer(GL_RENDERBUFFER, dsBuffer);
-		glCheckErrors();
-		glRenderbufferStorage(GL_RENDERBUFFER, internalFormat, texWidth, texHeight);
-		glCheckErrors();
-		glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_RENDERBUFFER, dsBuffer);
-		glCheckErrors();
-	} else if (depthBufferBits > 0) {
-		GLuint depthBuffer;
-		glGenRenderbuffers(1, &depthBuffer);
-		glCheckErrors();
-		glBindRenderbuffer(GL_RENDERBUFFER, depthBuffer);
-		glCheckErrors();
-		glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH_COMPONENT, texWidth, texHeight);
-		glCheckErrors();
-		glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, depthBuffer);
-		glCheckErrors();
-	}
 
 	glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, _texture, 0);
 	glCheckErrors();

--- a/Backends/OpenGL2/Sources/Kore/RenderTargetImpl.h
+++ b/Backends/OpenGL2/Sources/Kore/RenderTargetImpl.h
@@ -1,8 +1,5 @@
 #pragma once
 
-struct IDirect3DSurface9;
-struct IDirect3DTexture9;
-
 namespace Kore {
 	class RenderTargetImpl {
 	public:

--- a/Backends/iOS/Sources/Kore/GLView.h
+++ b/Backends/iOS/Sources/Kore/GLView.h
@@ -21,7 +21,7 @@
 	MTLRenderPassDescriptor* renderPassDescriptor;
 #else
 	EAGLContext* context;
-	GLuint defaultFramebuffer, colorRenderbuffer, depthRenderbuffer;
+	GLuint defaultFramebuffer, colorRenderbuffer, depthStencilRenderbuffer;
 #endif
 	
 	CMMotionManager* motionManager;

--- a/Backends/iOS/Sources/Kore/GLView.mm
+++ b/Backends/iOS/Sources/Kore/GLView.mm
@@ -115,9 +115,10 @@ int Kore::System::screenHeight() {
 	glBindRenderbufferOES(GL_RENDERBUFFER_OES, colorRenderbuffer);
 	glFramebufferRenderbufferOES(GL_FRAMEBUFFER_OES, GL_COLOR_ATTACHMENT0_OES, GL_RENDERBUFFER_OES, colorRenderbuffer);
 	
-	glGenRenderbuffersOES(1, &depthRenderbuffer);
-    glBindRenderbufferOES(GL_RENDERBUFFER_OES, depthRenderbuffer);
-    glFramebufferRenderbufferOES(GL_FRAMEBUFFER_OES, GL_DEPTH_ATTACHMENT_OES, GL_RENDERBUFFER_OES, depthRenderbuffer);
+	glGenRenderbuffersOES(1, &depthStencilRenderbuffer);
+    glBindRenderbufferOES(GL_RENDERBUFFER_OES, depthStencilRenderbuffer);
+    glFramebufferRenderbufferOES(GL_FRAMEBUFFER_OES, GL_DEPTH_ATTACHMENT_OES, GL_RENDERBUFFER_OES, depthStencilRenderbuffer);
+    glFramebufferRenderbufferOES(GL_FRAMEBUFFER_OES, GL_STENCIL_ATTACHMENT_OES, GL_RENDERBUFFER_OES, depthStencilRenderbuffer);
 
     // Start acceletometer
 	hasAccelerometer = false;
@@ -225,8 +226,8 @@ static float red = 0.0f;
 	
 	printf("backingWitdh/Height: %i, %i\n", backingWidth, backingHeight);
 	
-	glBindRenderbufferOES(GL_RENDERBUFFER_OES, depthRenderbuffer);
-	glRenderbufferStorageOES(GL_RENDERBUFFER_OES, GL_DEPTH_COMPONENT24_OES, backingWidth, backingHeight);
+	glBindRenderbufferOES(GL_RENDERBUFFER_OES, depthStencilRenderbuffer);
+	glRenderbufferStorageOES(GL_RENDERBUFFER_OES, GL_DEPTH24_STENCIL8_OES, backingWidth, backingHeight);
 	
 	if (glCheckFramebufferStatusOES(GL_FRAMEBUFFER_OES) != GL_FRAMEBUFFER_COMPLETE_OES) {
 		NSLog(@"Failed to make complete framebuffer object %x", glCheckFramebufferStatusOES(GL_FRAMEBUFFER_OES));
@@ -249,6 +250,11 @@ static float red = 0.0f;
 		glDeleteRenderbuffersOES(1, &colorRenderbuffer);
 		colorRenderbuffer = 0;
 	}
+    
+    if (depthStencilRenderbuffer) {
+        glDeleteRenderbuffersOES(1, &depthStencilRenderbuffer);
+        depthStencilRenderbuffer = 0;
+    }
 	
 	if ([EAGLContext currentContext] == context) [EAGLContext setCurrentContext:nil];
 	


### PR DESCRIPTION
Not a particularly nice implementation, but it's working.
- i used #ifdef (SYS_IOS) for now
- maybe RenderTargetImpl.cpp should be split into a GL2 + GLES version and the specific file pulled in via kha/koremake depending on the target

Tested on
- iPhone 4 (iOS 7.1.2)
- iPad 3 (iOS 9.1.2)
- iMac (OS X 10.10.5 Yosemite)
- iMac (OS X 10.11 El Capitan)

Edit: includes a fix for #39 now as well. It uses the gles implementation for SYS_IOS and SYS_ANDROID
