### PR TITLE
Pen input for Windows

### DIFF
--- a/Sources/Kore/Input/Pen.cpp
+++ b/Sources/Kore/Input/Pen.cpp
@@ -1,0 +1,36 @@
+#include "pch.h"
+
+#include "Pen.h"
+
+#include <Kore/Log.h>
+#include <Kore/System.h>
+
+using namespace Kore;
+
+namespace {
+	Pen pen;
+}
+
+Pen* Pen::the() {
+	return &pen;
+}
+
+Pen::Pen() {}
+
+void Pen::_move(int windowId, int x, int y, float pressure) {
+	if (Move != nullptr) {
+		Move(windowId, x, y, pressure);
+	}
+}
+
+void Pen::_press(int windowId, int x, int y, float pressure) {
+	if (Press != nullptr) {
+		Press(windowId, x, y, pressure);
+	}
+}
+
+void Pen::_release(int windowId, int x, int y, float pressure) {
+	if (Release != nullptr) {
+		Release(windowId, x, y, pressure);
+	}
+}

--- a/Sources/Kore/Input/Pen.h
+++ b/Sources/Kore/Input/Pen.h
@@ -1,0 +1,17 @@
+#pragma once
+
+namespace Kore {
+	class Pen {
+	public:
+		Pen();
+		static Pen* the();
+		void (*Move)(int windowId, int x, int y, float pressure);
+		void (*Press)(int windowId, int x, int y, float pressure);
+		void (*Release)(int windowId, int x, int y, float pressure);
+
+		// For backend
+		void _move(int windowId, int x, int y, float pressure);
+		void _press(int windowId, int x, int y, float pressure);
+		void _release(int windowId, int x, int y, float pressure);
+	};
+}


### PR DESCRIPTION
Spartan pen api. Tested on Windows + Wacom tablet, successfully reads pen pressure. Pressure is mapped to 0-1 range,