### PR TITLE
Setting 3D texture parameters

### DIFF
--- a/Backends/Graphics4/Direct3D11/Sources/Kore/Direct3D11.winrt.cpp
+++ b/Backends/Graphics4/Direct3D11/Sources/Kore/Direct3D11.winrt.cpp
@@ -427,6 +427,10 @@ void Graphics4::setTextureAddressing(TextureUnit unit, TexDir dir, TextureAddres
 	sampler->Release();
 }
 
+void Graphics4::setTexture3DAddressing(TextureUnit unit, TexDir dir, TextureAddressing addressing) {
+	Graphics4::setTextureAddressing(unit, dir, addressing);
+}
+
 void Graphics4::clear(uint flags, uint color, float depth, int stencil) {
 	if (currentRenderTargetView != nullptr && flags & ClearColorFlag) {
 		const float clearColor[] = {((color & 0x00ff0000) >> 16) / 255.0f, ((color & 0x0000ff00) >> 8) / 255.0f, (color & 0x000000ff) / 255.0f, 1.0f};
@@ -751,9 +755,21 @@ void Graphics4::setMatrix(ConstantLocation location, const mat3& value) {
 
 void Graphics4::setTextureMagnificationFilter(TextureUnit texunit, TextureFilter filter) {}
 
+void Graphics4::setTexture3DMagnificationFilter(TextureUnit texunit, TextureFilter filter) {
+	Graphics4::setTextureMagnificationFilter(texunit, filter);
+}
+
 void Graphics4::setTextureMinificationFilter(TextureUnit texunit, TextureFilter filter) {}
 
+void Graphics4::setTexture3DMinificationFilter(TextureUnit texunit, TextureFilter filter) {
+	Graphics4::setTextureMinificationFilter(texunit, filter);
+}
+
 void Graphics4::setTextureMipmapFilter(TextureUnit texunit, MipmapFilter filter) {}
+
+void Graphics4::setTexture3DMipmapFilter(TextureUnit texunit, MipmapFilter filter) {
+	Graphics4::setTextureMipmapFilter(texunit, filter);
+}
 
 namespace {
 	D3D11_BLEND convert(Graphics4::BlendingOperation operation) {

--- a/Backends/Graphics4/Direct3D9/Sources/Kore/Direct3D9.cpp
+++ b/Backends/Graphics4/Direct3D9/Sources/Kore/Direct3D9.cpp
@@ -308,12 +308,24 @@ void Graphics4::setTextureMagnificationFilter(TextureUnit texunit, TextureFilter
 	device->SetSamplerState(texunit.unit, D3DSAMP_MAGFILTER, convertFilter(filter));
 }
 
+void Graphics4::setTexture3DMagnificationFilter(TextureUnit texunit, TextureFilter filter) {
+	Graphics4::setTextureMagnificationFilter(texunit, filter);
+}
+
 void Graphics4::setTextureMinificationFilter(TextureUnit texunit, TextureFilter filter) {
 	device->SetSamplerState(texunit.unit, D3DSAMP_MINFILTER, convertFilter(filter));
 }
 
+void Graphics4::setTexture3DMinificationFilter(TextureUnit texunit, TextureFilter filter) {
+	Graphics4::setTextureMinificationFilter(texunit, filter);
+}
+
 void Graphics4::setTextureMipmapFilter(TextureUnit texunit, MipmapFilter filter) {
 	device->SetSamplerState(texunit.unit, D3DSAMP_MIPFILTER, convertMipFilter(filter));
+}
+
+void Graphics4::setTexture3DMipmapFilter(TextureUnit texunit, MipmapFilter filter) {
+	Graphics4::setTextureMipmapFilter(texunit, filter);
 }
 
 void Graphics4::makeCurrent(int contextId) {
@@ -397,6 +409,10 @@ void Graphics4::setTextureAddressing(TextureUnit unit, TexDir dir, TextureAddres
 		break;
 	}
 	device->SetSamplerState(unit.unit, dir == U ? D3DSAMP_ADDRESSU : D3DSAMP_ADDRESSV, value);
+}
+
+void Graphics4::setTexture3DAddressing(TextureUnit unit, TexDir dir, TextureAddressing addressing) {
+	Graphics4::setTextureAddressing(unit, dir, addressing);
 }
 
 namespace {

--- a/Backends/Graphics4/G4onG5/Sources/Kore/G4.cpp
+++ b/Backends/Graphics4/G4onG5/Sources/Kore/G4.cpp
@@ -55,6 +55,10 @@ void Graphics4::setTextureAddressing(TextureUnit unit, TexDir dir, TextureAddres
 	Graphics5::setTextureAddressing(unit._unit, (Graphics5::TexDir)dir, (Graphics5::TextureAddressing)addressing);
 }
 
+void Graphics4::setTexture3DAddressing(TextureUnit unit, TexDir dir, TextureAddressing addressing) {
+	Graphics4::setTextureAddressing(unit, dir, addressing);
+}
+
 void Graphics4::setColorMask(bool red, bool green, bool blue, bool alpha) {
 	Graphics5::setColorMask(red, green, blue, alpha);
 }
@@ -160,12 +164,24 @@ void Graphics4::setTextureMagnificationFilter(TextureUnit texunit, TextureFilter
 	Graphics5::setTextureMagnificationFilter(texunit._unit, (Graphics5::TextureFilter)filter);
 }
 
+void Graphics4::setTexture3DMagnificationFilter(TextureUnit texunit, TextureFilter filter) {
+	Graphics4::setTextureMagnificationFilter(texunit, filter);
+}
+
 void Graphics4::setTextureMinificationFilter(TextureUnit texunit, TextureFilter filter) {
 	Graphics5::setTextureMinificationFilter(texunit._unit, (Graphics5::TextureFilter)filter);
 }
 
+void Graphics4::setTexture3DMinificationFilter(TextureUnit texunit, TextureFilter filter) {
+	Graphics4::setTextureMinificationFilter(texunit, filter);
+}
+
 void Graphics4::setTextureMipmapFilter(TextureUnit texunit, MipmapFilter filter) {
 	Graphics5::setTextureMipmapFilter(texunit._unit, (Graphics5::MipmapFilter)filter);
+}
+
+void Graphics4::setTexture3DMipmapFilter(TextureUnit texunit, MipmapFilter filter) {
+	Graphics4::setTextureMipmapFilter(texunit, filter);
 }
 
 void Graphics4::setBlendingMode(BlendingOperation source, BlendingOperation destination) {

--- a/Sources/Kore/Graphics4/Graphics.h
+++ b/Sources/Kore/Graphics4/Graphics.h
@@ -80,7 +80,7 @@ namespace Kore {
 
 		enum CullMode { Clockwise, CounterClockwise, NoCulling };
 
-		enum TexDir { U, V };
+		enum TexDir { U, V, W };
 
 		enum FogType { LinearFog };
 
@@ -168,6 +168,10 @@ namespace Kore {
 		void setTextureMagnificationFilter(TextureUnit texunit, TextureFilter filter);
 		void setTextureMinificationFilter(TextureUnit texunit, TextureFilter filter);
 		void setTextureMipmapFilter(TextureUnit texunit, MipmapFilter filter);
+		void setTexture3DAddressing(TextureUnit unit, TexDir dir, TextureAddressing addressing);
+		void setTexture3DMagnificationFilter(TextureUnit texunit, TextureFilter filter);
+		void setTexture3DMinificationFilter(TextureUnit texunit, TextureFilter filter);
+		void setTexture3DMipmapFilter(TextureUnit texunit, MipmapFilter filter);
 		void setBlendingMode(BlendingOperation source, BlendingOperation destination);
 		void setBlendingModeSeparate(BlendingOperation source, BlendingOperation destination, BlendingOperation alphaSource, BlendingOperation alphaDestination);
 		void setTextureOperation(TextureOperation operation, TextureArgument arg1, TextureArgument arg2);

--- a/Sources/Kore/Graphics5/Graphics.h
+++ b/Sources/Kore/Graphics5/Graphics.h
@@ -84,7 +84,7 @@ namespace Kore {
 
 		enum CullMode { Clockwise, CounterClockwise, NoCulling };
 
-		enum TexDir { U, V };
+		enum TexDir { U, V, W };
 
 		enum FogType { LinearFog };
 


### PR DESCRIPTION
- Went with `setTexture3D...()` as discussed
- Does not seem to be needed for G5 (looks like only OpenGL makes a difference there..)