### PR TITLE
add modulo operation

### DIFF
--- a/Sources/Kore/Math/Core.cpp
+++ b/Sources/Kore/Math/Core.cpp
@@ -41,6 +41,11 @@ float Kore::floor(float value) {
 	return std::floor(value);
 }
 
+float Kore::mod(float numer, float denom)
+{
+	return std::fmod(numer, denom);
+}
+
 unsigned Kore::pow(unsigned value, unsigned exponent) {
 	/*unsigned ret = 1;
 	for (unsigned i = 0; i < exponent; ++i) ret *= value;

--- a/Sources/Kore/Math/Core.h
+++ b/Sources/Kore/Math/Core.h
@@ -22,6 +22,7 @@ namespace Kore {
 	float atan(float value);
 	float atan2(float y, float x);
 	float floor(float value);
+	float mod(float numer, float denom);
 
 	template<class T> T min(T a, T b) { return (a < b) ? a : b; }
 	template<class T> T max(T a, T b) { return (a > b) ? a : b; }


### PR DESCRIPTION
% is defined only for integer, so fmod is required, but it's not consistent with the other operations like sin, which are used from kore itself. So i think it could be helpful to add this operation.
