### PR TITLE
Storage fix for FileReader

### DIFF
--- a/Sources/Kore/IO/FileReader.winrt.cpp
+++ b/Sources/Kore/IO/FileReader.winrt.cpp
@@ -220,7 +220,7 @@ bool FileReader::open(const char* filename, FileType type) {
 	if (isAbsolute) {
 		strcpy(filepath, filename);
 	}
-	else if (fileslocation != nullptr) {
+	else if (fileslocation != nullptr && type != Save) {
 		strcpy(filepath, fileslocation);
 		strcat(filepath, "/");
 		strcat(filepath, filename);


### PR DESCRIPTION
Krom uses `fileslocation` which would then overwrite save path.