### PR TITLE
Added setKeepScreenOn

### DIFF
--- a/Backends/Android/Java-Sources/com/ktxsoftware/kore/KoreActivity.java
+++ b/Backends/Android/Java-Sources/com/ktxsoftware/kore/KoreActivity.java
@@ -42,21 +42,4 @@ public class KoreActivity extends NativeActivity {
 		WindowManager manager = (WindowManager)context.getSystemService(Context.WINDOW_SERVICE);
 		return manager.getDefaultDisplay().getRotation();
 	}
-    
-    public static void setKeepScreenOn(boolean on) {
-        if(on)
-        {
-            getInstance().runOnUiThread(new Runnable(){
-                public void run() {
-                    getInstance().getWindow().addFlags(android.view.WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
-                }
-            });
-        }else{
-            getInstance().runOnUiThread(new Runnable(){
-                public void run() {
-                    getInstance().getWindow().clearFlags(android.view.WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
-                }
-            });
-        }
-    }
 }

--- a/Backends/Android/Java-Sources/com/ktxsoftware/kore/KoreActivity.java
+++ b/Backends/Android/Java-Sources/com/ktxsoftware/kore/KoreActivity.java
@@ -42,4 +42,21 @@ public class KoreActivity extends NativeActivity {
 		WindowManager manager = (WindowManager)context.getSystemService(Context.WINDOW_SERVICE);
 		return manager.getDefaultDisplay().getRotation();
 	}
+    
+    public static void setKeepScreenOn(boolean on) {
+        if(on)
+        {
+            getInstance().runOnUiThread(new Runnable(){
+                public void run() {
+                    getInstance().getWindow().addFlags(android.view.WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+                }
+            });
+        }else{
+            getInstance().runOnUiThread(new Runnable(){
+                public void run() {
+                    getInstance().getWindow().clearFlags(android.view.WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+                }
+            });
+        }
+    }
 }

--- a/Backends/Android/Sources/Kore/System.cpp
+++ b/Backends/Android/Sources/Kore/System.cpp
@@ -826,6 +826,14 @@ void Kore::System::setTitle(const char*) {
 
 }
 
+void Kore::System::setKeepScreenOn( bool on ) {
+	JNIEnv* env;
+	activity->vm->AttachCurrentThread(&env, nullptr);
+	jclass koreActivityClass = KoreAndroid::findClass(env, "com.ktxsoftware.kore.KoreActivity");
+	env->CallStaticVoidMethod(koreActivityClass, env->GetStaticMethodID(koreActivityClass, "setKeepScreenOn", "(Z)V"), on);
+	activity->vm->DetachCurrentThread();
+}
+
 void Kore::System::showWindow() {
 }
 

--- a/Backends/Android/Sources/Kore/System.cpp
+++ b/Backends/Android/Sources/Kore/System.cpp
@@ -353,6 +353,7 @@ double Kore::System::time() {
 #include <Kore/Input/Surface.h>
 #include <EGL/egl.h>
 #include <android/sensor.h>
+#include <android/window.h>
 #include <android_native_app_glue.h>
 #include <GLContext.h>
 #include <stdlib.h>
@@ -827,11 +828,12 @@ void Kore::System::setTitle(const char*) {
 }
 
 void Kore::System::setKeepScreenOn( bool on ) {
-	JNIEnv* env;
-	activity->vm->AttachCurrentThread(&env, nullptr);
-	jclass koreActivityClass = KoreAndroid::findClass(env, "com.ktxsoftware.kore.KoreActivity");
-	env->CallStaticVoidMethod(koreActivityClass, env->GetStaticMethodID(koreActivityClass, "setKeepScreenOn", "(Z)V"), on);
-	activity->vm->DetachCurrentThread();
+    if(on)
+    {
+        ANativeActivity_setWindowFlags(activity, AWINDOW_FLAG_KEEP_SCREEN_ON, 0);
+    }else{
+        ANativeActivity_setWindowFlags(activity, 0, AWINDOW_FLAG_KEEP_SCREEN_ON);
+    }
 }
 
 void Kore::System::showWindow() {

--- a/Backends/HTML5/Sources/Kore/System.cpp
+++ b/Backends/HTML5/Sources/Kore/System.cpp
@@ -147,6 +147,10 @@ void Kore::System::setTitle(const char* title) {
 
 }
 
+void Kore::System::setKeepScreenOn( bool on ) {
+    
+}
+
 void Kore::System::showWindow() {
 
 }

--- a/Backends/Linux/Sources/Kore/System.cpp
+++ b/Backends/Linux/Sources/Kore/System.cpp
@@ -557,6 +557,10 @@ void Kore::System::setTitle(const char* title) {
 
 }
 
+void Kore::System::setKeepScreenOn( bool on ) {
+    
+}
+
 void Kore::System::showWindow() {
 
 }

--- a/Backends/OSX/Sources/Kore/System.cpp
+++ b/Backends/OSX/Sources/Kore/System.cpp
@@ -53,6 +53,10 @@ void System::setTitle(const char* title) {
 	
 }
 
+void System::setKeepScreenOn( bool on ) {
+    
+}
+
 #include <mach/mach_time.h>
 
 double System::frequency() {

--- a/Backends/Pi/Sources/Kore/System.cpp
+++ b/Backends/Pi/Sources/Kore/System.cpp
@@ -488,6 +488,10 @@ void Kore::System::setTitle(const char* title) {
 
 }
 
+void Kore::System::setKeepScreenOn( bool on ) {
+    
+}
+
 void Kore::System::showWindow() {
 
 }

--- a/Backends/Tizen/Sources/Kore/System.cpp
+++ b/Backends/Tizen/Sources/Kore/System.cpp
@@ -40,6 +40,10 @@ void Kore::System::setTitle(const char*) {
 
 }
 
+void Kore::System::setKeepScreenOn( bool on ) {
+    
+}
+
 void Kore::System::showWindow() {
     
 }

--- a/Backends/Windows/Sources/Kore/System.cpp
+++ b/Backends/Windows/Sources/Kore/System.cpp
@@ -695,6 +695,10 @@ void Kore::System::setTitle(const char* title) {
 	SetWindowTextA(windows[currentDevice()]->hwnd, title);
 }
 
+void Kore::System::setKeepScreenOn( bool on ) {
+    
+}
+
 // TODO (DK) windowId
 void Kore::System::showWindow() {
 	ShowWindow(windows[0]->hwnd, SW_SHOWDEFAULT);

--- a/Backends/WindowsApp/Sources/Kore/System.winrt.cpp
+++ b/Backends/WindowsApp/Sources/Kore/System.winrt.cpp
@@ -88,6 +88,10 @@ void Kore::System::setTitle(const char*) {
 
 }
 
+void Kore::System::setKeepScreenOn( bool on ) {
+    
+}
+
 void Kore::System::showWindow() {
 
 }

--- a/Backends/iOS/Sources/Kore/System.mm
+++ b/Backends/iOS/Sources/Kore/System.mm
@@ -44,6 +44,10 @@ void System::setTitle(const char* title) {
 	
 }
 
+void System::setKeepScreenOn( bool on ) {
+    
+}
+
 bool System::showsKeyboard() {
 	return keyboardshown;
 }

--- a/Sources/Kore/System.h
+++ b/Sources/Kore/System.h
@@ -74,6 +74,7 @@ namespace Kore {
 		void setBackgroundCallback( void (*value)() );
 		void setShutdownCallback( void (*value)() );
 		void setOrientationCallback( void (*value)(Orientation) );
+        void setKeepScreenOn( bool on );
         
         void callback();
         void foregroundCallback();


### PR DESCRIPTION
Added setKeepScreenOn stubs to HTML5, Linux, OSX, Pi, Tizen, Windows, WindowsApp and iOS.
Implemented setKeepScreenOn on Android.

This function stops the screen from going into standby when not actively pressing the screen (for example in a game where Accelerometer forms the primary controls, its not unusual to not press the screen for several minutes).

Since this is not applicable on HTML5, Pi, Linux, OSX and Windows and since I don't have a WindowsPhone or iOS device to test with this function was only tested on Android. (And made sure it doesn't crash on Windows).

Fixes https://github.com/KTXSoftware/Kha/issues/274
