### PR TITLE
Vulkan work

### DIFF
--- a/Backends/Vulkan/Sources/Kore/RenderTargetImpl.cpp
+++ b/Backends/Vulkan/Sources/Kore/RenderTargetImpl.cpp
@@ -153,6 +153,7 @@ RenderTarget::RenderTarget(int width, int height, int depthBufferBits, bool anti
 		image.format = VK_FORMAT_R8G8B8A8_UNORM;
 		image.extent.width = width;
 		image.extent.height = height;
+		image.extent.depth = 1;
 		image.mipLevels = 1;
 		image.arrayLayers = 1;
 		image.samples = VK_SAMPLE_COUNT_1_BIT;
@@ -338,4 +339,12 @@ void RenderTarget::useColorAsTexture(TextureUnit unit) {
 	vulkanTextures[unit.binding - 2] = nullptr;
 	if (ProgramImpl::current != nullptr)
 		vkCmdBindDescriptorSets(draw_cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, ProgramImpl::current->pipeline_layout, 0, 1, &desc_set, 0, nullptr);
+}
+
+void RenderTarget::useDepthAsTexture(TextureUnit unit) {
+
+}
+
+void RenderTarget::setDepthStencilFrom(RenderTarget* source) {
+
 }

--- a/Backends/Vulkan/Sources/Kore/Vulkan.cpp
+++ b/Backends/Vulkan/Sources/Kore/Vulkan.cpp
@@ -244,6 +244,14 @@ namespace {
 		image_memory_barrier.subresourceRange.levelCount = 1;
 		image_memory_barrier.subresourceRange.baseArrayLayer = 0;
 		image_memory_barrier.subresourceRange.layerCount = 1;
+		
+		if (old_image_layout != VK_IMAGE_LAYOUT_UNDEFINED) {
+			image_memory_barrier.srcAccessMask = VK_ACCESS_MEMORY_READ_BIT;
+		}
+
+		if (new_image_layout == VK_IMAGE_LAYOUT_PRESENT_SRC_KHR) {
+			image_memory_barrier.dstAccessMask = VK_ACCESS_MEMORY_READ_BIT;
+		}
 
 		if (new_image_layout == VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL) {
 			// Make sure anything that was copying from this image has completed
@@ -331,6 +339,8 @@ void Graphics::destroy(int windowId) {}
 #if defined(SYS_WINDOWS)
 void Graphics::setup() {}
 #endif
+
+void Graphics::changeResolution(int width, int height) {}
 
 void Graphics::setColorMask(bool red, bool green, bool blue, bool alpha) {}
 
@@ -997,6 +1007,7 @@ void Graphics::init(int windowId, int depthBufferBits, int stencilBufferBits) {
 	attachments[0].stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
 	attachments[0].initialLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
 	attachments[0].finalLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+	attachments[0].flags = 0;
 
 	attachments[1].format = depth_format;
 	attachments[1].samples = VK_SAMPLE_COUNT_1_BIT;
@@ -1006,6 +1017,7 @@ void Graphics::init(int windowId, int depthBufferBits, int stencilBufferBits) {
 	attachments[1].stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
 	attachments[1].initialLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
 	attachments[1].finalLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
+	attachments[1].flags = 0;
 
 	VkAttachmentReference color_reference = {};
 	color_reference.attachment = 0;

--- a/Sources/Kore/Graphics/Image.cpp
+++ b/Sources/Kore/Graphics/Image.cpp
@@ -1,5 +1,9 @@
 #include "pch.h"
 
+#if defined (SYS_WINDOWS) && (SYS_VULKAN)
+#include <windows.h>
+#endif
+
 #include "../IO/snappy/snappy.h"
 #include "../IO/lz4/lz4.h"
 #include "Image.h"


### PR DESCRIPTION
- Project compiles again.
- Red triangle works! (https://github.com/luboslenco/kha3d_examples/tree/master/tutorial02)
- Blocks do not work - the reason is uniforms are not set for some reason. I am not sure if spirv shaders could be somehow screwing things up. Console output:

```
ERROR: [SC] Code 5 : SPIR-V module not valid: Id is 0
ERROR: [SC] Code 5 : SPIR-V module not valid: Id is 0
ERROR: [SC] Code 3 : Attachment 0 not written by fragment shader
ERROR: [DS] Code 8 : Attempt to set lineWidth to 0.000000 but physical device wideLines feature not supported/enabled so lineWidth must be 1.0f!
```

- There is probably some define in Vulkan backend causing compilation errors in Image.cpp, 'Fixed' by including windows.h. Did not experience this in D3D12.

```
1>  Image.cpp
1>c:\program files (x86)\windows kits\8.1\include\um\winnt.h(561): error C3646: 'Mask': unknown override specifier
1>c:\program files (x86)\windows kits\8.1\include\um\winnt.h(561): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int
1>c:\program files (x86)\windows kits\8.1\include\um\winnt.h(794): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int
```