### PR TITLE
fix macOS gamepad support

### DIFF
--- a/Backends/System/macOS/Sources/Kore/Input/HIDGamepad.cpp
+++ b/Backends/System/macOS/Sources/Kore/Input/HIDGamepad.cpp
@@ -5,29 +5,12 @@
 
 #include <Kore/Input/Gamepad.h>
 #include <Kore/Log.h>
+#include <Kore/Error.h>
+#include <Kore/Math/Core.h>
 
 using namespace Kore;
 
 namespace {
-	int axisCount = 6;
-	int buttonCount = 15;
-	IOHIDElementCookie* axis = new IOHIDElementCookie[axisCount];
-	IOHIDElementCookie* buttons = new IOHIDElementCookie[buttonCount];
-
-	char* toString(CFStringRef string) {
-		if (string == NULL) {
-			return NULL;
-		}
-
-		CFIndex length = CFStringGetLength(string);
-		CFIndex maxSize = CFStringGetMaximumSizeForEncoding(length, kCFStringEncodingUTF8) + 1;
-		char* buffer = (char*)malloc(maxSize);
-		if (CFStringGetCString(string, buffer, maxSize, kCFStringEncodingUTF8)) {
-			return buffer;
-		}
-		return NULL;
-	}
-
 	bool debugButtonInput = false;
 	void logButton(int buttonIndex, bool pressed) {
 		switch (buttonIndex) {
@@ -129,60 +112,86 @@ namespace {
 	}
 }
 
-HIDGamepad::HIDGamepad(IOHIDDeviceRef deviceRef, int padIndex) : deviceRef(deviceRef), padIndex(padIndex) {
-	initHIDDevice();
-
-	Gamepad* gamepad = Gamepad::get(padIndex);
-	gamepad->vendor = getManufacturerKey();
-	gamepad->productName = getProductKey();
-	log(Info, "Add gamepad: Vendor: %s, Name: %s", gamepad->vendor, gamepad->productName);
-}
-
-HIDGamepad::~HIDGamepad() {
-	if (deviceRef) {
-		IOHIDDeviceClose(deviceRef, kIOHIDOptionsTypeSeizeDevice);
-		IOHIDDeviceUnscheduleFromRunLoop(deviceRef, CFRunLoopGetCurrent(), kCFRunLoopDefaultMode);
-		IOHIDDeviceRegisterRemovalCallback(deviceRef, NULL, this);
-	}
-
-	if (inIOHIDQueueRef) {
-		IOHIDQueueStop(inIOHIDQueueRef);
-		IOHIDQueueUnscheduleFromRunLoop(inIOHIDQueueRef, CFRunLoopGetCurrent(), kCFRunLoopDefaultMode);
-	}
-
-	delete[] axis;
-	delete[] buttons;
-	axis = nullptr;
-	buttons = nullptr;
-}
-
-void HIDGamepad::initHIDDevice() {
-	if (deviceRef) {
-		// Get all elements for a specific device
-		CFArrayRef elementCFArrayRef = IOHIDDeviceCopyMatchingElements(deviceRef, NULL, kIOHIDOptionsTypeNone);
-
-		// Open device
-		IOHIDDeviceOpen(deviceRef, kIOHIDOptionsTypeSeizeDevice);
-
-		// Register routines
-		IOHIDDeviceRegisterInputValueCallback(deviceRef, inputValueCallback, this);
-		IOHIDDeviceRegisterRemovalCallback(deviceRef, deviceRemovalCallback, this);
-
-		IOHIDDeviceScheduleWithRunLoop(deviceRef, CFRunLoopGetCurrent(), kCFRunLoopDefaultMode);
-
-		// Create a queue to access the values
-		inIOHIDQueueRef = IOHIDQueueCreate(kCFAllocatorDefault, deviceRef, 32, kIOHIDOptionsTypeNone);
-		if (CFGetTypeID(inIOHIDQueueRef) == IOHIDQueueGetTypeID()) {
-			// this is a valid HID queue reference!
-			initElementsFromArray(elementCFArrayRef);
-			IOHIDQueueStart(inIOHIDQueueRef);
-			IOHIDQueueRegisterValueAvailableCallback(inIOHIDQueueRef, valueAvailableCallback, this);
-			IOHIDQueueScheduleWithRunLoop(inIOHIDQueueRef, CFRunLoopGetCurrent(), kCFRunLoopDefaultMode);
+// Helper function to copy a CFStringRef to a cstring buffer.
+// CFStringRef is converted to UTF8 and as many characters as possible are
+// placed into the buffer followed by a null terminator.
+// The buffer is set to an empty string if the conversion fails.
+static void cstringFromCFStringRef(CFStringRef string, char *cstr, size_t clen) {
+	cstr[0] = '\0';
+	if (string != NULL) {
+		char temp[256];
+		if (CFStringGetCString(string, temp, 256, kCFStringEncodingUTF8)) {
+			temp[Kore::min(255, (int)(clen-1))] = '\0';
+			strncpy(cstr, temp, clen);
 		}
 	}
 }
 
-void HIDGamepad::initElementsFromArray(CFArrayRef elements) {
+HIDGamepad::HIDGamepad() {
+	reset();
+}
+
+HIDGamepad::~HIDGamepad() {
+	unbind();
+}
+
+void HIDGamepad::bind(IOHIDDeviceRef inDeviceRef, int inPadIndex) {
+	Kore::affirm(inDeviceRef != nullptr);
+	Kore::affirm(inPadIndex >= 0);
+	Kore::affirm(hidDeviceRef == nullptr);
+	Kore::affirm(hidQueueRef  == nullptr);
+	Kore::affirm(padIndex     == -1);
+
+	// Set device and device index
+	hidDeviceRef = inDeviceRef;
+	padIndex  	 = inPadIndex;
+
+	// Initialise HID Device
+	// ...open device
+	IOHIDDeviceOpen(hidDeviceRef, kIOHIDOptionsTypeSeizeDevice);
+
+	// ..register callbacks
+	IOHIDDeviceRegisterInputValueCallback(hidDeviceRef, inputValueCallback, this);
+	IOHIDDeviceScheduleWithRunLoop(hidDeviceRef, CFRunLoopGetCurrent(), kCFRunLoopDefaultMode);
+
+	// ...create a queue to access element values
+	hidQueueRef = IOHIDQueueCreate(kCFAllocatorDefault, hidDeviceRef, 32, kIOHIDOptionsTypeNone);
+	if (CFGetTypeID(hidQueueRef) == IOHIDQueueGetTypeID()) {
+		IOHIDQueueStart(hidQueueRef);
+		IOHIDQueueRegisterValueAvailableCallback(hidQueueRef, valueAvailableCallback, this);
+		IOHIDQueueScheduleWithRunLoop(hidQueueRef, CFRunLoopGetCurrent(), kCFRunLoopDefaultMode);
+	}
+
+	// ...get all elements (buttons, axes)
+	CFArrayRef elementCFArrayRef = IOHIDDeviceCopyMatchingElements(hidDeviceRef, NULL, kIOHIDOptionsTypeNone);
+	initDeviceElements(elementCFArrayRef);
+
+	// ...get device manufacturer and product details
+	{
+		CFNumberRef vendorIdRef = (CFNumberRef) IOHIDDeviceGetProperty(hidDeviceRef, CFSTR(kIOHIDVendorIDKey));
+		CFNumberGetValue(vendorIdRef, kCFNumberIntType, &hidDeviceVendorID);
+
+		CFNumberRef productIdRef = (CFNumberRef) IOHIDDeviceGetProperty(hidDeviceRef, CFSTR(kIOHIDProductIDKey));
+		CFNumberGetValue(productIdRef, kCFNumberIntType, &hidDeviceProductID);
+
+		CFStringRef vendorRef = (CFStringRef) IOHIDDeviceGetProperty(hidDeviceRef, CFSTR(kIOHIDManufacturerKey));
+		cstringFromCFStringRef(vendorRef, hidDeviceVendor, sizeof(hidDeviceVendor));
+
+		CFStringRef productRef = (CFStringRef) IOHIDDeviceGetProperty(hidDeviceRef, CFSTR(kIOHIDProductKey));
+		cstringFromCFStringRef(productRef, hidDeviceProduct, sizeof(hidDeviceProduct));
+	}
+
+	// Initialise Kore::Gamepad for this HID Device
+	Gamepad *gamepad = Gamepad::get(padIndex);
+	gamepad->vendor 	 = hidDeviceVendor;
+	gamepad->productName = hidDeviceProduct;
+
+	Kore::log(Info, "HIDGamepad.bind: <%p> idx:%d [0x%x:0x%x] [%s] [%s]", inDeviceRef, padIndex, hidDeviceVendorID, hidDeviceProductID, hidDeviceVendor, hidDeviceProduct);
+}
+
+void HIDGamepad::initDeviceElements(CFArrayRef elements) {
+	Kore::affirm(elements != nullptr);
+
 	for (CFIndex i = 0, count = CFArrayGetCount(elements); i < count; ++i) {
 		IOHIDElementRef elementRef = (IOHIDElementRef)CFArrayGetValueAtIndex(elements, i);
 		IOHIDElementType elemType = IOHIDElementGetType(elementRef);
@@ -194,124 +203,88 @@ void HIDGamepad::initElementsFromArray(CFArrayRef elements) {
 
 		// Match up items
 		switch (usagePage) {
-		case kHIDPage_GenericDesktop:
-			switch (usage) {
-			case kHIDUsage_GD_X: // Left stick X
-				// log(Info, "Left stick X axis[0] = %i", cookie);
-				axis[0] = cookie;
+			case kHIDPage_GenericDesktop:
+				switch (usage) {
+					case kHIDUsage_GD_X: // Left stick X
+						// log(Info, "Left stick X axis[0] = %i", cookie);
+						axis[0] = cookie;
+						break;
+					case kHIDUsage_GD_Y: // Left stick Y
+						// log(Info, "Left stick Y axis[1] = %i", cookie);
+						axis[1] = cookie;
+						break;
+					case kHIDUsage_GD_Z: // Left trigger
+						// log(Info, "Left trigger axis[4] = %i", cookie);
+						axis[4] = cookie;
+						break;
+					case kHIDUsage_GD_Rx: // Right stick X
+						// log(Info, "Right stick X axis[2] = %i", cookie);
+						axis[2] = cookie;
+						break;
+					case kHIDUsage_GD_Ry: // Right stick Y
+						// log(Info, "Right stick Y axis[3] = %i", cookie);
+						axis[3] = cookie;
+						break;
+					case kHIDUsage_GD_Rz: // Right trigger
+						// log(Info, "Right trigger axis[5] = %i", cookie);
+						axis[5] = cookie;
+						break;
+					case kHIDUsage_GD_Hatswitch:
+						break;
+					default:
+						break;
+				}
 				break;
-			case kHIDUsage_GD_Y: // Left stick Y
-				// log(Info, "Left stick Y axis[1] = %i", cookie);
-				axis[1] = cookie;
-				break;
-			case kHIDUsage_GD_Z: // Left trigger
-				// log(Info, "Left trigger axis[4] = %i", cookie);
-				axis[4] = cookie;
-				break;
-			case kHIDUsage_GD_Rx: // Right stick X
-				// log(Info, "Right stick X axis[2] = %i", cookie);
-				axis[2] = cookie;
-				break;
-			case kHIDUsage_GD_Ry: // Right stick Y
-				// log(Info, "Right stick Y axis[3] = %i", cookie);
-				axis[3] = cookie;
-				break;
-			case kHIDUsage_GD_Rz: // Right trigger
-				// log(Info, "Right trigger axis[5] = %i", cookie);
-				axis[5] = cookie;
-				break;
-			case kHIDUsage_GD_Hatswitch:
+			case kHIDPage_Button:
+				if ((usage >= 1) && (usage <= 15)) {
+					// Button 1-11
+					buttons[usage - 1] = cookie;
+					// log(Info, "Button %i = %i", usage-1, cookie);
+				}
 				break;
 			default:
 				break;
-			}
-			break;
-		case kHIDPage_Button:
-			if ((usage >= 1) && (usage <= 15)) {
-				// Button 1-11
-				buttons[usage - 1] = cookie;
-				// log(Info, "Button %i = %i", usage-1, cookie);
-			}
-			break;
-		default:
-			break;
 		}
 
 		if (elemType == kIOHIDElementTypeInput_Misc || elemType == kIOHIDElementTypeInput_Button || elemType == kIOHIDElementTypeInput_Axis) {
-			if (!IOHIDQueueContainsElement(inIOHIDQueueRef, elementRef)) IOHIDQueueAddElement(inIOHIDQueueRef, elementRef);
+			if (!IOHIDQueueContainsElement(hidQueueRef, elementRef)) IOHIDQueueAddElement(hidQueueRef, elementRef);
 		}
 	}
 }
 
-// Get a HID device's vendor ID (long)
-int HIDGamepad::getVendorID() {
-	int vendorID = 0;
-	CFNumberRef cfVendorID = (CFNumberRef)IOHIDDeviceGetProperty(deviceRef, CFSTR(kIOHIDVendorIDKey));
-	CFNumberGetValue(cfVendorID, kCFNumberIntType, &vendorID);
-	return vendorID;
+void HIDGamepad::unbind() {
+	Kore::log(Info, "HIDGamepad.unbind: idx:%d [0x%x:0x%x] [%s] [%s]", padIndex, hidDeviceVendorID, hidDeviceProductID, hidDeviceVendor, hidDeviceProduct);
+
+	if (hidQueueRef) {
+		IOHIDQueueStop(hidQueueRef);
+		IOHIDQueueUnscheduleFromRunLoop(hidQueueRef, CFRunLoopGetCurrent(), kCFRunLoopDefaultMode);
+	}
+
+	if (hidDeviceRef) {
+		IOHIDDeviceUnscheduleFromRunLoop(hidDeviceRef, CFRunLoopGetCurrent(), kCFRunLoopDefaultMode);
+		IOHIDDeviceClose(hidDeviceRef, kIOHIDOptionsTypeSeizeDevice);
+	}
+
+	if (padIndex >= 0) {
+		Gamepad *gamepad = Gamepad::get(padIndex);
+		gamepad->vendor 	 = nullptr;
+		gamepad->productName = nullptr;
+	}
+
+	reset();
 }
 
-// Get a HID device's product ID (long)
-int HIDGamepad::getProductID() {
-	int productID = 0;
-	CFNumberRef cfVendorID = (CFNumberRef)IOHIDDeviceGetProperty(deviceRef, CFSTR(kIOHIDProductIDKey));
-	CFNumberGetValue(cfVendorID, kCFNumberIntType, &productID);
-	return productID;
-}
+void HIDGamepad::reset() {
+	padIndex			= -1;
+	hidDeviceRef		= NULL;
+	hidQueueRef 		= NULL;
+	hidDeviceVendor[0]  = '\0';
+	hidDeviceProduct[0]	= '\0';
+	hidDeviceVendorID 	= 0;
+	hidDeviceProductID 	= 0;
 
-// Get a HID device's manifacture key (string)
-char* HIDGamepad::getManufacturerKey() {
-	CFStringRef manufacturerKey = (CFStringRef)IOHIDDeviceGetProperty(deviceRef, CFSTR(kIOHIDManufacturerKey));
-	return toString(manufacturerKey);
-}
-
-// Get a HID device's product key (string)
-char* HIDGamepad::getProductKey() {
-	CFStringRef productName = (CFStringRef)IOHIDDeviceGetProperty(deviceRef, CFSTR(kIOHIDProductKey));
-	return toString(productName);
-}
-
-void HIDGamepad::inputValueCallback(void* inContext, IOReturn inResult, void* inSender, IOHIDValueRef inIOHIDValueRef) {}
-
-void HIDGamepad::deviceRemovalCallback(void* inContext, IOReturn inResult, void* inSender) {
-	HIDGamepad* pad = (HIDGamepad*)inContext;
-	HIDManager::cleanupPad(pad->padIndex);
-}
-
-void HIDGamepad::valueAvailableCallback(void* inContext, IOReturn inResult, void* inSender) {
-	HIDGamepad* pad = (HIDGamepad*)inContext;
-	do {
-		IOHIDValueRef valueRef = IOHIDQueueCopyNextValueWithTimeout((IOHIDQueueRef)inSender, 0.);
-		if (!valueRef) break;
-		// process the HID value reference
-		IOHIDElementRef elementRef = IOHIDValueGetElement(valueRef);
-		// IOHIDElementType elemType = IOHIDElementGetType(elementRef);
-
-		// log(Info, "Type %d %d\n", elemType, elementRef);
-		IOHIDElementCookie cookie = IOHIDElementGetCookie(elementRef);
-		// uint32_t page = IOHIDElementGetUsagePage(elementRef);
-		// uint32_t usage = IOHIDElementGetUsage(elementRef);
-		// log(Info, "page %i, usage %i cookie %i", page, usage, cookie);
-
-		// Check button
-		bool found = false;
-		for (int i = 0; i < buttonCount && !found; ++i) {
-			if (cookie == buttons[i]) {
-				pad->buttonChanged(elementRef, valueRef, i);
-				found = true;
-			}
-		}
-
-		// Check axis
-		for (int i = 0; i < axisCount && !found; ++i) {
-			if (cookie == axis[i]) {
-				pad->axisChanged(elementRef, valueRef, i);
-				found = true;
-			}
-		}
-
-		CFRelease(valueRef);
-	} while (1);
+	memset(axis   , 0, sizeof(axis));
+	memset(buttons, 0, sizeof(buttons));
 }
 
 void HIDGamepad::buttonChanged(IOHIDElementRef elementRef, IOHIDValueRef valueRef, int buttonIndex) {
@@ -348,3 +321,42 @@ void HIDGamepad::axisChanged(IOHIDElementRef elementRef, IOHIDValueRef valueRef,
 
 	if (debugAxisInput) logAxis(axisIndex);
 }
+
+void HIDGamepad::inputValueCallback(void* inContext, IOReturn inResult, void* inSender, IOHIDValueRef inIOHIDValueRef) {}
+
+void HIDGamepad::valueAvailableCallback(void* inContext, IOReturn inResult, void* inSender) {
+	HIDGamepad* pad = (HIDGamepad*)inContext;
+	do {
+		IOHIDValueRef valueRef = IOHIDQueueCopyNextValueWithTimeout((IOHIDQueueRef)inSender, 0.);
+		if (!valueRef) break;
+
+		// process the HID value reference
+		IOHIDElementRef elementRef = IOHIDValueGetElement(valueRef);
+		// IOHIDElementType elemType = IOHIDElementGetType(elementRef);
+		// log(Info, "Type %d %d\n", elemType, elementRef);
+
+		IOHIDElementCookie cookie = IOHIDElementGetCookie(elementRef);
+		// uint32_t page = IOHIDElementGetUsagePage(elementRef);
+		// uint32_t usage = IOHIDElementGetUsage(elementRef);
+		// log(Info, "page %i, usage %i cookie %i", page, usage, cookie);
+
+		// Check button
+		for (int i = 0, c = sizeof(buttons); i < c; ++i) {
+			if (cookie == pad->buttons[i]) {
+				pad->buttonChanged(elementRef, valueRef, i);
+				break;
+			}
+		}
+
+		// Check axes
+		for (int i = 0, c = sizeof(axis); i < c; ++i) {
+			if (cookie == pad->axis[i]) {
+				pad->axisChanged(elementRef, valueRef, i);
+				break;
+			}
+		}
+
+		CFRelease(valueRef);
+	} while (1);
+}
+

--- a/Backends/System/macOS/Sources/Kore/Input/HIDGamepad.h
+++ b/Backends/System/macOS/Sources/Kore/Input/HIDGamepad.h
@@ -7,29 +7,32 @@
 namespace Kore {
 	class HIDGamepad {
 	private:
-		IOHIDDeviceRef deviceRef;
-		IOHIDQueueRef inIOHIDQueueRef;
-		int padIndex;
-
-		void initHIDDevice();
-
 		static void inputValueCallback(void* inContext, IOReturn inResult, void* inSender, IOHIDValueRef inIOHIDValueRef);
 		static void valueAvailableCallback(void* inContext, IOReturn inResult, void* inSender);
-		static void deviceRemovalCallback(void* inContext, IOReturn inResult, void* inSender);
 
-		void initElementsFromArray(CFArrayRef elements);
+		void reset();
+
+		void initDeviceElements(CFArrayRef elements);
 
 		void buttonChanged(IOHIDElementRef elementRef, IOHIDValueRef valueRef, int buttonIndex);
 		void axisChanged(IOHIDElementRef elementRef, IOHIDValueRef valueRef, int axisIndex);
 
+		int padIndex;
+		IOHIDDeviceRef hidDeviceRef;
+		IOHIDQueueRef hidQueueRef;
+		int hidDeviceVendorID;
+		int hidDeviceProductID;
+		char hidDeviceVendor[64];
+		char hidDeviceProduct[64];
+
+		IOHIDElementCookie axis[6];
+		IOHIDElementCookie buttons[15];
+
 	public:
-		HIDGamepad(IOHIDDeviceRef deviceRef, int ID);
+		HIDGamepad();
 		~HIDGamepad();
 
-		// Property functions
-		int getVendorID();
-		int getProductID();
-		char* getProductKey();
-		char* getManufacturerKey();
+		void bind(IOHIDDeviceRef deviceRef, int padIndex);
+		void unbind();
 	};
 }

--- a/Backends/System/macOS/Sources/Kore/Input/HIDManager.h
+++ b/Backends/System/macOS/Sources/Kore/Input/HIDManager.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "pch.h"
+
 #include <IOKit/IOKitLib.h>
 #include <IOKit/hid/IOHIDKeys.h>
 #include <IOKit/hid/IOHIDManager.h>
@@ -7,23 +9,33 @@
 #include "HIDGamepad.h"
 
 namespace Kore {
+
 	class HIDManager {
 
 	private:
 		IOHIDManagerRef managerRef;
 
 		int initHIDManager();
-
 		bool addMatchingArray(CFMutableArrayRef matchingCFArrayRef, CFDictionaryRef matchingCFDictRef);
 		CFMutableDictionaryRef createDeviceMatchingDictionary(u32 inUsagePage, u32 inUsage);
 
 		static void deviceConnected(void* inContext, IOReturn inResult, void* inSender, IOHIDDeviceRef inIOHIDDeviceRef);
 		static void deviceRemoved(void* inContext, IOReturn inResult, void* inSender, IOHIDDeviceRef inIOHIDDeviceRef);
 
+		// Slots to hold details on connected devices
+		struct DeviceRecord {
+			bool 			connected	= false;
+			IOHIDDeviceRef 	device		= nullptr;
+			HIDGamepad 		pad;
+		};
+		DeviceRecord* devices = new DeviceRecord[MAX_DEVICES];
+
 	public:
+		// Maximum number of devices supported
+		// Corresponds to size of Kore::Gamepad array
+		static const int MAX_DEVICES = 12;
+
 		HIDManager();
 		~HIDManager();
-
-		static void cleanupPad(int index);
 	};
 }


### PR DESCRIPTION
This PR fleshes out and partially reworks the existing implementation which ... does not work.
It seemed as if the existing implementation was unfinished or a PoC.

Tested with C++ (Kore) and Haxe (Kha), using the following input devices, on macOS High Sierra 10.13.6.
* Xbox 360 controller
* Unbranded SNES-clone USB gamepad
* Competition Pro USB joystick

Some potential TODO remain (noted in source) but this at least allows gamepads to work in Kha on macOS.