### PR TITLE
setDepthStencilFrom and useDepthAsTexture for OpenGL.

### DIFF
--- a/Backends/OpenGL2/Sources/Kore/RenderTargetImpl.cpp
+++ b/Backends/OpenGL2/Sources/Kore/RenderTargetImpl.cpp
@@ -18,48 +18,84 @@ namespace {
 		for (int power = 0; ; ++power)
 			if (pow(power) >= i) return pow(power);
 	}
+}
 
-	void setupDepthStencil(int depthBufferBits, int stencilBufferBits, int width, int height) {
-		if (depthBufferBits > 0 && stencilBufferBits > 0) {
+void RenderTargetImpl::setupDepthStencil(int depthBufferBits, int stencilBufferBits, int width, int height) {
+	if (depthBufferBits > 0 && stencilBufferBits > 0) {
 #ifdef OPENGLES
-			GLenum internalFormat = GL_DEPTH24_STENCIL8_OES;
+		GLenum internalFormat = GL_DEPTH24_STENCIL8_OES;
 #else
-			GLenum internalFormat;
-			if (depthBufferBits == 24) internalFormat = GL_DEPTH24_STENCIL8;
-			else internalFormat = GL_DEPTH32F_STENCIL8;
+		GLenum internalFormat;
+		if (depthBufferBits == 24) internalFormat = GL_DEPTH24_STENCIL8;
+		else internalFormat = GL_DEPTH32F_STENCIL8;
 #endif
-			GLuint dsBuffer;
-			glGenRenderbuffers(1, &dsBuffer);
-			glCheckErrors();
-			glBindRenderbuffer(GL_RENDERBUFFER, dsBuffer);
-			glCheckErrors();
-			glRenderbufferStorage(GL_RENDERBUFFER, internalFormat, width, height);
-			glCheckErrors();
+		// Renderbuffer
+// 		glGenRenderbuffers(1, &_depthRenderbuffer);
+// 		glCheckErrors();
+// 		glBindRenderbuffer(GL_RENDERBUFFER, _depthRenderbuffer);
+// 		glCheckErrors();
+// 		glRenderbufferStorage(GL_RENDERBUFFER, internalFormat, width, height);
+// 		glCheckErrors();
+// #ifdef OPENGLES
+// 		glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, _depthRenderbuffer);
+// 		glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_STENCIL_ATTACHMENT, GL_RENDERBUFFER, _depthRenderbuffer);
+// #else
+// 		glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_RENDERBUFFER, _depthRenderbuffer);
+// #endif
+// 		glCheckErrors();
+		// Texture
+		glGenTextures(1, &_depthTexture);
+		glCheckErrors();
+		glBindTexture(GL_TEXTURE_2D, _depthTexture);
+		glCheckErrors();
+		glTexImage2D(GL_TEXTURE_2D, 0, internalFormat, width, height, 0, GL_DEPTH_COMPONENT, GL_UNSIGNED_INT, 0);
+		glCheckErrors();
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+		glCheckErrors();
+		glBindFramebuffer(GL_FRAMEBUFFER, _framebuffer);
+		glCheckErrors();
 #ifdef OPENGLES
-			glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, dsBuffer);
-			glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_STENCIL_ATTACHMENT, GL_RENDERBUFFER, dsBuffer);
+		glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, _depthTexture, 0);
+		glFramebufferTexture2D(GL_FRAMEBUFFER, GL_STENCIL_ATTACHMENT, GL_TEXTURE_2D, _depthTexture, 0);
 #else
-			glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_RENDERBUFFER, dsBuffer);
+		glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_TEXTURE_2D, _depthTexture, 0);
 #endif
-			glCheckErrors();
-		}
-		else if (depthBufferBits > 0) {
-			GLuint depthBuffer;
-			glGenRenderbuffers(1, &depthBuffer);
-			glCheckErrors();
-			glBindRenderbuffer(GL_RENDERBUFFER, depthBuffer);
-			glCheckErrors();
-			glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH_COMPONENT, width, height);
-			glCheckErrors();
-			glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, depthBuffer);
-			glCheckErrors();
-		}
+		glCheckErrors();
+	}
+	else if (depthBufferBits > 0) {
+		// Renderbuffer
+		// glGenRenderbuffers(1, &_depthRenderbuffer);
+		// glCheckErrors();
+		// glBindRenderbuffer(GL_RENDERBUFFER, _depthRenderbuffer);
+		// glCheckErrors();
+		// glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH_COMPONENT, width, height);
+		// glCheckErrors();
+		// glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, _depthRenderbuffer);
+		// glCheckErrors();
+		// Texture
+		glGenTextures(1, &_depthTexture);
+		glCheckErrors();
+		glBindTexture(GL_TEXTURE_2D, _depthTexture);
+		glCheckErrors();
+		glTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH_COMPONENT, width, height, 0, GL_DEPTH_COMPONENT, GL_UNSIGNED_INT, 0);
+		glCheckErrors();
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+		glCheckErrors();
+		glBindFramebuffer(GL_FRAMEBUFFER, _framebuffer);
+		glCheckErrors();
+		glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, _depthTexture, 0);
+		glCheckErrors();
 	}
 }
 
 RenderTarget::RenderTarget(int width, int height, int depthBufferBits, bool antialiasing, RenderTargetFormat format, int stencilBufferBits, int contextId) : width(width), height(height) {
-#ifndef VR_RIFT
-	// TODO: For the DK 2 we need a NPOT texture
+#ifdef OPENGLES
 	texWidth = getPower2(width);
 	texHeight = getPower2(height);
 #else
@@ -88,11 +124,17 @@ RenderTarget::RenderTarget(int width, int height, int depthBufferBits, bool anti
 
 	switch (format) {
 	case Target128BitFloat:
-		glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, texWidth, texHeight, 0, GL_RGBA, GL_FLOAT, 0);
+#ifdef OPENGLES
+		glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA32F_EXT, texWidth, texHeight, 0, GL_RGBA, GL_FLOAT, 0);
+#else
+		glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA32F, texWidth, texHeight, 0, GL_RGBA, GL_FLOAT, 0);
+#endif
 		break;
 	case Target64BitFloat:
-#ifndef OPENGLES
-		glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, texWidth, texHeight, 0, GL_RGBA, GL_HALF_FLOAT, 0);
+#ifdef OPENGLES
+		glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA16F_EXT, texWidth, texHeight, 0, GL_RGBA, GL_HALF_FLOAT_OES, 0);
+#else
+		glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA16F, texWidth, texHeight, 0, GL_RGBA, GL_HALF_FLOAT, 0);
 #endif
 		break;
 	case Target16BitDepth:
@@ -140,4 +182,16 @@ void RenderTarget::useColorAsTexture(TextureUnit unit) {
 	glCheckErrors();
 	glBindTexture(GL_TEXTURE_2D, _texture);
 	glCheckErrors();
+}
+
+void RenderTarget::useDepthAsTexture(TextureUnit unit) {
+	glActiveTexture(GL_TEXTURE0 + unit.unit);
+	glCheckErrors();
+	glBindTexture(GL_TEXTURE_2D, _depthTexture);
+	glCheckErrors();
+}
+
+void RenderTarget::setDepthStencilFrom(RenderTarget* source) {
+	glBindFramebuffer(GL_FRAMEBUFFER, _framebuffer);
+	glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, source->_depthTexture, 0);
 }

--- a/Backends/OpenGL2/Sources/Kore/RenderTargetImpl.h
+++ b/Backends/OpenGL2/Sources/Kore/RenderTargetImpl.h
@@ -5,6 +5,9 @@ namespace Kore {
 	public:
 		unsigned _framebuffer;
 		unsigned _texture;
+		unsigned _depthTexture;
+		//unsigned _depthRenderbuffer;
 		int contextId;
+		void setupDepthStencil(int depthBufferBits, int stencilBufferBits, int width, int height);
 	};
 }

--- a/Sources/Kore/Graphics/Graphics.h
+++ b/Sources/Kore/Graphics/Graphics.h
@@ -128,7 +128,8 @@ namespace Kore {
 		int texHeight;
 		int contextId;
 		void useColorAsTexture(TextureUnit unit);
-		//void useDepthAsTexture(int texunit);
+		void useDepthAsTexture(TextureUnit unit);
+		void setDepthStencilFrom(RenderTarget* source);
 	};
 
 	namespace Graphics {


### PR DESCRIPTION
- setDepthStencilFrom() for GL.
- useDepthAsTexture() for GL. Changed depth renderbuffer to depth texture to enable this, similar to WebGL. Left renderbuffer code commented out in case of issues.
- The problem of npot texture sizes is mainly a thing of GLES if I recall, so I forced it only there.
- Preliminary support for float textures on GLES.
