### PR TITLE
Cubemap support for direct3d11

### DIFF
--- a/Backends/Graphics4/Direct3D11/Sources/Kore/Direct3D11.winrt.cpp
+++ b/Backends/Graphics4/Direct3D11/Sources/Kore/Direct3D11.winrt.cpp
@@ -861,7 +861,7 @@ void Graphics4::setRenderTargets(RenderTarget** targets, int count) {
 
 	renderTargetCount = count;
 	for (int i = 0; i < count; ++i) {
-		currentRenderTargetViews[i] = targets[i]->renderTargetView;
+		currentRenderTargetViews[i] = targets[i]->renderTargetView[0];
 	}
 
 	context->OMSetRenderTargets(count, currentRenderTargetViews, targets[0]->depthStencilView);
@@ -871,19 +871,9 @@ void Graphics4::setRenderTargets(RenderTarget** targets, int count) {
 
 void Graphics4::setRenderTargetFace(RenderTarget* texture, int face) {
 	// TODO
-	D3D11_TEX2D_ARRAY_RTV subres;
-	subres.MipSlice = 0;
-	subres.FirstArraySlice = face;
-	subres.ArraySize = 1;
+	currentRenderTargetViews[0] = texture->renderTargetView[face];
+	renderTargetCount = 1;
 
-	D3D11_RENDER_TARGET_VIEW_DESC viewDesc;
-	viewDesc.Format = DXGI_FORMAT_UNKNOWN;
-	viewDesc.ViewDimension = D3D11_RTV_DIMENSION_TEXTURE2DARRAY;
-	viewDesc.Texture2DArray = subres;
-
-	currentDepthStencilView = texture->depthStencilView;
-
-	device->CreateRenderTargetView(texture->texture, &viewDesc, currentRenderTargetViews);
 	context->OMSetRenderTargets(1, currentRenderTargetViews, texture->depthStencilView);
 	CD3D11_VIEWPORT viewPort(0.0f, 0.0f, static_cast<float>(texture->width), static_cast<float>(texture->height));
 	context->RSSetViewports(1, &viewPort);

--- a/Backends/Graphics4/Direct3D11/Sources/Kore/Direct3D11.winrt.cpp
+++ b/Backends/Graphics4/Direct3D11/Sources/Kore/Direct3D11.winrt.cpp
@@ -871,6 +871,25 @@ void Graphics4::setRenderTargets(RenderTarget** targets, int count) {
 
 void Graphics4::setRenderTargetFace(RenderTarget* texture, int face) {
 	// TODO
+	D3D11_TEX2D_ARRAY_RTV subres;
+	subres.MipSlice = 0;
+	subres.FirstArraySlice = face;
+	subres.ArraySize = 1;
+
+	D3D11_RENDER_TARGET_VIEW_DESC viewDesc;
+	viewDesc.Format = DXGI_FORMAT_UNKNOWN;
+	viewDesc.ViewDimension = D3D11_RTV_DIMENSION_TEXTURE2DARRAY;
+	viewDesc.Texture2DArray = subres;
+
+	currentDepthStencilView = texture->depthStencilView;
+
+	device->CreateRenderTargetView(texture->texture, &viewDesc, currentRenderTargetViews);
+	context->OMSetRenderTargets(1, currentRenderTargetViews, texture->depthStencilView);
+	CD3D11_VIEWPORT viewPort(0.0f, 0.0f, static_cast<float>(texture->width), static_cast<float>(texture->height));
+	context->RSSetViewports(1, &viewPort);
+
+	renderTargetWidth = texture->width;
+	renderTargetHeight = texture->height;
 }
 
 void Graphics4::setVertexBuffers(VertexBuffer** buffers, int count) {

--- a/Backends/Graphics4/Direct3D11/Sources/Kore/Direct3D11.winrt.cpp
+++ b/Backends/Graphics4/Direct3D11/Sources/Kore/Direct3D11.winrt.cpp
@@ -870,16 +870,12 @@ void Graphics4::setRenderTargets(RenderTarget** targets, int count) {
 }
 
 void Graphics4::setRenderTargetFace(RenderTarget* texture, int face) {
-	// TODO
 	currentRenderTargetViews[0] = texture->renderTargetView[face];
 	renderTargetCount = 1;
 
 	context->OMSetRenderTargets(1, currentRenderTargetViews, texture->depthStencilView);
 	CD3D11_VIEWPORT viewPort(0.0f, 0.0f, static_cast<float>(texture->width), static_cast<float>(texture->height));
 	context->RSSetViewports(1, &viewPort);
-
-	renderTargetWidth = texture->width;
-	renderTargetHeight = texture->height;
 }
 
 void Graphics4::setVertexBuffers(VertexBuffer** buffers, int count) {

--- a/Backends/Graphics4/Direct3D11/Sources/Kore/RenderTargetImpl.cpp
+++ b/Backends/Graphics4/Direct3D11/Sources/Kore/RenderTargetImpl.cpp
@@ -123,8 +123,119 @@ Graphics4::RenderTarget::RenderTarget(int width, int height, int depthBufferBits
 }
 
 Graphics4::RenderTarget::RenderTarget(int cubeMapSize, int depthBufferBits, bool antialiasing, RenderTargetFormat format, int stencilBufferBits, int contextId)
-	: isCubeMap(true), isDepthAttachment(false) {
+	: width(cubeMapSize), height(cubeMapSize), isCubeMap(true), isDepthAttachment(false) {
 	
+	this->texWidth = this->width = width;
+	this->texHeight = this->height = height;
+	this->contextId = contextId;
+
+	D3D11_TEXTURE2D_DESC desc;
+	desc.Width = width;
+	desc.Height = height;
+	desc.MipLevels = 1;
+	desc.ArraySize = 6;
+
+	switch (format) {
+	case Target128BitFloat:
+		desc.Format = DXGI_FORMAT_R32G32B32A32_FLOAT;
+		break;
+	case Target64BitFloat:
+		desc.Format = DXGI_FORMAT_R16G16B16A16_FLOAT;
+		break;
+	case Target32BitRedFloat:
+		desc.Format = DXGI_FORMAT_R32_FLOAT;
+		break;
+	case Target16BitRedFloat:
+		desc.Format = DXGI_FORMAT_R16_FLOAT;
+		break;
+	case Target8BitRed:
+		desc.Format = DXGI_FORMAT_R8_UNORM;
+		break;
+	case Target16BitDepth:
+		isDepthAttachment = true;
+		depthBufferBits = 16;
+		stencilBufferBits = 0;
+		break;
+	case Target32Bit:
+	default:
+		desc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+	}
+
+	if (antialiasing) {
+		desc.SampleDesc.Count = 4;
+		desc.SampleDesc.Quality = D3D11_STANDARD_MULTISAMPLE_PATTERN;
+	}
+	else {
+		desc.SampleDesc.Count = 1;
+		desc.SampleDesc.Quality = 0;
+	}
+	desc.Usage = D3D11_USAGE_DEFAULT;
+	desc.BindFlags = D3D11_BIND_RENDER_TARGET | D3D11_BIND_SHADER_RESOURCE;
+	desc.CPUAccessFlags = 0; // D3D11_CPU_ACCESS_WRITE;
+	desc.MiscFlags = 0;
+
+	texture = nullptr;
+	renderTargetView = nullptr;
+	if (!isDepthAttachment) {
+		affirm(device->CreateTexture2D(&desc, nullptr, &texture));
+
+		/*D3D11_RENDER_TARGET_VIEW_DESC renderTargetViewDesc;
+		renderTargetViewDesc.Format = desc.Format;
+		renderTargetViewDesc.ViewDimension = D3D11_RTV_DIMENSION_TEXTURE2D;
+		renderTargetViewDesc.Texture2D.MipSlice = 0;
+		affirm(device->CreateRenderTargetView(texture, &renderTargetViewDesc, &renderTargetView));*/
+	}
+
+	depthStencil = nullptr;
+	depthStencilView = nullptr;
+	DXGI_FORMAT depthFormat = DXGI_FORMAT_D24_UNORM_S8_UINT;
+	if (depthBufferBits == 32 && stencilBufferBits == 8) {
+		depthFormat = DXGI_FORMAT_D32_FLOAT_S8X24_UINT;
+	}
+	else if (depthBufferBits == 16 && stencilBufferBits <= 0) {
+		depthFormat = DXGI_FORMAT_D16_UNORM;
+	}
+	else if (stencilBufferBits <= 0) {
+		depthFormat = DXGI_FORMAT_D32_FLOAT;
+	}
+
+	if (depthBufferBits > 0) {
+		CD3D11_TEXTURE2D_DESC depthStencilDesc(DXGI_FORMAT_R24G8_TYPELESS, width, height, 6, 1, D3D11_BIND_DEPTH_STENCIL | D3D11_BIND_SHADER_RESOURCE);
+		if (antialiasing) {
+			depthStencilDesc.SampleDesc.Count = 4;
+			depthStencilDesc.SampleDesc.Quality = D3D11_STANDARD_MULTISAMPLE_PATTERN;
+		}
+		else {
+			depthStencilDesc.SampleDesc.Count = 1;
+			depthStencilDesc.SampleDesc.Quality = 0;
+		}
+		affirm(device->CreateTexture2D(&depthStencilDesc, nullptr, &depthStencil));
+
+		// affirm(device->CreateDepthStencilView(depthStencil, &CD3D11_DEPTH_STENCIL_VIEW_DESC(D3D11_DSV_DIMENSION_TEXTURE2D, DXGI_FORMAT_D24_UNORM_S8_UINT), &depthStencilView));
+	}
+
+	D3D11_SHADER_RESOURCE_VIEW_DESC shaderResourceViewDesc;
+	if (!isDepthAttachment) {
+		shaderResourceViewDesc.Format = desc.Format;
+		shaderResourceViewDesc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2DARRAY;
+		shaderResourceViewDesc.Texture2D.MostDetailedMip = 0;
+		shaderResourceViewDesc.Texture2D.MipLevels = 1;
+		affirm(device->CreateShaderResourceView(texture, &shaderResourceViewDesc, &renderTargetSRV));
+	}
+
+	if (depthBufferBits > 0) {
+		shaderResourceViewDesc.Format = DXGI_FORMAT_R24_UNORM_X8_TYPELESS;
+		shaderResourceViewDesc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2DARRAY;
+		shaderResourceViewDesc.Texture2D.MostDetailedMip = 0;
+		shaderResourceViewDesc.Texture2D.MipLevels = 1;
+		affirm(device->CreateShaderResourceView(depthStencil, &shaderResourceViewDesc, &depthStencilSRV));
+	}
+
+	lastBoundUnit = -1;
+	lastBoundDepthUnit = -1;
+
+	/*FLOAT colors[4] = { 0, 0, 0, 0 };
+	context->ClearRenderTargetView(renderTargetView, colors);*/
 }
 
 Graphics4::RenderTarget::~RenderTarget() {

--- a/Backends/Graphics4/Direct3D11/Sources/Kore/RenderTargetImpl.h
+++ b/Backends/Graphics4/Direct3D11/Sources/Kore/RenderTargetImpl.h
@@ -9,7 +9,7 @@ namespace Kore {
 	class RenderTargetImpl {
 	public:
 		ID3D11Texture2D* texture;
-		ID3D11RenderTargetView* renderTargetView;
+		ID3D11RenderTargetView* renderTargetView[6];
 		ID3D11Texture2D* depthStencil;
 		ID3D11DepthStencilView* depthStencilView;
 		ID3D11ShaderResourceView* renderTargetSRV;


### PR DESCRIPTION
An example application to test rendering to cubemaps and using them as a texture can be found under https://github.com/MarianThull/KhaDev.git in the branch CubemapsD3D11.