### PR TITLE
D3D12 work

### DIFF
--- a/Backends/Direct3D12/Sources/Kore/Direct3D12.h
+++ b/Backends/Direct3D12/Sources/Kore/Direct3D12.h
@@ -9,7 +9,6 @@ extern int currentBackBuffer;
 extern ID3D12Device* device;
 extern ID3D12RootSignature* rootSignature;
 extern ID3D12GraphicsCommandList* commandList;
-extern ID3D12Resource* constantBuffers[QUEUE_SLOT_COUNT];
 
 extern Kore::u8 vertexConstants[1024 * 4];
 extern Kore::u8 fragmentConstants[1024 * 4];

--- a/Backends/Direct3D12/Sources/Kore/ProgramImpl.cpp
+++ b/Backends/Direct3D12/Sources/Kore/ProgramImpl.cpp
@@ -33,18 +33,10 @@ void ProgramImpl::setConstants() {
 	}
 	*/
 
-	u8* data;
-	constantBuffers[currentBackBuffer]->Map(0, nullptr, (void**)&data);
-	memcpy(data, vertexConstants, sizeof(vertexConstants));
-	memcpy(data + sizeof(vertexConstants), fragmentConstants, sizeof(fragmentConstants));
-	constantBuffers[currentBackBuffer]->Unmap(0, nullptr);
-
 	commandList->SetPipelineState(_current->pso);
 	commandList->SetGraphicsRootSignature(rootSignature);
 
 	TextureImpl::setTextures();
-
-	commandList->SetGraphicsRootConstantBufferView(1, constantBuffers[currentBackBuffer]->GetGPUVirtualAddress());
 }
 
 ProgramImpl::ProgramImpl() : vertexShader(nullptr), fragmentShader(nullptr), geometryShader(nullptr), tessEvalShader(nullptr), tessControlShader(nullptr) {}
@@ -206,7 +198,7 @@ void Program::link(VertexStructure** structures, int count) {
 	psoDesc.InputLayout.pInputElementDescs = vertexDesc;
 
 	psoDesc.RasterizerState.FillMode = D3D12_FILL_MODE_SOLID;
-	psoDesc.RasterizerState.CullMode = D3D12_CULL_MODE_NONE;
+	psoDesc.RasterizerState.CullMode = D3D12_CULL_MODE_FRONT;
 	psoDesc.RasterizerState.FrontCounterClockwise = FALSE;
 	psoDesc.RasterizerState.DepthBias = D3D12_DEFAULT_DEPTH_BIAS;
 	psoDesc.RasterizerState.DepthBiasClamp = D3D12_DEFAULT_DEPTH_BIAS_CLAMP;
@@ -226,9 +218,13 @@ void Program::link(VertexStructure** structures, int count) {
 	psoDesc.BlendState.RenderTarget[0].DestBlendAlpha = D3D12_BLEND_INV_SRC_ALPHA;
 	psoDesc.BlendState.RenderTarget[0].BlendOpAlpha = D3D12_BLEND_OP_ADD;
 	psoDesc.BlendState.RenderTarget[0].RenderTargetWriteMask = D3D12_COLOR_WRITE_ENABLE_ALL;
-	psoDesc.SampleDesc.Count = 1;
-	psoDesc.DepthStencilState.DepthEnable = false;
+	psoDesc.DepthStencilState = CD3DX12_DEPTH_STENCIL_DESC(D3D12_DEFAULT);
+	psoDesc.DepthStencilState.DepthEnable = true;
+	psoDesc.DepthStencilState.DepthWriteMask = D3D12_DEPTH_WRITE_MASK_ALL;
+	psoDesc.DepthStencilState.DepthFunc = D3D12_COMPARISON_FUNC_LESS;
 	psoDesc.DepthStencilState.StencilEnable = false;
+	psoDesc.DSVFormat = DXGI_FORMAT_D32_FLOAT;
+	psoDesc.SampleDesc.Count = 1;
 	psoDesc.SampleMask = 0xFFFFFFFF;
 	psoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
 

--- a/Backends/Direct3D12/Sources/Kore/ProgramImpl.h
+++ b/Backends/Direct3D12/Sources/Kore/ProgramImpl.h
@@ -16,6 +16,7 @@ namespace Kore {
 		// ID3D11Buffer* geometryConstantBuffer;
 		// ID3D11Buffer* tessEvalConstantBuffer;
 		// ID3D11Buffer* tessControlConstantBuffer;
+
 		Shader* vertexShader;
 		Shader* fragmentShader;
 		Shader* geometryShader;


### PR DESCRIPTION

- Setting fragment shader uniforms using a single constant buffer was not working, did not find the reason yet. I created 2 constant buffer views with limited visibility (D3D12_SHADER_VISIBILITY_VERTEX/PIXEL) to make it work.
- Need to manage constant buffer views manually, looks like a single big one is ideal. I created 128 buffers just to get things going. Up to now setting uniforms would overwrite the previous ones.
- Added depth buffer code.
- Basic 3D stuff up and running now! Tons of possibilities to improve the perf, love it. I would probably wait for pipeline states impl. in Kore, but happy to spend more time here. Also loving PIX for Windows.