### PR TITLE
 screen dpi

### DIFF
--- a/Backends/Android/Java-Sources/com/ktxsoftware/kore/KoreActivity.java
+++ b/Backends/Android/Java-Sources/com/ktxsoftware/kore/KoreActivity.java
@@ -42,4 +42,12 @@ public class KoreActivity extends NativeActivity {
 		WindowManager manager = (WindowManager)context.getSystemService(Context.WINDOW_SERVICE);
 		return manager.getDefaultDisplay().getRotation();
 	}
+
+	public static int getScreenDpi() {
+		Context context = getInstance().getApplicationContext();
+		WindowManager manager = (WindowManager)context.getSystemService(Context.WINDOW_SERVICE);
+		android.util.DisplayMetrics metrics = new android.util.DisplayMetrics();
+		manager.getDefaultDisplay().getMetrics(metrics);
+		return (int)(metrics.density * android.util.DisplayMetrics.DENSITY_DEFAULT);
+	}
 }

--- a/Backends/Android/Sources/Kore/System.cpp
+++ b/Backends/Android/Sources/Kore/System.cpp
@@ -843,6 +843,16 @@ int Kore::System::windowCount() {
     return 1;
 }
 
+int Kore::System::screenDpi() {
+	JNIEnv* env;
+	activity->vm->AttachCurrentThread(&env, nullptr);
+	jclass koreActivityClass = KoreAndroid::findClass(env, "com.ktxsoftware.kore.KoreActivity");
+	jmethodID koreActivityGetScreenDpi = env->GetStaticMethodID(koreActivityClass, "getScreenDpi", "()I");
+	int dpi = env->CallStaticIntMethod(koreActivityClass, koreActivityGetScreenDpi);
+	activity->vm->DetachCurrentThread();
+	return dpi;
+}
+
 #include <sys/time.h>
 #include <time.h>
 

--- a/Backends/Windows/Sources/Kore/System.cpp
+++ b/Backends/Windows/Sources/Kore/System.cpp
@@ -101,6 +101,13 @@ namespace Kore { namespace System {
 		return i;
 		//return windows[id]->height;
 	}
+
+	int screenDpi() {
+		HDC hdc = CreateDC(TEXT("DISPLAY"), NULL, NULL, NULL);
+		int dpi = GetDeviceCaps(hdc, LOGPIXELSX);
+		DeleteDC(hdc);
+		return dpi;
+	}
 }}
 
 using namespace Kore;

--- a/Sources/Kore/System.cpp
+++ b/Sources/Kore/System.cpp
@@ -24,6 +24,12 @@ int Kore::System::desktopHeight() {
 
 #endif // !ined(SYS_WINDOWS) && !defined(SYS_OSX) && !defined(SYS_LINUX) && !defined(SYS_HTML5)
 
+#if !defined(SYS_ANDROID) 
+int:: Kore::System::screenDpi() {
+  return 0;
+}
+#endif //!defined(SYS_ANDROID) 
+
 namespace { namespace callbacks {
 	void (*callback)();
 	void (*foregroundCallback)();

--- a/Sources/Kore/System.cpp
+++ b/Sources/Kore/System.cpp
@@ -24,7 +24,7 @@ int Kore::System::desktopHeight() {
 
 #endif // !ined(SYS_WINDOWS) && !defined(SYS_OSX) && !defined(SYS_LINUX) && !defined(SYS_HTML5)
 
-#if !defined(SYS_ANDROID) 
+#if !defined(SYS_ANDROID) && !defined(SYS_WINDOWS)
 int:: Kore::System::screenDpi() {
   return 0;
 }

--- a/Sources/Kore/System.h
+++ b/Sources/Kore/System.h
@@ -27,6 +27,8 @@ namespace Kore {
 		int windowWidth(int id = 0);
 		int windowHeight(int id = 0);
 		int windowCount();
+		
+		int screenDpi();
 
 		void changeResolution(int width, int height, bool fullscreen);
 		bool handleMessages();


### PR DESCRIPTION
Added screenDpi() function. Currently implemented only for Android and Windows, returns 0 on other targets. 
