### PR TITLE
Unbind after glBufferData

### DIFF
--- a/Backends/OpenGL2/Sources/Kore/IndexBufferImpl.cpp
+++ b/Backends/OpenGL2/Sources/Kore/IndexBufferImpl.cpp
@@ -41,6 +41,8 @@ void IndexBuffer::unlock() {
 	glBufferData(GL_ELEMENT_ARRAY_BUFFER, myCount * 4, data, GL_STATIC_DRAW);
 	glCheckErrors();
 #endif
+	glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
+	glCheckErrors();
 }
 
 void IndexBuffer::_set() {


### PR DESCRIPTION
I experienced a weird nvogl64.dll driver crash happening (only) on new nvidia cards (9 and 10 series). This is for Kore embedded in another application, which I suspect tried to incorrectly modify bound data somehow. Unbinding GL_ELEMENT_ARRAY_BUFFER after the work is done fixes the crash.