### PR TITLE
Null lastPipeline on init

### DIFF
--- a/Backends/Graphics4/OpenGL/Sources/Kore/OpenGL.cpp
+++ b/Backends/Graphics4/OpenGL/Sources/Kore/OpenGL.cpp
@@ -220,6 +220,8 @@ void Graphics4::init(int windowId, int depthBufferBits, int stencilBufferBits, b
 
 	// glEnable(GL_DEBUG_OUTPUT);
 	// glDebugMessageCallback(debugCallback, nullptr);
+
+	lastPipeline = nullptr;
 }
 
 void Graphics4::changeResolution(int width, int height) {


### PR DESCRIPTION
Clears lastPipeline on init(), for times when Kore is embedded in another application and run over and over again.