### PR TITLE
Mouse hide linux

### DIFF
--- a/Backends/System/Linux/Sources/Kore/Input/Mouse.cpp
+++ b/Backends/System/Linux/Sources/Kore/Input/Mouse.cpp
@@ -7,6 +7,7 @@
 #include <GL/glx.h>
 
 #include <X11/X.h>
+#include <X11/extensions/Xfixes.h>
 #include <X11/keysym.h>
 
 using namespace Kore;
@@ -55,17 +56,16 @@ void Mouse::show(bool truth) {
 #ifdef KORE_OPENGL
 	::Display* dpy = XOpenDisplay(0);
 	::Window win = (XID)Window::get(0)->_data.handle;
-	if (truth) {
-		XUndefineCursor(dpy, win);
-	}
-	else {
-		XColor col;
-		char data[1] = {0};
-		Pixmap blank = XCreateBitmapFromData(dpy, win, data, 1, 1);
-		Cursor cursor = XCreatePixmapCursor(dpy, blank, blank, &col, &col, 0, 0);
-		XFreePixmap(dpy, blank);
-		XDefineCursor(dpy, win, cursor);
-	}
+	if (truth)
+    {
+        XFixesShowCursor(dpy, win);
+        XFlush(dpy);
+    }
+    else
+    {
+        XFixesHideCursor(dpy, win);
+        XFlush(dpy);
+    }
 #endif
 }
 

--- a/korefile.js
+++ b/korefile.js
@@ -311,6 +311,7 @@ else if (platform === Platform.Linux) {
 		addBackend('Graphics4/OpenGL');
 		project.addLib('GL');
 		project.addLib('X11');
+		project.addLib('Xfixes');
 		project.addLib('Xinerama');
 		project.addDefine('KORE_OPENGL');
 	}


### PR DESCRIPTION
The previous method of hiding the mouse under Ubuntu 18.04 (although the new method should be just as compatible and Linux distribution independent) didn't work. So here is a method that does work but adds <X11/extensions/Xfixes.h>, is a bit cleaner code. Also hides the mouse cursor across the whole desktop, which may not be desirable behaviour.