### PR TITLE
Restore "sticky immersive mode" after keyboard hide

### DIFF
--- a/Backends/Android/Java-Sources/com/ktxsoftware/kore/KoreActivity.java
+++ b/Backends/Android/Java-Sources/com/ktxsoftware/kore/KoreActivity.java
@@ -7,7 +7,9 @@ import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
 import android.net.Uri;
 import android.os.Bundle;
+import android.os.Handler;
 import android.os.IBinder;
+import android.os.Message;
 import android.view.View;
 import android.view.WindowManager;
 import android.view.inputmethod.InputMethodManager;
@@ -16,6 +18,12 @@ public class KoreActivity extends NativeActivity {
 	private static KoreActivity instance;
 	private InputMethodManager inputManager;
 	private boolean isDisabledStickyImmersiveMode;
+
+    private final Handler hideSystemUIHandler = new Handler() {
+        @Override public void handleMessage(Message msg) {
+            hideSystemUI();
+        }
+    };
 
 	public static KoreActivity getInstance() {
 		return instance;
@@ -35,18 +43,30 @@ public class KoreActivity extends NativeActivity {
         }
 	}
 
+    private void hideSystemUI() {
+        getWindow().getDecorView().setSystemUiVisibility(
+                View.SYSTEM_UI_FLAG_LAYOUT_STABLE
+                        | View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
+                        | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
+                        | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
+                        | View.SYSTEM_UI_FLAG_FULLSCREEN
+                        | View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY
+        );
+    }
+
+    private void delayedHideSystemUI() {
+        hideSystemUIHandler.removeMessages(0);
+        hideSystemUIHandler.sendEmptyMessageDelayed(0, 300);
+    }
+
     @Override
     public void onWindowFocusChanged(boolean hasFocus) {
         super.onWindowFocusChanged(hasFocus);
         if (hasFocus && !isDisabledStickyImmersiveMode) {
-            getWindow().getDecorView().setSystemUiVisibility(
-                View.SYSTEM_UI_FLAG_LAYOUT_STABLE
-                | View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
-                | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
-                | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
-                | View.SYSTEM_UI_FLAG_FULLSCREEN
-                | View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY
-            );
+            delayedHideSystemUI();
+        }
+        else {
+            hideSystemUIHandler.removeMessages(0);
         }
     }
 
@@ -56,6 +76,7 @@ public class KoreActivity extends NativeActivity {
 
 	public static void hideKeyboard() {
 		getInstance().inputManager.hideSoftInputFromWindow(getInstance().getWindow().getDecorView().getWindowToken(), 0);
+        getInstance().delayedHideSystemUI();
 	}
 
 	public static void loadURL(String url) {


### PR DESCRIPTION
Problem and solution is described here: http://stackoverflow.com/questions/24187728/sticky-immersive-mode-disabled-after-soft-keyboard-shown

The solution is not perfect. It works if keyboard is hidden with hideKeyboard() function. But if it's closed by some other means it fails to detect this. But after googling I can say there is currently no perfect solution.