### PR TITLE
Mouse leave event, mouse capture while button down

### DIFF
--- a/Backends/Windows/Sources/Kore/System.cpp
+++ b/Backends/Windows/Sources/Kore/System.cpp
@@ -20,6 +20,7 @@
 #define WIN32_LEAN_AND_MEAN
 #define NOMINMAX
 #include <Windows.h>
+#include <Windowsx.h>
 #include <XInput.h>
 #include <exception>
 #include <shlobj.h>
@@ -376,52 +377,52 @@ LRESULT WINAPI MsgProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam) {
 			tme.hwndTrack = hWnd;
 			TrackMouseEvent(&tme);
 		}
-		mouseX = LOWORD(lParam);
-		mouseY = HIWORD(lParam);
-		Mouse::the()->_move(windowId, LOWORD(lParam), HIWORD(lParam));
+		mouseX = GET_X_LPARAM(lParam);
+		mouseY = GET_Y_LPARAM(lParam);
+		Mouse::the()->_move(windowId, mouseX, mouseY);
 		break;
 	case WM_LBUTTONDOWN:
 		if (!Mouse::the()->isLocked(idFromHWND(hWnd)))
 			SetCapture(hWnd);
-		mouseX = LOWORD(lParam);
-		mouseY = HIWORD(lParam);
-		Mouse::the()->_press(idFromHWND(hWnd), 0, LOWORD(lParam), HIWORD(lParam));
+		mouseX = GET_X_LPARAM(lParam);
+		mouseY = GET_Y_LPARAM(lParam);
+		Mouse::the()->_press(idFromHWND(hWnd), 0, mouseX, mouseY);
 		break;
 	case WM_LBUTTONUP:
 		if (!Mouse::the()->isLocked(idFromHWND(hWnd)))
 			ReleaseCapture();
-		mouseX = LOWORD(lParam);
-		mouseY = HIWORD(lParam);
-		Mouse::the()->_release(idFromHWND(hWnd), 0, LOWORD(lParam), HIWORD(lParam));
+		mouseX = GET_X_LPARAM(lParam);
+		mouseY = GET_Y_LPARAM(lParam);
+		Mouse::the()->_release(idFromHWND(hWnd), 0, mouseX, mouseY);
 		break;
 	case WM_RBUTTONDOWN:
-		mouseX = LOWORD(lParam);
-		mouseY = HIWORD(lParam);
-		Mouse::the()->_press(idFromHWND(hWnd), 1, LOWORD(lParam), HIWORD(lParam));
+		mouseX = GET_X_LPARAM(lParam);
+		mouseY = GET_Y_LPARAM(lParam);
+		Mouse::the()->_press(idFromHWND(hWnd), 1, mouseX, mouseY);
 		break;
 	case WM_RBUTTONUP:
-		mouseX = LOWORD(lParam);
-		mouseY = HIWORD(lParam);
-		Mouse::the()->_release(idFromHWND(hWnd), 1, LOWORD(lParam), HIWORD(lParam));
+		mouseX = GET_X_LPARAM(lParam);
+		mouseY = GET_Y_LPARAM(lParam);
+		Mouse::the()->_release(idFromHWND(hWnd), 1, mouseX, mouseY);
 		break;
 	case WM_MBUTTONDOWN:
-		mouseX = LOWORD(lParam);
-		mouseY = HIWORD(lParam);
-		Mouse::the()->_press(idFromHWND(hWnd), 2, LOWORD(lParam), HIWORD(lParam));
+		mouseX = GET_X_LPARAM(lParam);
+		mouseY = GET_Y_LPARAM(lParam);
+		Mouse::the()->_press(idFromHWND(hWnd), 2, mouseX, mouseY);
 		break;
 	case WM_MBUTTONUP:
-		mouseX = LOWORD(lParam);
-		mouseY = HIWORD(lParam);
-		Mouse::the()->_release(idFromHWND(hWnd), 2, LOWORD(lParam), HIWORD(lParam));
+		mouseX = GET_X_LPARAM(lParam);
+		mouseY = GET_Y_LPARAM(lParam);
+		Mouse::the()->_release(idFromHWND(hWnd), 2, mouseX, mouseY);
 		break;
 	case WM_XBUTTONDOWN:
-		mouseX = LOWORD(lParam);
-		mouseY = HIWORD(lParam);
+		mouseX = GET_X_LPARAM(lParam);
+		mouseY = GET_Y_LPARAM(lParam);
 		Mouse::the()->_press(idFromHWND(hWnd), HIWORD(wParam) + 2, mouseX, mouseY);
 		break;
 	case WM_XBUTTONUP:
-		mouseX = LOWORD(lParam);
-		mouseY = HIWORD(lParam);
+		mouseX = GET_X_LPARAM(lParam);
+		mouseY = GET_Y_LPARAM(lParam);
 		Mouse::the()->_release(idFromHWND(hWnd), HIWORD(wParam) + 2, mouseX, mouseY);
 		break;
 	case WM_MOUSEWHEEL:

--- a/Backends/Windows/Sources/Kore/System.cpp
+++ b/Backends/Windows/Sources/Kore/System.cpp
@@ -381,11 +381,15 @@ LRESULT WINAPI MsgProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam) {
 		Mouse::the()->_move(windowId, LOWORD(lParam), HIWORD(lParam));
 		break;
 	case WM_LBUTTONDOWN:
+		if (!Mouse::the()->isLocked(idFromHWND(hWnd)))
+			SetCapture(hWnd);
 		mouseX = LOWORD(lParam);
 		mouseY = HIWORD(lParam);
 		Mouse::the()->_press(idFromHWND(hWnd), 0, LOWORD(lParam), HIWORD(lParam));
 		break;
 	case WM_LBUTTONUP:
+		if (!Mouse::the()->isLocked(idFromHWND(hWnd)))
+			ReleaseCapture();
 		mouseX = LOWORD(lParam);
 		mouseY = HIWORD(lParam);
 		Mouse::the()->_release(idFromHWND(hWnd), 0, LOWORD(lParam), HIWORD(lParam));

--- a/Sources/Kore/Input/Mouse.cpp
+++ b/Sources/Kore/Input/Mouse.cpp
@@ -66,6 +66,12 @@ void Mouse::_activated(int windowId, bool truth) {
 	}
 }
 
+void Mouse::___leave(int windowId) {
+	if (Leave != nullptr) {
+		Leave(windowId);
+	}
+}
+
 bool Mouse::isLocked(int windowId) {
 	return locked;
 }

--- a/Sources/Kore/Input/Mouse.h
+++ b/Sources/Kore/Input/Mouse.h
@@ -9,6 +9,7 @@ namespace Kore {
 		void (*Press)(int windowId, int button, int x, int y);
 		void (*Release)(int windowId, int button, int x, int y);
 		void (*Scroll)(int windowId, int delta);
+		void (*Leave)(int windowId);
 
 		bool canLock(int windowId);
 		bool isLocked(int windowId);
@@ -25,6 +26,7 @@ namespace Kore {
 		void _release(int windowId, int button, int x, int y);
 		void _scroll(int windowId, int delta);
 		void _activated(int windowId, bool truth);
+		void ___leave(int windowId); // use ___leave, because _leave and __leave are reserved keywords
 
 	private:
 		void _lock(int windowId, bool truth);


### PR DESCRIPTION
1. Added MouseLeave event.
2. Capture mouse while left button is down, so that window receives mouse messages while button is down even mouse goes outside window. This is very common behavior, and I do not think it can harm in any way. But if you prefer, than this can be an option.
3. Fixed bug with handling negative mouse coordinates (which were introduced with modifications from paragraph 2)
Everything only for Windows.