### PR TITLE
Conservative rasterization for OpenGL

### DIFF
--- a/Backends/Graphics4/OpenGL/Sources/Kore/OpenGL.cpp
+++ b/Backends/Graphics4/OpenGL/Sources/Kore/OpenGL.cpp
@@ -592,6 +592,12 @@ void Graphics4::setRenderState(RenderState state, bool on) {
 		else
 			glDisable(GL_BLEND);
 		break;
+	case ConservativeRasterization:
+		if (on)
+			glEnable(0x9346); // GL_CONSERVATIVE_RASTERIZATION_NV 
+		else
+			glDisable(0x9346);
+		break;
 	default:
 		break;
 	}

--- a/Backends/Graphics4/OpenGL/Sources/Kore/OpenGL.cpp
+++ b/Backends/Graphics4/OpenGL/Sources/Kore/OpenGL.cpp
@@ -57,6 +57,7 @@ namespace {
 
 	bool depthTest = false;
 	bool depthMask = true;
+	bool conservativeRasterOn = false;
 	bool colorMaskRed = true;
 	bool colorMaskGreen= true;
 	bool colorMaskBlue = true;
@@ -593,10 +594,13 @@ void Graphics4::setRenderState(RenderState state, bool on) {
 			glDisable(GL_BLEND);
 		break;
 	case ConservativeRasterization:
-		if (on)
+		if (on) {
 			glEnable(0x9346); // GL_CONSERVATIVE_RASTERIZATION_NV 
-		else
+		}
+		else if (conservativeRasterOn) {
 			glDisable(0x9346);
+		}
+		conservativeRasterOn = on;
 		break;
 	default:
 		break;

--- a/Sources/Kore/Graphics4/Graphics.h
+++ b/Sources/Kore/Graphics4/Graphics.h
@@ -51,7 +51,8 @@ namespace Kore {
 			BackfaceCulling,
 			/*FogState, FogStartState, FogEndState, FogTypeState, FogColorState,*/ ScissorTestState,
 			AlphaTestState,
-			AlphaReferenceState
+			AlphaReferenceState,
+			ConservativeRasterization
 		};
 
 		enum BlendingOperation {


### PR DESCRIPTION
Using NV_conservative_raster for now:
https://developer.nvidia.com/sites/default/files/akamai/opengl/specs/GL_NV_conservative_raster.txt