### PR TITLE
Disabled debug messages on Linux

### DIFF
--- a/Backends/Linux/Sources/Kore/System.cpp
+++ b/Backends/Linux/Sources/Kore/System.cpp
@@ -517,7 +517,7 @@ void Kore::System::makeCurrent( int contextId ) {
 		return;
 	}
 
-#if !defined(NDEBUG)
+#if defined(NDEBUG)
 	log(Info, "Kore/System | context switch from %i to %i", currentDeviceId, contextId);
 #endif
 
@@ -531,7 +531,7 @@ void Kore::Graphics::clearCurrent() {
 }
 
 void Kore::System::clearCurrent() {
-#if !defined(NDEBUG)
+#if defined(NDEBUG)
 	log(Info, "Kore/System | context clear");
 #endif
 


### PR DESCRIPTION
Two debug messages were enabled in release mode with !NDEBUG, and was showing all the time in the console.
It seems it should be like this in the windows target:
https://github.com/KTXSoftware/Kore/blob/master/Backends/Windows/Sources/Kore/System.cpp#L606
# if defined(_DEBUG)

```
log(Info, "Kore/System | context switch from %i to %i", currentDeviceId, contextId);
```
# endif
