### PR TITLE
setSampledTexture for opengl compute

### DIFF
--- a/Backends/Graphics3/OpenGL1/Sources/Kore/ComputeImpl.cpp
+++ b/Backends/Graphics3/OpenGL1/Sources/Kore/ComputeImpl.cpp
@@ -101,6 +101,22 @@ void Compute::setTexture(ComputeTextureUnit unit, Graphics4::Texture* texture, A
 #endif
 }
 
+void Compute::setTexture(ComputeTextureUnit unit, Graphics4::RenderTarget* target, Access access) {
+
+}
+
+void Compute::setSampledTexture(ComputeTextureUnit unit, Graphics4::Texture* texture) {
+
+}
+
+void Compute::setSampledTexture(ComputeTextureUnit unit, Graphics4::RenderTarget* target) {
+
+}
+
+void Compute::setSampledDepthTexture(ComputeTextureUnit unit, Graphics4::RenderTarget* target) {
+
+}
+
 void Compute::setShader(ComputeShader* shader) {
 #ifdef HAS_COMPUTE
 	glUseProgram(shader->_programid); glCheckErrors2();

--- a/Backends/Graphics4/Direct3D11/Sources/Kore/ComputeImpl.cpp
+++ b/Backends/Graphics4/Direct3D11/Sources/Kore/ComputeImpl.cpp
@@ -75,6 +75,22 @@ void Compute::setTexture(ComputeTextureUnit unit, Graphics4::Texture* texture, A
 	context->CSSetUnorderedAccessViews(0, 1, &texture->computeView, nullptr);
 }
 
+void Compute::setTexture(ComputeTextureUnit unit, Graphics4::RenderTarget* target, Access access) {
+
+}
+
+void Compute::setSampledTexture(ComputeTextureUnit unit, Graphics4::Texture* texture) {
+
+}
+
+void Compute::setSampledTexture(ComputeTextureUnit unit, Graphics4::RenderTarget* target) {
+
+}
+
+void Compute::setSampledDepthTexture(ComputeTextureUnit unit, Graphics4::RenderTarget* target) {
+
+}
+
 void Compute::setShader(ComputeShader* shader) {
 	context->CSSetShader((ID3D11ComputeShader*)shader->shader, nullptr, 0);
 }

--- a/Backends/Graphics4/OpenGL/Sources/Kore/ComputeImpl.cpp
+++ b/Backends/Graphics4/OpenGL/Sources/Kore/ComputeImpl.cpp
@@ -34,6 +34,26 @@ namespace {
 			return GL_R8;
 		}
 	}
+
+	int convertInternalFormat(Graphics4::RenderTargetFormat format) {
+		switch (format) {
+		case Graphics4::RenderTargetFormat::Target64BitFloat:
+			return GL_RGBA16F;
+		case Graphics4::RenderTargetFormat::Target32BitRedFloat:
+			return GL_R32F;
+		case Graphics4::RenderTargetFormat::Target128BitFloat:
+			return GL_RGBA32F;
+		case Graphics4::RenderTargetFormat::Target16BitDepth:
+			return GL_DEPTH_COMPONENT16;
+		case Graphics4::RenderTargetFormat::Target8BitRed:
+			return GL_RED;
+		case Graphics4::RenderTargetFormat::Target16BitRedFloat:
+			return GL_R16F;
+		case Graphics4::RenderTargetFormat::Target32Bit:
+		default:
+			return GL_RGBA;
+		}
+	}
 #endif
 }
 
@@ -235,6 +255,44 @@ void Compute::setTexture(ComputeTextureUnit unit, Graphics4::Texture* texture, A
 	glCheckErrors2();
 	GLenum glaccess = access == Access::Read ? GL_READ_ONLY : (access == Access::Write ? GL_WRITE_ONLY : GL_READ_WRITE);
 	glBindImageTexture(unit.unit, texture->texture, 0, GL_FALSE, 0, glaccess, convertInternalFormat(texture->format));
+	glCheckErrors2();
+#endif
+}
+
+void Compute::setTexture(ComputeTextureUnit unit, Graphics4::RenderTarget* target, Access access) {
+#ifdef HAS_COMPUTE
+	glActiveTexture(GL_TEXTURE0 + unit.unit);
+	glCheckErrors2();
+	GLenum glaccess = access == Access::Read ? GL_READ_ONLY : (access == Access::Write ? GL_WRITE_ONLY : GL_READ_WRITE);
+	glBindImageTexture(unit.unit, target->_texture, 0, GL_FALSE, 0, glaccess, convertInternalFormat((Graphics4::RenderTargetFormat)target->format));
+	glCheckErrors2();
+#endif
+}
+
+void Compute::setSampledTexture(ComputeTextureUnit unit, Graphics4::Texture* texture) {
+#ifdef HAS_COMPUTE
+	glActiveTexture(GL_TEXTURE0 + unit.unit);
+	glCheckErrors2();
+	GLenum gltarget = texture->depth > 1 ? GL_TEXTURE_3D : GL_TEXTURE_2D;
+	glBindTexture(gltarget, texture->texture);
+	glCheckErrors2();
+#endif
+}
+
+void Compute::setSampledTexture(ComputeTextureUnit unit, Graphics4::RenderTarget* target) {
+#ifdef HAS_COMPUTE
+	glActiveTexture(GL_TEXTURE0 + unit.unit);
+	glCheckErrors2();
+	glBindTexture(target->isCubeMap ? GL_TEXTURE_CUBE_MAP : GL_TEXTURE_2D, target->_texture);
+	glCheckErrors2();
+#endif
+}
+
+void Compute::setSampledDepthTexture(ComputeTextureUnit unit, Graphics4::RenderTarget* target) {
+#ifdef HAS_COMPUTE
+	glActiveTexture(GL_TEXTURE0 + unit.unit);
+	glCheckErrors2();
+	glBindTexture(target->isCubeMap ? GL_TEXTURE_CUBE_MAP : GL_TEXTURE_2D, target->_depthTexture);
 	glCheckErrors2();
 #endif
 }

--- a/Sources/Kore/Compute/Compute.h
+++ b/Sources/Kore/Compute/Compute.h
@@ -9,6 +9,7 @@
 namespace Kore {
 	namespace Graphics4 {
 		class Texture;
+		class RenderTarget;
 	}
 
 	class ComputeConstantLocation : public ComputeConstantLocationImpl {};
@@ -50,6 +51,10 @@ namespace Kore {
 		void setBuffer(ShaderStorageBuffer* buffer, int index);
 #endif
 		void setTexture(ComputeTextureUnit unit, Graphics4::Texture* texture, Access access);
+		void setTexture(ComputeTextureUnit unit, Graphics4::RenderTarget* texture, Access access);
+		void setSampledTexture(ComputeTextureUnit unit, Graphics4::Texture* texture);
+		void setSampledTexture(ComputeTextureUnit unit, Graphics4::RenderTarget* target);
+		void setSampledDepthTexture(ComputeTextureUnit unit, Graphics4::RenderTarget* target);
 		void setShader(ComputeShader* shader);
 		void compute(int x, int y, int z);
 	};


### PR DESCRIPTION
- Allows to attach color/depth textures to `sampler2D`/..
- `setTexture()` functions also work for render targets now