### PR TITLE
Add setFloat4s

### DIFF
--- a/Backends/Direct3D11/Sources/Kore/Direct3D11.winrt.cpp
+++ b/Backends/Direct3D11/Sources/Kore/Direct3D11.winrt.cpp
@@ -685,6 +685,10 @@ void Graphics::setFloats(ConstantLocation location, float* values, int count) {
 	::setFloats(tessControlConstants, location.tessControlOffset, location.tessControlSize, values, count);
 }
 
+void Graphics::setFloat4s(ConstantLocation location, float* values, int count) {
+	Graphics::setFloats(location, values, count);
+}
+
 void Graphics::setBool(ConstantLocation location, bool value) {
 	::setBool(vertexConstants, location.vertexOffset, location.vertexSize, value);
 	::setBool(fragmentConstants, location.fragmentOffset, location.fragmentSize, value);

--- a/Backends/Direct3D12/Sources/Kore/Direct3D12.cpp
+++ b/Backends/Direct3D12/Sources/Kore/Direct3D12.cpp
@@ -590,6 +590,10 @@ void Graphics::setFloats(ConstantLocation location, float* values, int count) {
 	::setFloats(tessControlConstants, location.tessControlOffset, location.tessControlSize, values, count);
 }
 
+void Graphics::setFloat4s(ConstantLocation location, float* values, int count) {
+	Graphics::setFloats(location, values, count);
+}
+
 void Graphics::setBool(ConstantLocation location, bool value) {
 	::setBool(vertexConstants, location.vertexOffset, location.vertexSize, value);
 	::setBool(fragmentConstants, location.fragmentOffset, location.fragmentSize, value);

--- a/Backends/Direct3D9/Sources/Kore/Direct3D9.cpp
+++ b/Backends/Direct3D9/Sources/Kore/Direct3D9.cpp
@@ -737,6 +737,10 @@ void Graphics::setFloats(ConstantLocation location, float* values, int count) {
 	}
 }
 
+void Graphics::setFloat4s(ConstantLocation location, float* values, int count) {
+	Graphics::setFloats(location, values, count);
+}
+
 void Graphics::setMatrix(ConstantLocation location, const mat4& value) {
 	if (location.shaderType == -1) return;
 	float floats[16];

--- a/Backends/Metal/Sources/Kore/Metal.mm
+++ b/Backends/Metal/Sources/Kore/Metal.mm
@@ -156,6 +156,10 @@ void Graphics::setFloats(ConstantLocation location, float* values, int count) {
 	}
 }
 
+void Graphics::setFloat4s(ConstantLocation location, float* values, int count) {
+	Graphics::setFloats(location, values, count);
+}
+
 void Graphics::setMatrix(ConstantLocation location, const mat4& value) {
 	if (location.vertexOffset >= 0) {
 		float* floats = (float*)vertexData(location.vertexOffset);

--- a/Backends/OpenGL2/Sources/Kore/OpenGL.cpp
+++ b/Backends/OpenGL2/Sources/Kore/OpenGL.cpp
@@ -263,6 +263,11 @@ void Graphics::setFloats(ConstantLocation location, float* values, int count) {
 	glCheckErrors();
 }
 
+void Graphics::setFloat4s(ConstantLocation location, float* values, int count) {
+	glUniform4fv(location.location, count, values);
+	glCheckErrors();
+}
+
 void Graphics::setMatrix(ConstantLocation location, const mat4& value) {
 	glUniformMatrix4fv(location.location, 1, GL_FALSE, &value.matrix[0][0]);
 	glCheckErrors();

--- a/Backends/Vulkan/Sources/Kore/Vulkan.cpp
+++ b/Backends/Vulkan/Sources/Kore/Vulkan.cpp
@@ -1177,6 +1177,10 @@ void Graphics::setFloats(ConstantLocation location, float* values, int count) {
 	}
 }
 
+void Graphics::setFloat4s(ConstantLocation location, float* values, int count) {
+	Graphics::setFloats(location, values, count);
+}
+
 void Graphics::setMatrix(ConstantLocation location, const mat4& value) {
 	if (location.vertexOffset >= 0) {
 		float* data = (float*)&((u8*)ProgramImpl::current->uniformDataVertex)[location.vertexOffset];

--- a/Sources/Kore/Graphics/Graphics.h
+++ b/Sources/Kore/Graphics/Graphics.h
@@ -117,6 +117,7 @@ namespace Kore {
 		void setFloat4(ConstantLocation location, float value1, float value2, float value3, float value4);
 		void setFloat4(ConstantLocation location, vec4 value);
 		void setFloats(ConstantLocation location, float* values, int count);
+		void setFloat4s(ConstantLocation location, float* values, int count);
 		void setMatrix(ConstantLocation location, const mat3& value);
 		void setMatrix(ConstantLocation location, const mat4& value);
 


### PR DESCRIPTION
Added setFloat4s() for setting vec4[] uniforms. Unfortunately this is a separate function in opengl, otherwise setFloats() would suffice for both float[] and vec4[] uniforms.