### PR TITLE
initial Windows 8.1 Universal App and Apple tvOS compatibility

### DIFF
--- a/Backends/Direct3D11/Sources/Kore/Direct3D11.winrt.cpp
+++ b/Backends/Direct3D11/Sources/Kore/Direct3D11.winrt.cpp
@@ -379,12 +379,16 @@ unsigned Graphics::refreshRate() {
 
 void Graphics::swapBuffers(int windowId) {
 	HRESULT hr = swapChain->Present(1, 0);
+	// TODO: if (hr == DXGI_STATUS_OCCLUDED)...
+	// http://www.pouet.net/topic.php?which=10454
+	// "Proper handling of DXGI_STATUS_OCCLUDED would be to pause the application,
+	// and periodically call Present with the TEST flag, and when it returns S_OK, resume rendering."
 
 	//if (hr == DXGI_ERROR_DEVICE_REMOVED || hr == DXGI_ERROR_DEVICE_RESET) {
 	//	Initialize(m_window);
 	//}
 	//else {
-		affirm(hr);
+		affirm(SUCCEEDED(hr));
 	//}
 }
 

--- a/Backends/WindowsApp/Sources/Kore/System.winrt.cpp
+++ b/Backends/WindowsApp/Sources/Kore/System.winrt.cpp
@@ -7,7 +7,19 @@
 #define WIN32_LEAN_AND_MEAN
 #define NOMINMAX
 #include <windows.h>
+
+#ifndef XINPUT
+	#ifdef SYS_WINDOWS
+		#define XINPUT 1
+	#endif
+
+	#ifdef SYS_WINDOWSAPP
+		#define XINPUT !(WINAPI_PARTITION_PHONE_APP)
+	#endif
+#endif
+#if XINPUT
 #include <Xinput.h>
+#endif
 
 ref class Win8Application sealed : public Windows::ApplicationModel::Core::IFrameworkView {
 public:
@@ -59,7 +71,8 @@ using namespace Windows::Graphics::Display;
 bool Kore::System::handleMessages() {
 	CoreWindow::GetForCurrentThread()->Dispatcher->ProcessEvents(CoreProcessEventsOption::ProcessAllIfPresent);
 
-		DWORD dwResult;
+	#if XINPUT
+	DWORD dwResult;
 	for (DWORD i = 0; i < XUSER_MAX_COUNT; ++i) {
 		XINPUT_STATE state;
 		ZeroMemory(&state, sizeof(XINPUT_STATE));
@@ -111,6 +124,7 @@ bool Kore::System::handleMessages() {
 			Kore::Gamepad::get(i)->productName = nullptr;
 		}
 	}
+    #endif
 
 	return true;
 }

--- a/Backends/iOS/Sources/Kore/GLView.h
+++ b/Backends/iOS/Sources/Kore/GLView.h
@@ -7,7 +7,9 @@
 #import <OpenGLES/ES1/gl.h>
 #import <OpenGLES/ES1/glext.h>
 #endif
+#ifndef SYS_TVOS
 #import <CoreMotion/CMMotionManager.h>
+#endif
 
 @interface GLView : UIView <UIKeyInput> {
 @private
@@ -24,7 +26,9 @@
 	GLuint defaultFramebuffer, colorRenderbuffer, depthStencilRenderbuffer;
 #endif
 	
+#ifndef SYS_TVOS
 	CMMotionManager* motionManager;
+#endif
 	bool hasAccelerometer;
 	float lastAccelerometerX, lastAccelerometerY, lastAccelerometerZ;
 }

--- a/Backends/iOS/Sources/Kore/GLView.mm
+++ b/Backends/iOS/Sources/Kore/GLView.mm
@@ -121,15 +121,18 @@ int Kore::System::windowHeight(int id) {
 
     // Start acceletometer
 	hasAccelerometer = false;
-
+#ifndef SYS_TVOS
 	motionManager = [[CMMotionManager alloc]init];
 	if ([motionManager isAccelerometerAvailable]) {
 		motionManager.accelerometerUpdateInterval = 0.033;
 		[motionManager startAccelerometerUpdates];
 		hasAccelerometer = true;
 	}
-	
+#endif
+    
+#ifndef SYS_TVOS
 	[[NSNotificationCenter defaultCenter]addObserver:self selector:@selector(onKeyboardHide:) name:UIKeyboardWillHideNotification object:nil];
+#endif
 
 	return self;
 }
@@ -171,6 +174,7 @@ int Kore::System::windowHeight(int id) {
     glBindFramebufferOES(GL_FRAMEBUFFER_OES, defaultFramebuffer);
     glViewport(0, 0, backingWidth, backingHeight);
 
+#ifndef SYS_TVOS
     // Accelerometer updates
     if (hasAccelerometer) {
 
@@ -185,6 +189,7 @@ int Kore::System::windowHeight(int id) {
  			lastAccelerometerZ = acc.z;
  		}
     }
+#endif
 }
 #endif
 

--- a/Backends/iOS/Sources/Kore/GLViewController.h
+++ b/Backends/iOS/Sources/Kore/GLViewController.h
@@ -2,7 +2,9 @@
 #import <QuartzCore/QuartzCore.h>
 #import <OpenGLES/ES1/gl.h>
 #import <OpenGLES/ES1/glext.h>
+#ifndef SYS_TVOS
 #import <CoreMotion/CMMotionManager.h>
+#endif
 
 @interface GLViewController : UIViewController {
 @private

--- a/Backends/iOS/Sources/Kore/KoreAppDelegate.mm
+++ b/Backends/iOS/Sources/Kore/KoreAppDelegate.mm
@@ -43,8 +43,10 @@ int kore(int argc, char** argv);
 	
 	//glView = [[GLView alloc] initWithFrame:CGRectMake(0, 0, Kore::max(screenBounds.size.width, screenBounds.size.height), Kore::max(screenBounds.size.width, screenBounds.size.height))];
 	GLViewController* glViewController = [[GLViewController alloc] init];
+#ifndef SYS_TVOS
 	glViewController.view.multipleTouchEnabled = YES;
-	//glViewController.view = glView;
+#endif
+    //glViewController.view = glView;
 	//[glViewController ]
 	//[window addSubview:glView];
 	[window setRootViewController:glViewController];
@@ -55,6 +57,7 @@ int kore(int argc, char** argv);
     return YES;
 }
 
+#ifndef SYS_TVOS
 static Kore::Orientation convertOrientation(UIDeviceOrientation orientation) {
 	switch (orientation) {
 		case UIDeviceOrientationLandscapeLeft:
@@ -84,6 +87,7 @@ static UIInterfaceOrientation convertAppleOrientation(UIDeviceOrientation orient
 			return lastOrientation;
 	}
 }
+#endif
 
 void KoreUpdateKeyboard();
 /*

--- a/Backends/iOS/Sources/Kore/Video.mm
+++ b/Backends/iOS/Sources/Kore/Video.mm
@@ -51,7 +51,7 @@ Video::Video(const char* filename) : playing(false), sound(nullptr) {
 	char name[2048];
 	strcpy(name, iphonegetresourcepath());
 	strcat(name, "/");
-	strcat(name, KORE_DEBUGDIR);
+	strcat(name, "Deployment");
 	strcat(name, "/");
 	strcat(name, filename);
 	url = [NSURL fileURLWithPath:[NSString stringWithUTF8String:name]];

--- a/Sources/Kore/pch.h
+++ b/Sources/Kore/pch.h
@@ -1,5 +1,10 @@
 #pragma once
 
+#ifdef SYS_TVOS
+#undef SYS_IOS
+#define SYS_IOS
+#endif
+
 namespace Kore {
 	typedef unsigned char      u8;  // 1 Byte
 	typedef unsigned short     u16; // 2 Byte


### PR DESCRIPTION
Allows to build and run as a Windows 8.1 Universal App on desktop and phone, and on Apple TV.

Windows:
- Disables Gamepad functionality on Windows Phone as XInput is not available
- Correctly tests result of swap chain Present() (but see TODO comment)

AppleTV:
- Disables motion (CoreMotion not available on tvOS)
- Misc other changes to allow compilation

Compatibility is not fully tested with either of these platforms, but this is a starting point.
