### PR TITLE
Begin GLES3 features.

### DIFF
--- a/Backends/OpenGL2/Sources/Kore/OpenGL.cpp
+++ b/Backends/OpenGL2/Sources/Kore/OpenGL.cpp
@@ -44,6 +44,10 @@ namespace {
 	
 	int _width;
 	int _height;
+
+#if defined(OPENGLES) && defined(SYS_ANDROID)
+	void* glesDrawBuffers;
+#endif
 }
 
 void Graphics::destroy(int windowId) {
@@ -184,6 +188,10 @@ void Graphics::init(int windowId, int depthBufferBits, int stencilBufferBits) {
 	
 	_width = System::windowWidth(0);
 	_height = System::windowHeight(0);
+
+#if defined(OPENGLES) && defined(SYS_ANDROID)
+	glesDrawBuffers = (void*)eglGetProcAddress("glDrawBuffers");
+#endif
 }
 
 void Graphics::changeResolution(int width, int height){
@@ -757,7 +765,9 @@ void Graphics::setRenderTarget(RenderTarget* texture, int num, int additionalTar
 		if (num == additionalTargets) {
 			GLenum buffers[16];
 			for (int i = 0; i <= additionalTargets; ++i) buffers[i] = GL_COLOR_ATTACHMENT0 + i;
-#ifndef OPENGLES
+#if defined(OPENGLES) && defined(SYS_ANDROID)
+            ((void(*)(GLsizei, GLenum*))glesDrawBuffers)(additionalTargets + 1, buffers);
+#else
 			glDrawBuffers(additionalTargets + 1, buffers);
 #endif
 		}

--- a/Backends/OpenGL2/Sources/Kore/ogl.h
+++ b/Backends/OpenGL2/Sources/Kore/ogl.h
@@ -13,11 +13,13 @@
 #ifdef SYS_IOS
 #import <OpenGLES/ES2/gl.h>
 #import <OpenGLES/ES2/glext.h>
+#import <OpenGLES/ES3/gl.h>
 #define OPENGLES
 #endif
 
 #ifdef SYS_ANDROID
-//#include <EGL/egl.h>
+#include <EGL/egl.h>
+#include <GLES3/gl3.h>
 #include <GLES2/gl2.h>
 #include <GLES2/gl2ext.h>
 #define OPENGLES


### PR DESCRIPTION
For some reason, eglGetProcAddress("glDrawBuffers"); was needed on Android.
