### PR TITLE
CFBundleIdentifier now matches koremake targetOption's bundle

### DIFF
--- a/Backends/iOS/Sources/Kore/ios.plist
+++ b/Backends/iOS/Sources/Kore/ios.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.ktxsoftware.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>


### PR DESCRIPTION
Matches the commit at https://github.com/laxa88/koremake/commit/de7ca9a8a8da8bd2b1767e5b0b4f8b320ef96da9
