### PR TITLE
Texture format work for OpenGL

### DIFF
--- a/Backends/Graphics4/OpenGL/Sources/Kore/RenderTargetImpl.cpp
+++ b/Backends/Graphics4/OpenGL/Sources/Kore/RenderTargetImpl.cpp
@@ -22,10 +22,10 @@ using namespace Kore;
 #ifndef GL_R16F_EXT
 #define GL_R16F_EXT 0x822D
 #endif
-                 
+
 #ifndef GL_R32F_EXT
 #define GL_R32F_EXT 0x822E
-#endif                
+#endif
 
 #ifndef GL_HALF_FLOAT
 #define GL_HALF_FLOAT 0x140B
@@ -363,11 +363,17 @@ void Graphics4::RenderTarget::getPixels(u8* data) {
 	glBindFramebuffer(GL_FRAMEBUFFER, _framebuffer);
 	switch((RenderTargetFormat)format) {
 	case Target128BitFloat:
-	case Target64BitFloat:
 		glReadPixels(0, 0, texWidth, texHeight, GL_RGBA, GL_FLOAT, data);
 		break;
+	case Target64BitFloat:
+		glReadPixels(0, 0, texWidth, texHeight, GL_RGBA, GL_HALF_FLOAT, data);
+		break;
 	case Target8BitRed:
+		glReadPixels(0, 0, texWidth, texHeight, GL_RED, GL_UNSIGNED_BYTE, data);
+		break;
 	case Target16BitRedFloat:
+		glReadPixels(0, 0, texWidth, texHeight, GL_RED, GL_HALF_FLOAT, data);
+		break;
 	case Target32BitRedFloat:
 		glReadPixels(0, 0, texWidth, texHeight, GL_RED, GL_FLOAT, data);
 		break;

--- a/Backends/Graphics4/OpenGL/Sources/Kore/RenderTargetImpl.h
+++ b/Backends/Graphics4/OpenGL/Sources/Kore/RenderTargetImpl.h
@@ -9,6 +9,7 @@ namespace Kore {
 		bool _hasDepth;
 		// unsigned _depthRenderbuffer;
 		int contextId;
+		int format;
 		void setupDepthStencil(unsigned int texType, int depthBufferBits, int stencilBufferBits, int width, int height);
 	};
 }

--- a/Backends/Graphics4/OpenGL/Sources/Kore/TextureImpl.cpp
+++ b/Backends/Graphics4/OpenGL/Sources/Kore/TextureImpl.cpp
@@ -63,6 +63,7 @@ namespace {
 		case Graphics4::Image::RGB24:
 			return GL_RGB;
 		case Graphics4::Image::A32:
+		case Graphics4::Image::A16:
 		case Graphics4::Image::Grey8:
 #ifdef KORE_OPENGL_ES
 			return GL_LUMINANCE;
@@ -96,6 +97,16 @@ namespace {
 #else
 	#ifdef GL_ARB_texture_float
 			return GL_R32F;
+	#else
+			return GL_RED;
+	#endif
+#endif
+		case Graphics4::Image::A16:
+#ifdef KORE_OPENGL_ES
+			return GL_LUMINANCE;
+#else
+	#ifdef GL_ARB_texture_float
+			return GL_R16F;
 	#else
 			return GL_RED;
 	#endif
@@ -220,6 +231,7 @@ namespace {
 			case Graphics4::Image::RGBA128:
 			case Graphics4::Image::RGBA64:
 			case Graphics4::Image::A32:
+			case Graphics4::Image::A16:
 				break;
 		}
 	}

--- a/Backends/Graphics4/OpenGL/Sources/Kore/TextureImpl.cpp
+++ b/Backends/Graphics4/OpenGL/Sources/Kore/TextureImpl.cpp
@@ -122,6 +122,7 @@ namespace {
 		case Graphics4::Image::RGBA128:
 		case Graphics4::Image::RGBA64:
 		case Graphics4::Image::A32:
+		case Graphics4::Image::A16:
 			return GL_FLOAT;
 		case Graphics4::Image::RGBA32:
 		default:

--- a/Backends/Graphics4/OpenGL/Sources/Kore/TextureImpl.cpp
+++ b/Backends/Graphics4/OpenGL/Sources/Kore/TextureImpl.cpp
@@ -13,6 +13,30 @@ using namespace Kore;
 #define GL_TEXTURE_3D 0x806F
 #endif
 
+#ifndef GL_RGBA16F_EXT
+#define GL_RGBA16F_EXT 0x881A
+#endif
+
+#ifndef GL_RGBA32F_EXT
+#define GL_RGBA32F_EXT 0x8814
+#endif
+
+#ifndef GL_R16F_EXT
+#define GL_R16F_EXT 0x822D
+#endif
+
+#ifndef GL_R32F_EXT
+#define GL_R32F_EXT 0x822E
+#endif
+
+#ifndef GL_HALF_FLOAT
+#define GL_HALF_FLOAT 0x140B
+#endif
+
+#ifndef GL_RED
+#define GL_RED GL_LUMINANCE
+#endif
+
 #ifndef GL_KHR_texture_compression_astc_ldr
 #define GL_KHR_texture_compression_astc_ldr 1
 
@@ -65,58 +89,31 @@ namespace {
 		case Graphics4::Image::A32:
 		case Graphics4::Image::A16:
 		case Graphics4::Image::Grey8:
-#ifdef KORE_OPENGL_ES
-			return GL_LUMINANCE;
-#else
 			return GL_RED;
-#endif
 		}
 	}
 
 	int convertInternalFormat(Graphics4::Image::Format format) {
 		switch (format) {
 		case Graphics4::Image::RGBA128:
-#ifdef GL_ARB_texture_float
-			return GL_RGBA32F;
-#else
-			return GL_RGBA;
-#endif
-		case Graphics4::Image::RGBA32:
+			return GL_RGBA32F_EXT;
 		case Graphics4::Image::RGBA64:
+			return GL_RGBA16F_EXT;
+		case Graphics4::Image::RGBA32:
 		default:
-			// #ifdef GL_BGRA
+// #ifdef GL_BGRA
 			// return GL_BGRA;
-			// #else
+// #else
 			return GL_RGBA;
-		// #endif
+// #endif
 		case Graphics4::Image::RGB24:
 			return GL_RGB;
 		case Graphics4::Image::A32:
-#ifdef KORE_OPENGL_ES
-			return GL_LUMINANCE;
-#else
-	#ifdef GL_ARB_texture_float
-			return GL_R32F;
-	#else
-			return GL_RED;
-	#endif
-#endif
+			return GL_R32F_EXT;
 		case Graphics4::Image::A16:
-#ifdef KORE_OPENGL_ES
-			return GL_LUMINANCE;
-#else
-	#ifdef GL_ARB_texture_float
-			return GL_R16F;
-	#else
-			return GL_RED;
-	#endif
-#endif
+			return GL_R16F_EXT;
 		case Graphics4::Image::Grey8:
-#ifdef KORE_OPENGL_ES
-			return GL_LUMINANCE;
-#else
 			return GL_RED;
-#endif
 		}
 	}
 
@@ -514,13 +511,11 @@ void Graphics4::Texture::setMipmap(Texture* mipmap, int level) {
 	glBindTexture(target, texture);
 	glCheckErrors();
 	if (isHdr) {
-		glTexImage2D(target, level, convertInternalFormat(mipmap->format), mipmap->texWidth, mipmap->texHeight, 0, convertFormat(mipmap->format), convertedType,
-		             mipmap->hdrData);
+		glTexImage2D(target, level, convertInternalFormat(mipmap->format), mipmap->texWidth, mipmap->texHeight, 0, convertFormat(mipmap->format), convertedType, mipmap->hdrData);
 		glCheckErrors();
 	}
 	else {
-		glTexImage2D(target, level, convertInternalFormat(mipmap->format), mipmap->texWidth, mipmap->texHeight, 0, convertFormat(mipmap->format), convertedType,
-		             mipmap->data);
+		glTexImage2D(target, level, convertInternalFormat(mipmap->format), mipmap->texWidth, mipmap->texHeight, 0, convertFormat(mipmap->format), convertedType, mipmap->data);
 		glCheckErrors();
 	}
 }

--- a/Backends/Graphics4/OpenGL/Sources/Kore/TextureImpl.cpp
+++ b/Backends/Graphics4/OpenGL/Sources/Kore/TextureImpl.cpp
@@ -94,7 +94,11 @@ namespace {
 #ifdef KORE_OPENGL_ES
 			return GL_LUMINANCE;
 #else
-			return GL_R8;
+	#ifdef GL_ARB_texture_float
+			return GL_R32F;
+	#else
+			return GL_RED;
+	#endif
 #endif
 		case Graphics4::Image::Grey8:
 #ifdef KORE_OPENGL_ES

--- a/Sources/Kore/Graphics1/Image.cpp
+++ b/Sources/Kore/Graphics1/Image.cpp
@@ -43,6 +43,8 @@ int Graphics1::Image::sizeOf(Image::Format format) {
 		return 8;
 	case Image::A32:
 		return 4;
+	case Image::A16:
+		return 2;
 	case Image::Grey8:
 		return 1;
 	case Image::RGB24:
@@ -72,7 +74,7 @@ Graphics1::Image::Image(Reader& reader, const char* format, bool readable) : dep
 
 Graphics1::Image::Image(void* data, int width, int height, Format format, bool readable) : width(width), height(height), depth(1), format(format), readable(readable) {
 	compression = ImageCompressionNone;
-	bool isFloat = format == RGBA128 || format == RGBA64 || format == A32;
+	bool isFloat = format == RGBA128 || format == RGBA64 || format == A32 || format == A16;
     if (isFloat) {
         this->hdrData = (float*)data;
     }
@@ -259,7 +261,7 @@ void Graphics1::Image::init(Kore::Reader& file, const char* format, bool readabl
 
 Graphics1::Image::~Image() {
 	if (readable) {
-		if (format == RGBA128 || format == RGBA64 || format == A32) {
+		if (format == RGBA128 || format == RGBA64 || format == A32 || format == A16) {
 			delete[] hdrData;
 			hdrData = nullptr;
 		}

--- a/Sources/Kore/Graphics1/Image.h
+++ b/Sources/Kore/Graphics1/Image.h
@@ -10,7 +10,7 @@ namespace Kore {
 
 		class Image {
 		public:
-			enum Format { RGBA32, Grey8, RGB24, RGBA128, RGBA64, A32, BGRA32 };
+			enum Format { RGBA32, Grey8, RGB24, RGBA128, RGBA64, A32, BGRA32, A16 };
 
 			static int sizeOf(Image::Format format);
 

--- a/Sources/Kore/Graphics4/Graphics.h
+++ b/Sources/Kore/Graphics4/Graphics.h
@@ -88,7 +88,7 @@ namespace Kore {
 
 		enum FogType { LinearFog };
 
-		enum RenderTargetFormat { Target32Bit, Target64BitFloat, Target32BitRedFloat, Target128BitFloat, Target16BitDepth, Target8BitRed };
+		enum RenderTargetFormat { Target32Bit, Target64BitFloat, Target32BitRedFloat, Target128BitFloat, Target16BitDepth, Target8BitRed, Target16BitRedFloat };
 
 		enum StencilAction { Keep, Zero, Replace, Increment, IncrementWrap, Decrement, DecrementWrap, Invert };
 


### PR DESCRIPTION
- Adds Target16BitRedFloat and Target32BitRedFloat render target format
- RenderTarget::getPixels() takes texture format into account
- Adds A16 image format
- Tried to clean up the #ifdef bloat a bit