### PR TITLE
CubeMap support

### DIFF
--- a/Backends/Direct3D11/Sources/Kore/Direct3D11.winrt.cpp
+++ b/Backends/Direct3D11/Sources/Kore/Direct3D11.winrt.cpp
@@ -853,6 +853,10 @@ void Graphics::setRenderTarget(RenderTarget* target, int num, int additionalTarg
 	context->RSSetViewports(1, &viewPort);
 }
 
+void Graphics::setRenderTargetFace(RenderTarget* texture, int face) {
+	
+}
+
 void Graphics::setVertexBuffers(VertexBuffer** buffers, int count) {
 	buffers[0]->_set(0);
 

--- a/Backends/Direct3D11/Sources/Kore/RenderTargetImpl.cpp
+++ b/Backends/Direct3D11/Sources/Kore/RenderTargetImpl.cpp
@@ -49,6 +49,10 @@ RenderTarget::RenderTarget(int width, int height, int depthBufferBits, bool anti
 	lastBoundUnit = -1;
 }
 
+RenderTarget::RenderTarget(int cubeMapSize, int depthBufferBits, bool antialiasing, RenderTargetFormat format, int stencilBufferBits, int contextId) {
+	
+}
+
 RenderTarget::~RenderTarget() {
 	renderTargetView->Release();
 	view->Release();

--- a/Backends/Direct3D12/Sources/Kore/Direct3D12.cpp
+++ b/Backends/Direct3D12/Sources/Kore/Direct3D12.cpp
@@ -703,6 +703,10 @@ void Graphics::setRenderTarget(RenderTarget* target, int num, int additionalTarg
 	commandList->RSSetScissorRects(1, (D3D12_RECT*)&target->scissor);
 }
 
+void Graphics::setRenderTargetFace(RenderTarget* texture, int face) {
+	
+}
+
 void Graphics::setVertexBuffers(VertexBuffer** buffers, int count) {
 	buffers[0]->_set(0);
 }

--- a/Backends/Direct3D12/Sources/Kore/RenderTargetImpl.cpp
+++ b/Backends/Direct3D12/Sources/Kore/RenderTargetImpl.cpp
@@ -76,6 +76,10 @@ RenderTarget::RenderTarget(int width, int height, int depthBufferBits, bool anti
 	viewport = {0.0f, 0.0f, static_cast<float>(width), static_cast<float>(height), 0.0f, 1.0f};
 }
 
+RenderTarget::RenderTarget(int cubeMapSize, int depthBufferBits, bool antialiasing, RenderTargetFormat format, int stencilBufferBits, int contextId) {
+	
+}
+
 RenderTarget::~RenderTarget() {
 	renderTarget->Release();
 	renderTargetDescriptorHeap->Release();

--- a/Backends/Direct3D9/Sources/Kore/Direct3D9.cpp
+++ b/Backends/Direct3D9/Sources/Kore/Direct3D9.cpp
@@ -373,6 +373,10 @@ void Graphics::setRenderTarget(RenderTarget* target, int num, int additionalTarg
 	affirm(device->SetRenderTarget(num, target->colorSurface));
 }
 
+void Graphics::setRenderTargetFace(RenderTarget* texture, int face) {
+	
+}
+
 // void Graphics::setDepthStencilTarget(Texture* texture) {
 //	//if (depthBuffer != nullptr) depthBuffer->Release();
 //	device->GetDepthStencilSurface(&depthBuffer);

--- a/Backends/Direct3D9/Sources/Kore/RenderTargetImpl.cpp
+++ b/Backends/Direct3D9/Sources/Kore/RenderTargetImpl.cpp
@@ -50,6 +50,10 @@ RenderTarget::RenderTarget(int width, int height, int depthBufferBits, bool anti
 	}
 }
 
+RenderTarget::RenderTarget(int cubeMapSize, int depthBufferBits, bool antialiasing, RenderTargetFormat format, int stencilBufferBits, int contextId) {
+	
+}
+
 RenderTarget::~RenderTarget() {
 	if (colorSurface != nullptr) colorSurface->Release();
 	if (depthSurface != nullptr) depthSurface->Release();

--- a/Backends/Metal/Sources/Kore/Metal.mm
+++ b/Backends/Metal/Sources/Kore/Metal.mm
@@ -278,6 +278,8 @@ void Graphics::setBlendingModeSeparate(BlendingOperation source, BlendingOperati
 
 void Graphics::setRenderTarget(RenderTarget* texture, int num, int additionalTargets) {}
 
+void Graphics::setRenderTargetFace(RenderTarget* texture, int face) {}
+
 void Graphics::restoreRenderTarget() {}
 
 void Graphics::setColorMask(bool red, bool green, bool blue, bool alpha) {}

--- a/Backends/Metal/Sources/Kore/RenderTargetImpl.cpp
+++ b/Backends/Metal/Sources/Kore/RenderTargetImpl.cpp
@@ -25,6 +25,10 @@ RenderTarget::RenderTarget(int width, int height, int depthBufferBits, bool anti
 	texHeight = getPower2(height);
 }
 
+RenderTarget::RenderTarget(int cubeMapSize, int depthBufferBits, bool antialiasing, RenderTargetFormat format, int stencilBufferBits, int contextId) {
+	
+}
+
 RenderTarget::~RenderTarget() {}
 
 void RenderTarget::useColorAsTexture(TextureUnit unit) {}

--- a/Backends/OpenGL/Sources/Kore/RenderTargetImpl.cpp
+++ b/Backends/OpenGL/Sources/Kore/RenderTargetImpl.cpp
@@ -208,6 +208,10 @@ RenderTarget::RenderTarget(int width, int height, int depthBufferBits, bool anti
 	glCheckErrors();
 }
 
+RenderTarget::RenderTarget(int cubeMapSize, int depthBufferBits, bool antialiasing, RenderTargetFormat format, int stencilBufferBits, int contextId) {
+	
+}
+
 void RenderTarget::useColorAsTexture(TextureUnit unit) {
 	glActiveTexture(GL_TEXTURE0 + unit.unit);
 	glCheckErrors();

--- a/Backends/OpenGL2/Sources/Kore/OpenGL.cpp
+++ b/Backends/OpenGL2/Sources/Kore/OpenGL.cpp
@@ -837,6 +837,7 @@ void Graphics::setRenderTarget(RenderTarget* texture, int num, int additionalTar
 		// System::makeCurrent(texture->contextId);
 		glBindFramebuffer(GL_FRAMEBUFFER, texture->_framebuffer);
 		glCheckErrors();
+		if (texture->isCubeMap) glFramebufferTexture(GL_FRAMEBUFFER, texture->isDepthAttachment ? GL_DEPTH_ATTACHMENT : GL_COLOR_ATTACHMENT0, texture->_texture, 0); // Layered
 		glViewport(0, 0, texture->width, texture->height);
 		_renderTargetWidth = texture->width;
 		_renderTargetHeight = texture->height;
@@ -856,6 +857,17 @@ void Graphics::setRenderTarget(RenderTarget* texture, int num, int additionalTar
 #endif
 		}
 	}
+}
+
+void Graphics::setRenderTargetFace(RenderTarget* texture, int face) {
+	glBindFramebuffer(GL_FRAMEBUFFER, texture->_framebuffer);
+	glCheckErrors();
+	glFramebufferTexture2D(GL_FRAMEBUFFER, texture->isDepthAttachment ? GL_DEPTH_ATTACHMENT : GL_COLOR_ATTACHMENT0, GL_TEXTURE_CUBE_MAP_POSITIVE_X + face, texture->_texture, 0);
+	glViewport(0, 0, texture->width, texture->height);
+	_renderTargetWidth = texture->width;
+	_renderTargetHeight = texture->height;
+	renderToBackbuffer = false;
+	glCheckErrors();
 }
 
 void Graphics::restoreRenderTarget() {

--- a/Backends/OpenGL2/Sources/Kore/RenderTargetImpl.h
+++ b/Backends/OpenGL2/Sources/Kore/RenderTargetImpl.h
@@ -9,6 +9,6 @@ namespace Kore {
 		bool _hasDepth;
 		// unsigned _depthRenderbuffer;
 		int contextId;
-		void setupDepthStencil(int depthBufferBits, int stencilBufferBits, int width, int height);
+		void setupDepthStencil(unsigned int texType, int depthBufferBits, int stencilBufferBits, int width, int height);
 	};
 }

--- a/Backends/Unreal/Sources/Kore/RHI.cpp
+++ b/Backends/Unreal/Sources/Kore/RHI.cpp
@@ -61,6 +61,10 @@ void Graphics::setRenderTarget(RenderTarget* target, int num, int additionalTarg
 
 }
 
+void Graphics::setRenderTargetFace(RenderTarget* texture, int face) {
+	
+}
+
 void Graphics::restoreRenderTarget() {
 
 }

--- a/Backends/Unreal/Sources/Kore/RenderTargetImpl.cpp
+++ b/Backends/Unreal/Sources/Kore/RenderTargetImpl.cpp
@@ -11,6 +11,10 @@ RenderTarget::RenderTarget(int width, int height, int depthBufferBits, bool anti
 
 }
 
+RenderTarget::RenderTarget(int cubeMapSize, int depthBufferBits, bool antialiasing, RenderTargetFormat format, int stencilBufferBits, int contextId) {
+	
+}
+
 RenderTarget::~RenderTarget() {
 
 }

--- a/Backends/Vulkan/Sources/Kore/RenderTargetImpl.cpp
+++ b/Backends/Vulkan/Sources/Kore/RenderTargetImpl.cpp
@@ -332,6 +332,10 @@ RenderTarget::RenderTarget(int width, int height, int depthBufferBits, bool anti
 	createDescriptorSet(nullptr, this, desc_set);
 }
 
+RenderTarget::RenderTarget(int cubeMapSize, int depthBufferBits, bool antialiasing, RenderTargetFormat format, int stencilBufferBits, int contextId) {
+	
+}
+
 RenderTarget::~RenderTarget() {}
 
 void RenderTarget::useColorAsTexture(TextureUnit unit) {

--- a/Backends/Vulkan/Sources/Kore/Vulkan.cpp
+++ b/Backends/Vulkan/Sources/Kore/Vulkan.cpp
@@ -1639,6 +1639,10 @@ void Graphics::setRenderTarget(RenderTarget* texture, int num, int additionalTar
 	vkCmdSetScissor(draw_cmd, 0, 1, &scissor);
 }
 
+void Graphics::setRenderTargetFace(RenderTarget* texture, int face) {
+	
+}
+
 void Graphics::restoreRenderTarget() {
 	if (onBackBuffer) return;
 

--- a/Sources/Kore/Graphics/Graphics.h
+++ b/Sources/Kore/Graphics/Graphics.h
@@ -105,12 +105,16 @@ namespace Kore {
 	public:
 		RenderTarget(int width, int height, int depthBufferBits, bool antialiasing = false, RenderTargetFormat format = Target32Bit, int stencilBufferBits = -1,
 		             int contextId = 0);
+		RenderTarget(int cubeMapSize, int depthBufferBits, bool antialiasing = false, RenderTargetFormat format = Target32Bit, int stencilBufferBits = -1,
+		             int contextId = 0);
 		~RenderTarget();
 		int width;
 		int height;
 		int texWidth;
 		int texHeight;
 		int contextId;
+		bool isCubeMap;
+		bool isDepthAttachment;
 		void useColorAsTexture(TextureUnit unit);
 		void useDepthAsTexture(TextureUnit unit);
 		void setDepthStencilFrom(RenderTarget* source);
@@ -149,6 +153,7 @@ namespace Kore {
 
 		bool renderTargetsInvertedY();
 		void setRenderTarget(RenderTarget* texture, int num = 0, int additionalTargets = 0);
+		void setRenderTargetFace(RenderTarget* texture, int face = 0);
 		void restoreRenderTarget();
 
 		// TODO (DK) windowId should be renamed contextId?


### PR DESCRIPTION
- OpenGL2 & render target only for starters
- GL_TEXTURE_CUBE_MAP is core since 1.3 so hopefully no broken non-desktop compilation

```cpp
// Creating cubemap RT
RenderTarget::RenderTarget(int cubeMapSize, ...);

// Drawing to cubemap
Graphics::setRenderTarget(texture, ...);
Graphics::setRenderTargetFace(texture, face);

// Set samplerCube
cubeMap->renderTarget->useColorAsTexture();
cubeMap->renderTarget->useDepthAsTexture();
```