### PR TITLE
setImageTexture draft.

### DIFF
--- a/Backends/OpenGL2/Sources/Kore/OpenGL.cpp
+++ b/Backends/OpenGL2/Sources/Kore/OpenGL.cpp
@@ -688,6 +688,10 @@ void Graphics::setTexture(TextureUnit unit, Texture* texture) {
 	texture->_set(unit);
 }
 
+void Graphics::setImageTexture(TextureUnit unit, Texture* texture) {
+	texture->_setImage(unit);
+}
+
 void Graphics::setTextureAddressing(TextureUnit unit, TexDir dir, TextureAddressing addressing) {
 	glActiveTexture(GL_TEXTURE0 + unit.unit);
 	GLenum texDir;

--- a/Backends/OpenGL2/Sources/Kore/TextureImpl.cpp
+++ b/Backends/OpenGL2/Sources/Kore/TextureImpl.cpp
@@ -359,6 +359,13 @@ void Texture::_set(TextureUnit unit) {
 #endif
 }
 
+void Texture::_setImage(TextureUnit unit) {
+#if defined(SYS_WINDOWS) || defined(SYS_LINUX)
+	glBindImageTexture(unit.unit, texture, 0, GL_TRUE, 0, GL_WRITE_ONLY, GL_RGBA8);
+	glCheckErrors();
+#endif
+}
+
 int Texture::stride() {
 	return width * 4;
 }

--- a/Sources/Kore/Graphics/Graphics.h
+++ b/Sources/Kore/Graphics/Graphics.h
@@ -123,6 +123,7 @@ namespace Kore {
 		void setVertexBuffers(VertexBuffer** vertexBuffers, int count);
 		void setIndexBuffer(IndexBuffer& indexBuffer);
 		void setTexture(TextureUnit unit, Texture* texture);
+		void setImageTexture(TextureUnit unit, Texture* texture);
 
 		void drawIndexedVertices();
 		void drawIndexedVertices(int start, int count);

--- a/Sources/Kore/Graphics/Texture.h
+++ b/Sources/Kore/Graphics/Texture.h
@@ -15,6 +15,7 @@ namespace Kore {
 		Texture(unsigned texid);
 #endif
 		void _set(TextureUnit unit);
+		void _setImage(TextureUnit unit);
 		u8* lock();
 		void unlock();
 #ifdef SYS_IOS


### PR DESCRIPTION
Just a draft of very basic 'setImageTexture' implementation, to allow [image load/store](https://www.opengl.org/wiki/Image_Load_Store) functionality in Kore.

We talked this is also needed for compute shaders, if there are any specifics I can modify/adapt the code.

 Missing stubs for other backends, not a complete PR.