### PR TITLE
Bugfix Android back button

### DIFF
--- a/Backends/Android/Sources/Kore/System.cpp
+++ b/Backends/Android/Sources/Kore/System.cpp
@@ -469,7 +469,7 @@ namespace {
 							return 1;
 						}
 						else {
-							Kore::Keyboard::the()->_keyup(Kore::Key_Back, 1);
+							Kore::Keyboard::the()->_keydown(Kore::Key_Back, 1);
 							return 1;
 						}
 					case AKEYCODE_BUTTON_A:


### PR DESCRIPTION
Seems that the _keyup handler was called in both the keyup and keydown cases causing code like this:
http://pastebin.com/Cb6AbUH7
to be called twice.
