### PR TITLE
Set android native to use "sticky immersive mode"

### DIFF
--- a/Backends/Android/Java-Sources/com/ktxsoftware/kore/KoreActivity.java
+++ b/Backends/Android/Java-Sources/com/ktxsoftware/kore/KoreActivity.java
@@ -6,6 +6,7 @@ import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
 import android.os.IBinder;
+import android.view.View;
 import android.view.WindowManager;
 import android.view.inputmethod.InputMethodManager;
 
@@ -23,6 +24,19 @@ public class KoreActivity extends NativeActivity {
 		instance = this;
 		inputManager = (InputMethodManager)getSystemService(Context.INPUT_METHOD_SERVICE);
 	}
+
+    @Override
+    public void onWindowFocusChanged(boolean hasFocus) {
+        super.onWindowFocusChanged(hasFocus);
+        if (hasFocus) {
+            getWindow().getDecorView().setSystemUiVisibility(
+                    View.SYSTEM_UI_FLAG_LAYOUT_STABLE
+                            | View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
+                            | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
+                            | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
+                            | View.SYSTEM_UI_FLAG_FULLSCREEN
+                            | View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY);}
+    }
 
 	public static void showKeyboard() {
 		getInstance().inputManager.showSoftInput(getInstance().getWindow().getDecorView(), 0);


### PR DESCRIPTION
Set android native to use "sticky immersive mode" - https://developer.android.com/training/system-ui/immersive.html#sticky

May be this have to be an option, but as I see Kore already tries to run full screen: it hides status bar by setting android:theme="@android:style/Theme.Black.NoTitleBar.Fullscreen in manifest. So why not also hide navigation bar?
