### PR TITLE
Fix maximum constant size for D3D11/12

### DIFF
--- a/Backends/Graphics4/Direct3D11/Sources/Kore/Direct3D11.winrt.cpp
+++ b/Backends/Graphics4/Direct3D11/Sources/Kore/Direct3D11.winrt.cpp
@@ -453,26 +453,26 @@ void Graphics4::setTextureOperation(TextureOperation operation, TextureArgument 
 }
 
 namespace {
-	void setInt(u8* constants, u8 offset, u8 size, int value) {
+	void setInt(u8* constants, u32 offset, u32 size, int value) {
 		if (size == 0) return;
 		int* ints = reinterpret_cast<int*>(&constants[offset]);
 		ints[0] = value;
 	}
 
-	void setFloat(u8* constants, u8 offset, u8 size, float value) {
+	void setFloat(u8* constants, u32 offset, u32 size, float value) {
 		if (size == 0) return;
 		float* floats = reinterpret_cast<float*>(&constants[offset]);
 		floats[0] = value;
 	}
 
-	void setFloat2(u8* constants, u8 offset, u8 size, float value1, float value2) {
+	void setFloat2(u8* constants, u32 offset, u32 size, float value1, float value2) {
 		if (size == 0) return;
 		float* floats = reinterpret_cast<float*>(&constants[offset]);
 		floats[0] = value1;
 		floats[1] = value2;
 	}
 
-	void setFloat3(u8* constants, u8 offset, u8 size, float value1, float value2, float value3) {
+	void setFloat3(u8* constants, u32 offset, u32 size, float value1, float value2, float value3) {
 		if (size == 0) return;
 		float* floats = reinterpret_cast<float*>(&constants[offset]);
 		floats[0] = value1;
@@ -480,7 +480,7 @@ namespace {
 		floats[2] = value3;
 	}
 
-	void setFloat4(u8* constants, u8 offset, u8 size, float value1, float value2, float value3, float value4) {
+	void setFloat4(u8* constants, u32 offset, u32 size, float value1, float value2, float value3, float value4) {
 		if (size == 0) return;
 		float* floats = reinterpret_cast<float*>(&constants[offset]);
 		floats[0] = value1;
@@ -489,7 +489,7 @@ namespace {
 		floats[3] = value4;
 	}
 
-	void setFloats(u8* constants, u8 offset, u8 size, float* values, int count) {
+	void setFloats(u8* constants, u32 offset, u32 size, float* values, int count) {
 		if (size == 0) return;
 		float* floats = reinterpret_cast<float*>(&constants[offset]);
 		for (int i = 0; i < count; ++i) {
@@ -497,13 +497,13 @@ namespace {
 		}
 	}
 
-	void setBool(u8* constants, u8 offset, u8 size, bool value) {
+	void setBool(u8* constants, u32 offset, u32 size, bool value) {
 		if (size == 0) return;
 		int* ints = reinterpret_cast<int*>(&constants[offset]);
 		ints[0] = value ? 1 : 0;
 	}
 
-	void setMatrix(u8* constants, u8 offset, u8 size, const mat4& value) {
+	void setMatrix(u8* constants, u32 offset, u32 size, const mat4& value) {
 		if (size == 0) return;
 		float* floats = reinterpret_cast<float*>(&constants[offset]);
 		for (int y = 0; y < 4; ++y) {
@@ -513,7 +513,7 @@ namespace {
 		}
 	}
 
-	void setMatrix(u8* constants, u8 offset, u8 size, const mat3& value) {
+	void setMatrix(u8* constants, u32 offset, u32 size, const mat3& value) {
 		if (size == 0) return;
 		float* floats = reinterpret_cast<float*>(&constants[offset]);
 		for (int y = 0; y < 3; ++y) {

--- a/Backends/Graphics4/Direct3D11/Sources/Kore/ShaderImpl.h
+++ b/Backends/Graphics4/Direct3D11/Sources/Kore/ShaderImpl.h
@@ -23,15 +23,15 @@ namespace Kore {
 
 	class ConstantLocationImpl {
 	public:
-		u8 vertexOffset;
-		u8 vertexSize;
-		u8 fragmentOffset;
-		u8 fragmentSize;
-		u8 geometryOffset;
-		u8 geometrySize;
-		u8 tessEvalOffset;
-		u8 tessEvalSize;
-		u8 tessControlOffset;
-		u8 tessControlSize;
+		u32 vertexOffset;
+		u32 vertexSize;
+		u32 fragmentOffset;
+		u32 fragmentSize;
+		u32 geometryOffset;
+		u32 geometrySize;
+		u32 tessEvalOffset;
+		u32 tessEvalSize;
+		u32 tessControlOffset;
+		u32 tessControlSize;
 	};
 }

--- a/Backends/Graphics5/Direct3D12/Sources/Kore/Direct3D12.cpp
+++ b/Backends/Graphics5/Direct3D12/Sources/Kore/Direct3D12.cpp
@@ -515,26 +515,26 @@ void Graphics5::flush() {}
 void Graphics5::setTextureOperation(TextureOperation operation, TextureArgument arg1, TextureArgument arg2) {}
 
 namespace {
-	void setInt(u8* constants, u8 offset, u8 size, int value) {
+	void setInt(u8* constants, u32 offset, u32 size, int value) {
 		if (size == 0) return;
 		int* ints = reinterpret_cast<int*>(&constants[offset]);
 		ints[0] = value;
 	}
 
-	void setFloat(u8* constants, u8 offset, u8 size, float value) {
+	void setFloat(u8* constants, u32 offset, u32 size, float value) {
 		if (size == 0) return;
 		float* floats = reinterpret_cast<float*>(&constants[offset]);
 		floats[0] = value;
 	}
 
-	void setFloat2(u8* constants, u8 offset, u8 size, float value1, float value2) {
+	void setFloat2(u8* constants, u32 offset, u32 size, float value1, float value2) {
 		if (size == 0) return;
 		float* floats = reinterpret_cast<float*>(&constants[offset]);
 		floats[0] = value1;
 		floats[1] = value2;
 	}
 
-	void setFloat3(u8* constants, u8 offset, u8 size, float value1, float value2, float value3) {
+	void setFloat3(u8* constants, u32 offset, u32 size, float value1, float value2, float value3) {
 		if (size == 0) return;
 		float* floats = reinterpret_cast<float*>(&constants[offset]);
 		floats[0] = value1;
@@ -542,7 +542,7 @@ namespace {
 		floats[2] = value3;
 	}
 
-	void setFloat4(u8* constants, u8 offset, u8 size, float value1, float value2, float value3, float value4) {
+	void setFloat4(u8* constants, u32 offset, u32 size, float value1, float value2, float value3, float value4) {
 		if (size == 0) return;
 		float* floats = reinterpret_cast<float*>(&constants[offset]);
 		floats[0] = value1;
@@ -551,7 +551,7 @@ namespace {
 		floats[3] = value4;
 	}
 
-	void setFloats(u8* constants, u8 offset, u8 size, float* values, int count) {
+	void setFloats(u8* constants, u32 offset, u32 size, float* values, int count) {
 		if (size == 0) return;
 		float* floats = reinterpret_cast<float*>(&constants[offset]);
 		for (int i = 0; i < count; ++i) {
@@ -559,13 +559,13 @@ namespace {
 		}
 	}
 
-	void setBool(u8* constants, u8 offset, u8 size, bool value) {
+	void setBool(u8* constants, u32 offset, u32 size, bool value) {
 		if (size == 0) return;
 		int* ints = reinterpret_cast<int*>(&constants[offset]);
 		ints[0] = value ? 1 : 0;
 	}
 
-	void setMatrix(u8* constants, u8 offset, u8 size, const mat4& value) {
+	void setMatrix(u8* constants, u32 offset, u32 size, const mat4& value) {
 		if (size == 0) return;
 		float* floats = reinterpret_cast<float*>(&constants[offset]);
 		for (int y = 0; y < 4; ++y) {
@@ -575,7 +575,7 @@ namespace {
 		}
 	}
 
-	void setMatrix(u8* constants, u8 offset, u8 size, const mat3& value) {
+	void setMatrix(u8* constants, u32 offset, u32 size, const mat3& value) {
 		if (size == 0) return;
 		float* floats = reinterpret_cast<float*>(&constants[offset]);
 		for (int y = 0; y < 3; ++y) {

--- a/Backends/Graphics5/Direct3D12/Sources/Kore/Shader5Impl.cpp
+++ b/Backends/Graphics5/Direct3D12/Sources/Kore/Shader5Impl.cpp
@@ -42,8 +42,10 @@ Graphics5::Shader::Shader(void* _data, int length, ShaderType type) {
 			if (name[i2] == 0) break;
 		}
 		ShaderConstant constant;
-		constant.offset = data[index++];
-		constant.size = data[index++];
+		constant.offset = *(u32*)&data[index];
+		index += 4;
+		constant.size = *(u32*)&data[index];
+		index += 4;
 		constants[name] = constant;
 		constantsSize = constant.offset + constant.size;
 	}

--- a/Backends/Graphics5/Direct3D12/Sources/Kore/Shader5Impl.h
+++ b/Backends/Graphics5/Direct3D12/Sources/Kore/Shader5Impl.h
@@ -5,8 +5,8 @@
 
 namespace Kore {
 	struct ShaderConstant {
-		u8 offset;
-		u8 size;
+		u32 offset;
+		u32 size;
 	};
 
 	class Shader5Impl {


### PR DESCRIPTION
Constant size/offset was capped to one byte. This is a followup to the issue already fixed in krafix earlier at https://github.com/Kode/krafix/issues/43.

Using this skinning now works perfectly in d3d11.