### PR TITLE
UWP work

### DIFF
--- a/Backends/System/WindowsApp/Sources/Kore/System.winrt.cpp
+++ b/Backends/System/WindowsApp/Sources/Kore/System.winrt.cpp
@@ -282,6 +282,14 @@ void Win8Application::OnKeyDown(Windows::UI::Core::CoreWindow^ sender, Windows::
 	case Windows::System::VirtualKey::Down:
 		Keyboard::the()->_keydown(Kore::KeyDown);
 		break;
+	default:
+		if (args->VirtualKey >= Windows::System::VirtualKey::A && args->VirtualKey <= Windows::System::VirtualKey::Z) {
+			Keyboard::the()->_keydown((Kore::KeyCode)args->VirtualKey);
+		}
+		else if (args->VirtualKey >= Windows::System::VirtualKey::Number0 && args->VirtualKey <= Windows::System::VirtualKey::Number9) {
+			Keyboard::the()->_keydown((Kore::KeyCode)args->VirtualKey);
+		}
+		break;
 	}
 }
 
@@ -298,6 +306,14 @@ void Win8Application::OnKeyUp(Windows::UI::Core::CoreWindow ^ sender, Windows::U
 		break;
 	case Windows::System::VirtualKey::Down:
 		Keyboard::the()->_keyup(Kore::KeyDown);
+		break;
+	default:
+		if (args->VirtualKey >= Windows::System::VirtualKey::A && args->VirtualKey <= Windows::System::VirtualKey::Z) {
+			Keyboard::the()->_keyup((Kore::KeyCode)args->VirtualKey);
+		}
+		else if (args->VirtualKey >= Windows::System::VirtualKey::Number0 && args->VirtualKey <= Windows::System::VirtualKey::Number9) {
+			Keyboard::the()->_keyup((Kore::KeyCode)args->VirtualKey);
+		}
 		break;
 	}
 }

--- a/Backends/System/WindowsApp/Sources/Kore/System.winrt.cpp
+++ b/Backends/System/WindowsApp/Sources/Kore/System.winrt.cpp
@@ -9,11 +9,11 @@
 #include <windows.h>
 
 #ifndef XINPUT
-#ifdef SYS_WINDOWS
+#ifdef KORE_WINDOWS
 #define XINPUT 1
 #endif
 
-#ifdef SYS_WINDOWSAPP
+#ifdef KORE_WINDOWSAPP
 #define XINPUT !(WINAPI_PARTITION_PHONE_APP)
 #endif
 #endif

--- a/Sources/Kore/IO/FileReader.winrt.cpp
+++ b/Sources/Kore/IO/FileReader.winrt.cpp
@@ -172,7 +172,8 @@ bool FileReader::open(const char* filename, FileType type) {
 		if (filepath[i] == '/') filepath[i] = '\\';
 #endif
 #ifdef KORE_WINDOWSAPP
-	const wchar_t* location = Windows::ApplicationModel::Package::Current->InstalledLocation->Path->Data();
+	Platform::String^ locationString = Windows::ApplicationModel::Package::Current->InstalledLocation->Path;
+	const wchar_t* location = locationString->Begin();
 	int i;
 	for (i = 0; location[i] != 0; ++i) {
 		filepath[i] = (char)location[i];


### PR DESCRIPTION
Kore still deploys to the xbox uwp without trouble, crazy.

Regarding the https://github.com/Kode/Kore/commit/98e808845d07f948b3938ad88fe9ad20998d39b9 (Fix location string for windowsapp), I have been getting random crashes in release mode(error reading characters of string), this seems to run ok.