### PR TITLE
Fix kha freezes on Android 7 after going background

### DIFF
--- a/Backends/Android/Sources/Kore/System.cpp
+++ b/Backends/Android/Sources/Kore/System.cpp
@@ -50,17 +50,17 @@ namespace {
 		displayIsInitialized = false;
 	}
 
-    void tryCallForegroundCallback() {
-        if(displayIsInitialized && appIsForeground) {
-            Kore::System::foregroundCallback();
-        }
-    }
+	void tryCallForegroundCallback() {
+		if(displayIsInitialized && appIsForeground) {
+			Kore::System::foregroundCallback();
+		}
+	}
 
-    void tryCallBackgroundCallback() {
-        if(!(displayIsInitialized && appIsForeground)) {
-            Kore::System::backgroundCallback();
-        }
-    }
+	void tryCallBackgroundCallback() {
+		if(!(displayIsInitialized && appIsForeground)) {
+			Kore::System::backgroundCallback();
+		}
+	}
 
 	int32_t input(android_app* app, AInputEvent* event) {
 		if (AInputEvent_getType(event) == AINPUT_EVENT_TYPE_MOTION) {

--- a/Backends/Android/Sources/Kore/System.cpp
+++ b/Backends/Android/Sources/Kore/System.cpp
@@ -35,19 +35,19 @@ namespace {
 
 	bool started = false;
 	bool paused = true;
-    bool displayIsInitialized = false;
-    bool appIsForeground = false;
+	bool displayIsInitialized = false;
+	bool appIsForeground = false;
 
 	void initDisplay() {
 		if (glContext->Resume(app->window) != EGL_SUCCESS) {
 			Kore::log(Kore::Warning, "GL context lost.");
 		}
-        displayIsInitialized = true;
+		displayIsInitialized = true;
 	}
 
 	void termDisplay() {
 		glContext->Suspend();
-        displayIsInitialized = false;
+		displayIsInitialized = false;
 	}
 
     void tryCallForegroundCallback() {
@@ -390,12 +390,12 @@ namespace {
 					started = true;
 				}
 				Kore::System::swapBuffers(0);
-                tryCallForegroundCallback();
-            }
+				tryCallForegroundCallback();
+			}
 			break;
 		case APP_CMD_TERM_WINDOW:
 			termDisplay();
-            tryCallBackgroundCallback();
+			tryCallBackgroundCallback();
 			break;
 		case APP_CMD_GAINED_FOCUS:
 			if (accelerometerSensor != NULL) {
@@ -416,8 +416,8 @@ namespace {
 			}
 			break;
 		case APP_CMD_START:
-            appIsForeground = true;
-            tryCallForegroundCallback();
+			appIsForeground = true;
+			tryCallForegroundCallback();
 			break;
 		case APP_CMD_RESUME:
 			Kore::System::resumeCallback();
@@ -430,7 +430,7 @@ namespace {
 			paused = true;
 			break;
 		case APP_CMD_STOP:
-            appIsForeground = false;
+			appIsForeground = false;
 			tryCallBackgroundCallback();
 			break;
 		case APP_CMD_DESTROY:


### PR DESCRIPTION
Made background/foreground callbacks be called assuming that app is foreground when both app is actually foreground (APP_CMD_START recieved) and display is initialized (APP_CMD_INIT_WINDOW recieved).

This fixes kha bug on Android 7 caused by assumption that display is initialized if app is foreground.