### PR TITLE
Render target formats for D3D11

### DIFF
--- a/Backends/Graphics4/Direct3D11/Sources/Kore/RenderTargetImpl.cpp
+++ b/Backends/Graphics4/Direct3D11/Sources/Kore/RenderTargetImpl.cpp
@@ -8,7 +8,8 @@
 
 using namespace Kore;
 
-Graphics4::RenderTarget::RenderTarget(int width, int height, int depthBufferBits, bool antialiasing, RenderTargetFormat format, int stencilBufferBits, int contextId) {
+Graphics4::RenderTarget::RenderTarget(int width, int height, int depthBufferBits, bool antialiasing, RenderTargetFormat format, int stencilBufferBits, int contextId)
+	: isCubeMap(false), isDepthAttachment(false) {
 	this->texWidth = this->width = width;
 	this->texHeight = this->height = height;
 	this->contextId = contextId;
@@ -100,7 +101,8 @@ Graphics4::RenderTarget::RenderTarget(int width, int height, int depthBufferBits
 	lastBoundUnit = -1;
 }
 
-Graphics4::RenderTarget::RenderTarget(int cubeMapSize, int depthBufferBits, bool antialiasing, RenderTargetFormat format, int stencilBufferBits, int contextId) {
+Graphics4::RenderTarget::RenderTarget(int cubeMapSize, int depthBufferBits, bool antialiasing, RenderTargetFormat format, int stencilBufferBits, int contextId)
+	: isCubeMap(true), isDepthAttachment(false) {
 	
 }
 

--- a/Backends/Graphics4/Direct3D9/Sources/Kore/RenderTargetImpl.cpp
+++ b/Backends/Graphics4/Direct3D9/Sources/Kore/RenderTargetImpl.cpp
@@ -9,7 +9,7 @@
 using namespace Kore;
 
 Graphics4::RenderTarget::RenderTarget(int width, int height, int depthBufferBits, bool antialiasing, Graphics4::RenderTargetFormat format, int stencilBufferBits, int contextId)
-	: width(width), height(height), texWidth(width), texHeight(height), isDepthAttachment(false) {
+	: width(width), height(height), texWidth(width), texHeight(height), isCubeMap(false), isDepthAttachment(false) {
 	this->antialiasing = antialiasing;
 	this->contextId = contextId;
 	D3DFORMAT d3dformat;

--- a/Backends/Graphics4/Direct3D9/Sources/Kore/RenderTargetImpl.cpp
+++ b/Backends/Graphics4/Direct3D9/Sources/Kore/RenderTargetImpl.cpp
@@ -9,7 +9,7 @@
 using namespace Kore;
 
 Graphics4::RenderTarget::RenderTarget(int width, int height, int depthBufferBits, bool antialiasing, Graphics4::RenderTargetFormat format, int stencilBufferBits, int contextId)
-    : width(width), height(height), texWidth(width), texHeight(height) {
+	: width(width), height(height), texWidth(width), texHeight(height), isDepthAttachment(false) {
 	this->antialiasing = antialiasing;
 	this->contextId = contextId;
 	D3DFORMAT d3dformat;
@@ -57,7 +57,8 @@ Graphics4::RenderTarget::RenderTarget(int width, int height, int depthBufferBits
 	}
 }
 
-Graphics4::RenderTarget::RenderTarget(int cubeMapSize, int depthBufferBits, bool antialiasing, RenderTargetFormat format, int stencilBufferBits, int contextId) {
+Graphics4::RenderTarget::RenderTarget(int cubeMapSize, int depthBufferBits, bool antialiasing, RenderTargetFormat format, int stencilBufferBits, int contextId)
+	: isCubeMap(true), isDepthAttachment(false) {
 	
 }
 


### PR DESCRIPTION
- Implements more render target types
- Shadow-mapping using Target16BitDepth works
- Target16BitDepth could be reworked down the road - maybe by adding something like TargetNull to indicate there is no interest in color buffer, and just setting up depth and stencil bits (probably also better combined into single enum).