### PR TITLE
generateMipmaps and setMipmap for OpenGL

### DIFF
--- a/Backends/Direct3D11/Sources/Kore/TextureImpl.cpp
+++ b/Backends/Direct3D11/Sources/Kore/TextureImpl.cpp
@@ -101,3 +101,11 @@ void Texture::unlock() {
 int Texture::stride() {
 	return format == Image::RGBA32 ? width * 4 : width;
 }
+
+void Texture::generateMipmaps(int levels) {
+
+}
+
+void Texture::setMipmap(Texture* mipmap, int level) {
+
+}

--- a/Backends/Direct3D12/Sources/Kore/TextureImpl.cpp
+++ b/Backends/Direct3D12/Sources/Kore/TextureImpl.cpp
@@ -156,3 +156,11 @@ void Texture::unlock() {
 int Texture::stride() {
 	return 1;
 }
+
+void Texture::generateMipmaps(int levels) {
+
+}
+
+void Texture::setMipmap(Texture* mipmap, int level) {
+
+}

--- a/Backends/Direct3D9/Sources/Kore/TextureImpl.cpp
+++ b/Backends/Direct3D9/Sources/Kore/TextureImpl.cpp
@@ -95,3 +95,11 @@ void Texture::unlock() {
 int Texture::stride() {
 	return pitch;
 }
+
+void Texture::generateMipmaps(int levels) {
+
+}
+
+void Texture::setMipmap(Texture* mipmap, int level) {
+
+}

--- a/Backends/Metal/Sources/Kore/TextureImpl.mm
+++ b/Backends/Metal/Sources/Kore/TextureImpl.mm
@@ -83,3 +83,11 @@ void Texture::upload(u8* data) {
 
 }
 #endif
+
+void Texture::generateMipmaps(int levels) {
+
+}
+
+void Texture::setMipmap(Texture* mipmap, int level) {
+
+}

--- a/Backends/OpenGL2/Sources/Kore/TextureImpl.cpp
+++ b/Backends/OpenGL2/Sources/Kore/TextureImpl.cpp
@@ -362,3 +362,13 @@ void Texture::upload(u8* data) {
 	glCheckErrors();
 }
 #endif
+
+void Texture::generateMipmaps(int levels) {
+	glBindTexture(GL_TEXTURE_2D, texture);
+	glGenerateMipmap(GL_TEXTURE_2D);
+}
+
+void Texture::setMipmap(Texture* mipmap, int level) {
+	glBindTexture(GL_TEXTURE_2D, texture);
+	glTexImage2D(GL_TEXTURE_2D, level, convert(mipmap->format), mipmap->texWidth, mipmap->texHeight, 0, convertInternal(mipmap->format), GL_UNSIGNED_BYTE, mipmap->data);
+}

--- a/Backends/Vulkan/Sources/Kore/TextureImpl.cpp
+++ b/Backends/Vulkan/Sources/Kore/TextureImpl.cpp
@@ -308,3 +308,11 @@ u8* Texture::lock() {
 void Texture::unlock() {
 
 }
+
+void Texture::generateMipmaps(int levels) {
+
+}
+
+void Texture::setMipmap(Texture* mipmap, int level) {
+
+}

--- a/Sources/Kore/Graphics/Texture.h
+++ b/Sources/Kore/Graphics/Texture.h
@@ -21,6 +21,9 @@ namespace Kore {
 #ifdef SYS_IOS
 		void upload(u8* data);
 #endif
+		void generateMipmaps(int levels);
+		void setMipmap(Texture* mipmap, int level);
+		
 		int stride();
 		int texWidth;
 		int texHeight;


### PR DESCRIPTION
In order to set mipmap, readable flag of specified mipmap texture needs to be set to true to preserve data buffer.
