### PR TITLE
fixed trace spam

### DIFF
--- a/Backends/OSX/Sources/Kore/System.cpp
+++ b/Backends/OSX/Sources/Kore/System.cpp
@@ -84,3 +84,7 @@ void Kore::System::makeCurrent(int contextId) {
     appstate::currentDeviceId = contextId;
     Graphics::makeCurrent(contextId);
 }
+
+void Kore::System::clearCurrent() {
+    appstate::currentDeviceId = -1;
+}

--- a/Backends/OSX/Sources/Kore/System.mm
+++ b/Backends/OSX/Sources/Kore/System.mm
@@ -99,9 +99,6 @@ void Graphics::makeCurrent(int contextId) {
     [[windows[contextId]->view openGLContext] makeCurrentContext];
 }
 
-void System::clearCurrent() {
-}
-
 int Kore::System::windowWidth(int id) {
     return windows[id]->width;
 }


### PR DESCRIPTION
implemented Kore::System::clearCurrent(), so the debug traces in Graphics:begin() don't show up every frame
