### PR TITLE
Multiple render targets for OpenGL2.

### DIFF
--- a/Backends/Direct3D11/Sources/Kore/Direct3D11.winrt.cpp
+++ b/Backends/Direct3D11/Sources/Kore/Direct3D11.winrt.cpp
@@ -647,7 +647,7 @@ void Graphics::restoreRenderTarget() {
 	context->RSSetViewports(1, &viewPort);
 }
 
-void Graphics::setRenderTarget(RenderTarget* target, int) {
+void Graphics::setRenderTarget(RenderTarget* target, int num, int additionalTargets) {
 	context->OMSetRenderTargets(1, &target->renderTargetView, nullptr);
 	CD3D11_VIEWPORT viewPort(0.0f, 0.0f, static_cast<float>(target->width), static_cast<float>(target->height));
 	context->RSSetViewports(1, &viewPort);

--- a/Backends/Direct3D12/Sources/Kore/Direct3D12.cpp
+++ b/Backends/Direct3D12/Sources/Kore/Direct3D12.cpp
@@ -649,7 +649,7 @@ void Graphics::restoreRenderTarget() {
 	commandList->RSSetScissorRects(1, &rectScissor);
 }
 
-void Graphics::setRenderTarget(RenderTarget* target, int) {
+void Graphics::setRenderTarget(RenderTarget* target, int num, int additionalTargets) {
 	commandList->OMSetRenderTargets(1, &target->renderTargetDescriptorHeap->GetCPUDescriptorHandleForHeapStart(), true, nullptr);
 	commandList->RSSetViewports(1, (D3D12_VIEWPORT*)&target->viewport);
 	commandList->RSSetScissorRects(1, (D3D12_RECT*)&target->scissor);

--- a/Backends/Direct3D9/Sources/Kore/Direct3D9.cpp
+++ b/Backends/Direct3D9/Sources/Kore/Direct3D9.cpp
@@ -309,7 +309,7 @@ void Graphics::clearCurrent() {
 	// TODO (DK) implement me
 }
 
-void Graphics::setRenderTarget(RenderTarget* target, int num) {
+void Graphics::setRenderTarget(RenderTarget* target, int num, int additionalTargets) {
 	//if (backBuffer != nullptr) backBuffer->Release();
 	
 	System::makeCurrent(target->contextId);

--- a/Backends/Metal/Sources/Kore/Metal.mm
+++ b/Backends/Metal/Sources/Kore/Metal.mm
@@ -276,7 +276,7 @@ void Graphics::setBlendingMode(BlendingOperation source, BlendingOperation desti
 
 }
 
-void Graphics::setRenderTarget(RenderTarget* texture, int num) {
+void Graphics::setRenderTarget(RenderTarget* texture, int num, int additionalTargets) {
 
 }
 

--- a/Backends/OpenGL2/Sources/Kore/OpenGL.cpp
+++ b/Backends/OpenGL2/Sources/Kore/OpenGL.cpp
@@ -729,14 +729,24 @@ void Graphics::setBlendingMode(BlendingOperation source, BlendingOperation desti
 	glCheckErrors();
 }
 
-void Graphics::setRenderTarget(RenderTarget* texture, int num) {
-    // TODO (DK) uneccessary?
-	//System::makeCurrent(texture->contextId);
-
-	glBindFramebuffer(GL_FRAMEBUFFER, texture->_framebuffer);
-	glCheckErrors();
-	glViewport(0, 0, texture->texWidth, texture->texHeight);
-	glCheckErrors();
+void Graphics::setRenderTarget(RenderTarget* texture, int num, int additionalTargets) {
+	if (num == 0) {
+		// TODO (DK) uneccessary?
+		//System::makeCurrent(texture->contextId);
+		glBindFramebuffer(GL_FRAMEBUFFER, texture->_framebuffer);
+		glCheckErrors();
+		glViewport(0, 0, texture->texWidth, texture->texHeight);
+		glCheckErrors();
+	}
+	
+	if (additionalTargets > 0) {
+		glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0 + num, GL_TEXTURE_2D, texture->_texture, 0);
+		if (num == additionalTargets) {
+			GLenum buffers[additionalTargets + 1];
+			for (int i = 0; i <= additionalTargets; ++i) buffers[i] = GL_COLOR_ATTACHMENT0 + i;
+			glDrawBuffers(additionalTargets + 1, buffers);
+		}
+	}
 }
 
 void Graphics::restoreRenderTarget() {

--- a/Backends/OpenGL2/Sources/Kore/RenderTargetImpl.cpp
+++ b/Backends/OpenGL2/Sources/Kore/RenderTargetImpl.cpp
@@ -149,6 +149,9 @@ RenderTarget::RenderTarget(int width, int height, int depthBufferBits, bool anti
 	case Target128BitFloat:
 		glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, texWidth, texHeight, 0, GL_RGBA, GL_FLOAT, 0);
 		break;
+    case Target64BitFloat:
+        glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, texWidth, texHeight, 0, GL_RGBA, GL_HALF_FLOAT, 0);
+        break;
     case Target16BitDepth:
         glTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH_COMPONENT16, texWidth, texHeight, 0, GL_DEPTH_COMPONENT, GL_FLOAT, 0);
         break;

--- a/Backends/Vulkan/Sources/Kore/Vulkan.cpp
+++ b/Backends/Vulkan/Sources/Kore/Vulkan.cpp
@@ -1629,7 +1629,7 @@ namespace {
 	}
 }
 
-void Graphics::setRenderTarget(RenderTarget* texture, int num) {
+void Graphics::setRenderTarget(RenderTarget* texture, int num, int additionalTargets) {
 	endPass();
 
 	currentRenderTarget = texture;

--- a/Sources/Kore/Graphics/Graphics.h
+++ b/Sources/Kore/Graphics/Graphics.h
@@ -162,7 +162,7 @@ namespace Kore {
 		void setAntialiasingSamples(int samples);
 
 		bool renderTargetsInvertedY();
-		void setRenderTarget(RenderTarget* texture, int num = 0);
+		void setRenderTarget(RenderTarget* texture, int num = 0, int additionalTargets = 0);
 		void restoreRenderTarget();
 
 		// TODO (DK) windowId should be renamed contextId?


### PR DESCRIPTION
MRT attempt for Kore. No arrays shuffling around, just needs to pass number of additional targets being attached. Basically the same implementation like WebGL.
