### PR TITLE
First work on enabling generic buffer support in compute shaders.

### DIFF
--- a/Backends/OpenGL2/Sources/Kore/ComputeImpl.cpp
+++ b/Backends/OpenGL2/Sources/Kore/ComputeImpl.cpp
@@ -87,6 +87,12 @@ void Compute::setFloat(ComputeConstantLocation location, float value) {
 #endif
 }
 
+void Compute::setBuffer(ShaderStorageBuffer* buffer, int index) {
+#ifdef HAS_COMPUTE
+	glBindBufferBase(GL_SHADER_STORAGE_BUFFER, index, buffer->bufferId); glCheckErrors2();
+#endif
+}
+
 void Compute::setTexture(ComputeTextureUnit unit, Texture* texture) {
 #ifdef HAS_COMPUTE
 	glActiveTexture(GL_TEXTURE0 + unit.unit); glCheckErrors2();
@@ -104,5 +110,6 @@ void Compute::compute(int x, int y, int z) {
 #ifdef HAS_COMPUTE
 	glDispatchCompute(x, y, z); glCheckErrors2();
 	glMemoryBarrier(GL_SHADER_IMAGE_ACCESS_BARRIER_BIT); glCheckErrors2();
+	glMemoryBarrier(GL_SHADER_STORAGE_BARRIER_BIT); glCheckErrors2();
 #endif
 }

--- a/Backends/OpenGL2/Sources/Kore/ShaderStorageBufferImpl.cpp
+++ b/Backends/OpenGL2/Sources/Kore/ShaderStorageBufferImpl.cpp
@@ -1,0 +1,69 @@
+#include "pch.h"
+#include <Kore/Compute/Compute.h>
+#include "ogl.h"
+
+using namespace Kore;
+
+ShaderStorageBuffer* ShaderStorageBufferImpl::current = nullptr;
+
+ShaderStorageBufferImpl::ShaderStorageBufferImpl(int count, VertexData type) : myCount(count) {
+
+}
+
+ShaderStorageBuffer::ShaderStorageBuffer(int indexCount, VertexData type) : ShaderStorageBufferImpl(indexCount, type) {
+	myStride = 0;
+	switch (type) {
+	case ColorVertexData:
+		myStride += 1 * 4;
+		break;
+	case Float1VertexData:
+		myStride += 1 * 4;
+		break;
+	case Float2VertexData:
+		myStride += 2 * 4;
+		break;
+	case Float3VertexData:
+		myStride += 3 * 4;
+		break;
+	case Float4VertexData:
+		myStride += 4 * 4;
+		break;
+	case Float4x4VertexData:
+		myStride += 4 * 4 * 4;
+		break;
+	}
+
+	glGenBuffers(1, &bufferId);
+	glCheckErrors();
+	data = new int[indexCount];
+}
+
+ShaderStorageBuffer::~ShaderStorageBuffer() {
+	unset();
+	delete[] data;
+}
+
+int* ShaderStorageBuffer::lock() {
+	return data;
+}
+
+void ShaderStorageBuffer::unlock() {
+	glBindBuffer(GL_SHADER_STORAGE_BUFFER, bufferId);
+	glCheckErrors();
+	glBufferData(GL_SHADER_STORAGE_BUFFER, myCount * myStride, data, GL_STATIC_DRAW);
+	glCheckErrors();
+}
+
+void ShaderStorageBuffer::_set() {
+	current = this;
+	glBindBuffer(GL_SHADER_STORAGE_BUFFER, bufferId);
+	glCheckErrors();
+}
+
+void ShaderStorageBufferImpl::unset() {
+	if ((void*)current == (void*)this) current = nullptr;
+}
+
+int ShaderStorageBuffer::count() {
+	return myCount;
+}

--- a/Backends/OpenGL2/Sources/Kore/ShaderStorageBufferImpl.h
+++ b/Backends/OpenGL2/Sources/Kore/ShaderStorageBufferImpl.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <Kore/Graphics/VertexStructure.h>
+
+namespace Kore {
+	class ShaderStorageBuffer;
+
+	class ShaderStorageBufferImpl {
+	protected:
+	public:
+		ShaderStorageBufferImpl(int count, VertexData type);
+		void unset();
+
+		int* data;
+		int myCount;
+		int myStride;
+		uint bufferId;
+	public:
+		static ShaderStorageBuffer* current;
+	};
+}

--- a/Sources/Kore/Compute/Compute.h
+++ b/Sources/Kore/Compute/Compute.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Kore/ComputeImpl.h>
+#include <Kore/ShaderStorageBufferImpl.h>
 
 namespace Kore {
 	class ComputeConstantLocation : public ComputeConstantLocationImpl {
@@ -20,8 +21,19 @@ namespace Kore {
 		ComputeTextureUnit getTextureUnit(const char* name);
 	};
 
+	class ShaderStorageBuffer : public ShaderStorageBufferImpl {
+	public:
+		ShaderStorageBuffer(int count, VertexData type);
+		virtual ~ShaderStorageBuffer();
+		int* lock();
+		void unlock();
+		int count();
+		void _set();
+	};
+
 	namespace Compute {
 		void setFloat(ComputeConstantLocation location, float value);
+		void setBuffer(ShaderStorageBuffer* buffer, int index);
 		void setTexture(ComputeTextureUnit unit, Texture* texture);
 		void setShader(ComputeShader* shader);
 		void compute(int x, int y, int z);


### PR DESCRIPTION
Uploading as a discussion base since I am unsure whether modifying vertex data in a compute shader requires major api changes:
Could be that the concept of another buffer (ShaderStorageBuffer) is flawed and we need a modified VertexBuffer instead. However, this seems incompatible with having multiple elements (e.g. pos and texCoords) in asingle VertexBuffer when only one is used in the compute shader. 
