### PR TITLE
Updated Pi code

### DIFF
--- a/Backends/OpenGL2/Sources/Kore/OpenGL.cpp
+++ b/Backends/OpenGL2/Sources/Kore/OpenGL.cpp
@@ -876,7 +876,7 @@ bool Graphics::nonPow2TexturesSupported() {
 	return true;
 }
 
-#if defined(OPENGL) || (defined(SYS_ANDROID) && SYS_ANDROID_API >= 18)
+#if (defined(OPENGL) && !defined(SYS_PI)) || (defined(SYS_ANDROID) && SYS_ANDROID_API >= 18)
 bool Graphics::initOcclusionQuery(uint* occlusionQuery) {
 	glGenQueries(1, occlusionQuery);
 	return true;

--- a/Backends/OpenGL2/Sources/Kore/RenderTargetImpl.cpp
+++ b/Backends/OpenGL2/Sources/Kore/RenderTargetImpl.cpp
@@ -54,8 +54,10 @@ namespace {
 void RenderTargetImpl::setupDepthStencil(int depthBufferBits, int stencilBufferBits, int width, int height) {
 	if (depthBufferBits > 0 && stencilBufferBits > 0) {
 		_hasDepth = true;
-#ifdef OPENGLES
+#if defined(OPENGLES) && !defined(SYS_PI)
 		GLenum internalFormat = GL_DEPTH24_STENCIL8_OES;
+#elif defined(SYS_PI)
+		GLenum internalFormat = NULL;
 #else
 		GLenum internalFormat;
 		if (depthBufferBits == 24)

--- a/Sources/Kore/System.cpp
+++ b/Sources/Kore/System.cpp
@@ -14,7 +14,7 @@ double Kore::System::time() {
 #endif
 #endif
 
-#if !defined(SYS_WINDOWS) && !defined(SYS_OSX) && !defined(SYS_LINUX) && !defined(SYS_HTML5)
+#if !defined(SYS_WINDOWS) && !defined(SYS_OSX) && !defined(SYS_LINUX) && !defined(SYS_HTML5) && !defined(SYS_PI)
 
 int Kore::System::desktopWidth() {
 	return windowWidth(0);


### PR DESCRIPTION
Changes to make the Pi work again.
Made some changes to be able to get the screen size in Kore with desktopWidth() / desktopHeight() before the window is created. These methods aren't available in kha.System.hx (we have kha.Display.hx for this), but are used in some places inside Kha/Kore.