### PR TITLE
Fixed initialization of float textures in Image

### DIFF
--- a/Backends/Graphics4/OpenGL/Sources/Kore/TextureImpl.cpp
+++ b/Backends/Graphics4/OpenGL/Sources/Kore/TextureImpl.cpp
@@ -513,7 +513,8 @@ int Graphics4::Texture::stride() {
 }
 
 u8* Graphics4::Texture::lock() {
-	return (u8*)data;
+	// If data is nullptr then it must be a float image
+	return (data ? data : reinterpret_cast<u8*>(hdrData));
 }
 
 /*void Texture::unlock() {

--- a/Sources/Kore/Graphics1/Image.cpp
+++ b/Sources/Kore/Graphics1/Image.cpp
@@ -55,12 +55,29 @@ int Graphics1::Image::sizeOf(Image::Format format) {
 
 Graphics1::Image::Image(int width, int height, Format format, bool readable) : width(width), height(height), depth(1), format(format), readable(readable) {
 	compression = ImageCompressionNone;
-	data = new u8[width * height * sizeOf(format)];
+	
+	// If format is a floating point format
+	if(format == RGBA128 || format == RGBA64 || format == A32 || format == A16) {
+		hdrData = reinterpret_cast<float*>(new u8[width * height * sizeOf(format)]);
+		data = nullptr;
+	} else {
+		data = new u8[width * height * sizeOf(format)];
+		hdrData = nullptr;
+	}
 }
 
 Graphics1::Image::Image(int width, int height, int depth, Format format, bool readable) : width(width), height(height), depth(depth), format(format), readable(readable) {
 	compression = ImageCompressionNone;
-	data = new u8[width * height * depth * sizeOf(format)];
+	
+	// If format is a floating point format
+	if(format == RGBA128 || format == RGBA64 || format == A32 || format == A16) {
+		hdrData = reinterpret_cast<float*>(new u8[width * height * sizeOf(format)]);
+		data = nullptr;
+	}
+	else {
+		data = new u8[width * height * sizeOf(format)];
+		hdrData = nullptr;
+	}
 }
 
 Graphics1::Image::Image(const char* filename, bool readable) : depth(1), format(RGBA32), readable(readable) {
@@ -75,23 +92,23 @@ Graphics1::Image::Image(Reader& reader, const char* format, bool readable) : dep
 Graphics1::Image::Image(void* data, int width, int height, Format format, bool readable) : width(width), height(height), depth(1), format(format), readable(readable) {
 	compression = ImageCompressionNone;
 	bool isFloat = format == RGBA128 || format == RGBA64 || format == A32 || format == A16;
-    if (isFloat) {
-        this->hdrData = (float*)data;
-    }
-    else {
-        this->data = (u8*)data;
-    }
+	if (isFloat) {
+		this->hdrData = (float*)data;
+	}
+	else {
+		this->data = (u8*)data;
+	}
 }
 
 Graphics1::Image::Image(void* data, int width, int height, int depth, Format format, bool readable) : width(width), height(height), depth(depth), format(format), readable(readable) {
 	compression = ImageCompressionNone;
 	bool isFloat = format == RGBA128 || format == RGBA64 || format == A32 || format == A16;
-    if (isFloat) {
-        this->hdrData = (float*)data;
-    }
-    else {
-        this->data = (u8*)data;
-    }
+	if (isFloat) {
+		this->hdrData = (float*)data;
+	}
+	else {
+		this->data = (u8*)data;
+	}
 }
 
 Graphics1::Image::Image() : depth(1), format(RGBA32), readable(false) {}


### PR DESCRIPTION
Fixes an uninitialized pointer issue where the hdrData field in the Graphics1::Image class was not initialized when creating an in-memory texture without loading from a file. It also fixes the Graphics4 OpenGL implementation of the Texture::lock method which used to always return the data field, regardless of the actual texture type.