### PR TITLE
D3D11 improvements

### DIFF
--- a/Backends/Graphics4/Direct3D11/Sources/Kore/Direct3D11.winrt.cpp
+++ b/Backends/Graphics4/Direct3D11/Sources/Kore/Direct3D11.winrt.cpp
@@ -806,6 +806,13 @@ void Graphics4::setRenderTargets(RenderTarget** targets, int count) {
 			ID3D11ShaderResourceView* nullview[1];
 			nullview[0] = nullptr;
 			context->PSSetShaderResources(targets[i]->lastBoundUnit, 1, nullview);
+			targets[i]->lastBoundUnit = -1;
+		}
+		if (targets[i]->lastBoundDepthUnit >= 0) {
+			ID3D11ShaderResourceView* nullview[1];
+			nullview[0] = nullptr;
+			context->PSSetShaderResources(targets[i]->lastBoundDepthUnit, 1, nullview);
+			targets[i]->lastBoundDepthUnit = -1;
 		}
 	}
 	

--- a/Backends/Graphics4/Direct3D11/Sources/Kore/PipelineStateImpl.cpp
+++ b/Backends/Graphics4/Direct3D11/Sources/Kore/PipelineStateImpl.cpp
@@ -15,9 +15,9 @@ namespace Kore {
 	D3D11_CULL_MODE convert(Graphics4::CullMode cullMode) {
 		switch (cullMode) {
 		case Graphics4::Clockwise:
-			return D3D11_CULL_BACK;
-		case Graphics4::CounterClockwise:
 			return D3D11_CULL_FRONT;
+		case Graphics4::CounterClockwise:
+			return D3D11_CULL_BACK;
 		case Graphics4::NoCulling:
 		default:
 			return D3D11_CULL_NONE;
@@ -342,7 +342,6 @@ void Graphics4::PipelineState::compile() {
 		D3D11_RASTERIZER_DESC rasterDesc;
 		rasterDesc.CullMode = convert(cullMode);
 		rasterDesc.FillMode = D3D11_FILL_SOLID;
-		rasterDesc.CullMode = D3D11_CULL_NONE;
 		rasterDesc.FrontCounterClockwise = FALSE;
 		rasterDesc.DepthBias = 0;
 		rasterDesc.SlopeScaledDepthBias = 0.0f;

--- a/Backends/Graphics4/Direct3D11/Sources/Kore/PipelineStateImpl.cpp
+++ b/Backends/Graphics4/Direct3D11/Sources/Kore/PipelineStateImpl.cpp
@@ -229,10 +229,11 @@ namespace {
 		return ret;
 	}
 
-	void setVertexDesc(D3D11_INPUT_ELEMENT_DESC& vertexDesc, int attributeIndex, int index, int stream) {
+	void setVertexDesc(D3D11_INPUT_ELEMENT_DESC& vertexDesc, int attributeIndex, int index, int stream, bool interleavedLayout) {
 		vertexDesc.SemanticName = "TEXCOORD";
 		vertexDesc.SemanticIndex = attributeIndex;
 		vertexDesc.InputSlot = stream;
+		if (!interleavedLayout) vertexDesc.InputSlot += stream == 0 ? index : attributeIndex;
 		vertexDesc.AlignedByteOffset = (index == 0) ? 0 : D3D11_APPEND_ALIGNED_ELEMENT;
 		vertexDesc.InputSlotClass = stream == 0 ? D3D11_INPUT_PER_VERTEX_DATA : D3D11_INPUT_PER_INSTANCE_DATA; // hack
 		vertexDesc.InstanceDataStepRate = stream == 0 ? 0 : 1;                                                 // hack
@@ -274,27 +275,27 @@ void Graphics4::PipelineState::compile() {
 		for (int index = 0; index < inputLayout[stream]->size; ++index) {
 			switch (inputLayout[stream]->elements[index].data) {
 			case Float1VertexData:
-				setVertexDesc(vertexDesc[i], vertexShader->attributes[inputLayout[stream]->elements[index].name], index, stream);
+				setVertexDesc(vertexDesc[i], vertexShader->attributes[inputLayout[stream]->elements[index].name], index, stream, interleavedLayout);
 				vertexDesc[i].Format = DXGI_FORMAT_R32_FLOAT;
 				++i;
 				break;
 			case Float2VertexData:
-				setVertexDesc(vertexDesc[i], vertexShader->attributes[inputLayout[stream]->elements[index].name], index, stream);
+				setVertexDesc(vertexDesc[i], vertexShader->attributes[inputLayout[stream]->elements[index].name], index, stream, interleavedLayout);
 				vertexDesc[i].Format = DXGI_FORMAT_R32G32_FLOAT;
 				++i;
 				break;
 			case Float3VertexData:
-				setVertexDesc(vertexDesc[i], vertexShader->attributes[inputLayout[stream]->elements[index].name], index, stream);
+				setVertexDesc(vertexDesc[i], vertexShader->attributes[inputLayout[stream]->elements[index].name], index, stream, interleavedLayout);
 				vertexDesc[i].Format = DXGI_FORMAT_R32G32B32_FLOAT;
 				++i;
 				break;
 			case Float4VertexData:
-				setVertexDesc(vertexDesc[i], vertexShader->attributes[inputLayout[stream]->elements[index].name], index, stream);
+				setVertexDesc(vertexDesc[i], vertexShader->attributes[inputLayout[stream]->elements[index].name], index, stream, interleavedLayout);
 				vertexDesc[i].Format = DXGI_FORMAT_R32G32B32A32_FLOAT;
 				++i;
 				break;
 			case ColorVertexData:
-				setVertexDesc(vertexDesc[i], vertexShader->attributes[inputLayout[stream]->elements[index].name], index, stream);
+				setVertexDesc(vertexDesc[i], vertexShader->attributes[inputLayout[stream]->elements[index].name], index, stream, interleavedLayout);
 				vertexDesc[i].Format = DXGI_FORMAT_R8G8B8A8_UINT;
 				++i;
 				break;
@@ -307,7 +308,7 @@ void Graphics4::PipelineState::compile() {
 					_itoa(i2, &name[length], 10);
 					name[length + 1] = 0;
 
-					setVertexDesc(vertexDesc[i], vertexShader->attributes[name], index + i2, stream);
+					setVertexDesc(vertexDesc[i], vertexShader->attributes[name], index + i2, stream, interleavedLayout);
 					vertexDesc[i].Format = DXGI_FORMAT_R32G32B32A32_FLOAT;
 
 					++i;

--- a/Backends/Graphics4/Direct3D11/Sources/Kore/RenderTargetImpl.cpp
+++ b/Backends/Graphics4/Direct3D11/Sources/Kore/RenderTargetImpl.cpp
@@ -29,6 +29,9 @@ Graphics4::RenderTarget::RenderTarget(int width, int height, int depthBufferBits
 	case Target32BitRedFloat:
 		desc.Format = DXGI_FORMAT_R32_FLOAT;
 		break;
+	case Target16BitRedFloat:
+		desc.Format = DXGI_FORMAT_R16_FLOAT;
+		break;
 	case Target8BitRed:
 		desc.Format = DXGI_FORMAT_R8_UNORM;
 		break;

--- a/Backends/Graphics4/Direct3D11/Sources/Kore/RenderTargetImpl.cpp
+++ b/Backends/Graphics4/Direct3D11/Sources/Kore/RenderTargetImpl.cpp
@@ -99,6 +99,7 @@ Graphics4::RenderTarget::RenderTarget(int width, int height, int depthBufferBits
 	}
 
 	lastBoundUnit = -1;
+	lastBoundDepthUnit = -1;
 }
 
 Graphics4::RenderTarget::RenderTarget(int cubeMapSize, int depthBufferBits, bool antialiasing, RenderTargetFormat format, int stencilBufferBits, int contextId)
@@ -121,7 +122,7 @@ void Graphics4::RenderTarget::useColorAsTexture(TextureUnit unit) {
 void Graphics4::RenderTarget::useDepthAsTexture(TextureUnit unit) {
 	if (unit.unit < 0) return;
 	context->PSSetShaderResources(unit.unit, 1, &depthStencilSRV);
-	lastBoundUnit = unit.unit;
+	lastBoundDepthUnit = unit.unit;
 }
 
 void Graphics4::RenderTarget::setDepthStencilFrom(RenderTarget* source) {

--- a/Backends/Graphics4/Direct3D11/Sources/Kore/RenderTargetImpl.h
+++ b/Backends/Graphics4/Direct3D11/Sources/Kore/RenderTargetImpl.h
@@ -15,5 +15,6 @@ namespace Kore {
 		ID3D11ShaderResourceView* renderTargetSRV;
 		ID3D11ShaderResourceView* depthStencilSRV;
 		int lastBoundUnit;
+		int lastBoundDepthUnit;
 	};
 }

--- a/Backends/Graphics4/Direct3D11/Sources/Kore/TextureImpl.cpp
+++ b/Backends/Graphics4/Direct3D11/Sources/Kore/TextureImpl.cpp
@@ -10,6 +10,46 @@ using namespace Kore;
 namespace {
 	Graphics4::Texture* setTextures[16] = {nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
 	                            nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr};
+
+	DXGI_FORMAT convertFormat(Graphics4::Image::Format format) {
+		switch (format) {
+		case Graphics4::Image::RGBA32:
+		default:
+			return DXGI_FORMAT_R8G8B8A8_UNORM;
+		case Graphics4::Image::RGBA128:
+			return DXGI_FORMAT_R32G32B32A32_FLOAT;
+		case Graphics4::Image::RGBA64:
+			return DXGI_FORMAT_R16G16B16A16_FLOAT;
+		case Graphics4::Image::RGB24:
+			return DXGI_FORMAT_R8G8B8A8_UNORM;
+		case Graphics4::Image::A32:
+			return DXGI_FORMAT_R32_FLOAT;
+		case Graphics4::Image::A16:
+			return DXGI_FORMAT_R16_FLOAT;
+		case Graphics4::Image::Grey8:
+			return DXGI_FORMAT_R8_UNORM;
+		}
+	}
+
+	int formatByteSize(Graphics4::Image::Format format) {
+		switch (format) {
+		case Graphics4::Image::RGBA32:
+		default:
+			return 4;
+		case Graphics4::Image::RGBA128:
+			return 16;
+		case Graphics4::Image::RGBA64:
+			return 8;
+		case Graphics4::Image::RGB24:
+			return 4;
+		case Graphics4::Image::A32:
+			return 4;
+		case Graphics4::Image::A16:
+			return 2;
+		case Graphics4::Image::Grey8:
+			return 1;
+		}
+	}
 }
 
 void Graphics4::Texture::init(const char* format, bool readable) {
@@ -18,12 +58,13 @@ void Graphics4::Texture::init(const char* format, bool readable) {
 	texWidth = width;
 	texHeight = height;
 	rowPitch = 0;
+	bool isHdr = this->format == Graphics4::Image::RGBA128 || this->format == Graphics4::Image::RGBA64 || this->format == Graphics4::Image::A32 || this->format == Graphics4::Image::A16;
 
 	D3D11_TEXTURE2D_DESC desc;
 	desc.Width = width;
 	desc.Height = height;
 	desc.MipLevels = desc.ArraySize = 1;
-	desc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+	desc.Format = convertFormat(this->format);
 	desc.SampleDesc.Count = 1;
 	desc.SampleDesc.Quality = 0;
 	desc.Usage = D3D11_USAGE_DEFAULT;
@@ -32,8 +73,8 @@ void Graphics4::Texture::init(const char* format, bool readable) {
 	desc.MiscFlags = 0;
 
 	D3D11_SUBRESOURCE_DATA data;
-	data.pSysMem = this->data;
-	data.SysMemPitch = width * 4;
+	data.pSysMem = isHdr ? (void*)this->hdrData : this->data;
+	data.SysMemPitch = width * formatByteSize(this->format);
 	data.SysMemSlicePitch = 0;
 
 	texture = nullptr;
@@ -41,8 +82,14 @@ void Graphics4::Texture::init(const char* format, bool readable) {
 	affirm(device->CreateShaderResourceView(texture, nullptr, &view));
 
 	if (!readable) {
-		delete[] this->data;
-		this->data = nullptr;
+		if (isHdr) {
+			delete[] this->hdrData;
+			this->hdrData = nullptr;
+		}
+		else {
+			delete[] this->data;
+			this->data = nullptr;
+		}
 	}
 }
 
@@ -135,6 +182,11 @@ int Graphics4::Texture::stride() {
 	return rowPitch;
 }
 
-void Graphics4::Texture::generateMipmaps(int levels) {}
+void Graphics4::Texture::generateMipmaps(int levels) {
+	//context->GenerateMips(view);
+}
 
-void Graphics4::Texture::setMipmap(Texture* mipmap, int level) {}
+void Graphics4::Texture::setMipmap(Texture* mipmap, int level) {
+	//D3D11CalcSubresource();
+	//context->UpdateSubresource();
+}

--- a/Sources/Kore/Graphics4/PipelineState.cpp
+++ b/Sources/Kore/Graphics4/PipelineState.cpp
@@ -7,6 +7,7 @@ using namespace Kore;
 
 Graphics4::PipelineState::PipelineState() {
 	for (int i = 0; i < 16; ++i) inputLayout[i] = nullptr;
+	interleavedLayout = true;
 	vertexShader = nullptr;
 	fragmentShader = nullptr;
 	geometryShader = nullptr;

--- a/Sources/Kore/Graphics4/PipelineState.h
+++ b/Sources/Kore/Graphics4/PipelineState.h
@@ -15,6 +15,7 @@ namespace Kore {
 			~PipelineState();
 
 			VertexStructure* inputLayout[16];
+			bool interleavedLayout;
 			Shader* vertexShader;
 			Shader* fragmentShader;
 			Shader* geometryShader;


### PR DESCRIPTION
- Fixed non-interleaved vertex buffers. For D3D we need to explicitly define this when setting vertex description - cleanest solution I found so far is by `pipeline.interleavedLayout` flag. Also works combined with instancing.
- Culling was disabled for some reason, seems to work fine now.
- Fixed an unbind case when both color and depth buffers of texture were attached.
- Implemented missing render target/texture formats, including .hdr.

This should not change existing behavior, testing welcome.