### PR TITLE
Use 2 framebuffers for D3D12

### DIFF
--- a/Backends/Graphics4/G4onG5/Sources/Kore/G4.cpp
+++ b/Backends/Graphics4/G4onG5/Sources/Kore/G4.cpp
@@ -20,7 +20,7 @@ u64 frameNumber = 0;
 bool waitAfterNextDraw = false;
 
 namespace {
-	const int bufferCount = 3;
+	const int bufferCount = 2;
 	int currentBuffer = -1;
 	Graphics5::RenderTarget* framebuffers[bufferCount];
 

--- a/Backends/Graphics5/Direct3D12/Sources/Kore/Direct3D12.h
+++ b/Backends/Graphics5/Direct3D12/Sources/Kore/Direct3D12.h
@@ -11,7 +11,7 @@
 #define IID_GRAPHICS_PPV_ARGS(x) IID_PPV_ARGS(x)
 #endif
 
-static const int QUEUE_SLOT_COUNT = 3;
+static const int QUEUE_SLOT_COUNT = 2;
 extern int currentBackBuffer;
 extern ID3D12Device* device;
 extern ID3D12RootSignature* rootSignature;


### PR DESCRIPTION
With these changes everything seems to work ok using 2 framebuffers. (Unless there was some other reason to use 3 buffers.)

Related: https://github.com/Kore-Samples/ShaderG5-Kore/pull/2 and https://github.com/Kode/Kore/issues/285.