### PR TITLE
Default values when not using Xinerama on Linux OpenGL

### DIFF
--- a/Backends/System/Linux/Sources/Kore/Display_Xinerama.cpp
+++ b/Backends/System/Linux/Sources/Kore/Display_Xinerama.cpp
@@ -67,6 +67,13 @@ namespace Kore {
 			}
 			else {
 				log(Warning, "Xinerama extension is not installed");
+				DeviceInfo &di = displays[0];
+				di.isAvailable = true;
+				di.x = 0;
+				di.y = 0;
+				di.width = 1920;
+				di.height = 1080;
+				di.isPrimary = true;
 			}
 		}
 	}


### PR DESCRIPTION
Defaults to make it run on Linux even if no Xinerama is present