### PR TITLE
colorWriteMask per render target

### DIFF
--- a/Backends/Graphics4/Direct3D11/Sources/Kore/PipelineStateImpl.cpp
+++ b/Backends/Graphics4/Direct3D11/Sources/Kore/PipelineStateImpl.cpp
@@ -445,9 +445,10 @@ void Graphics4::PipelineState::compile() {
 		rtbd.SrcBlendAlpha = convert(alphaBlendSource);
 		rtbd.DestBlendAlpha = convert(alphaBlendDestination);
 		rtbd.BlendOpAlpha = D3D11_BLEND_OP_ADD;
-		rtbd.RenderTargetWriteMask = (((colorWriteMaskRed ? D3D11_COLOR_WRITE_ENABLE_RED : 0) | (colorWriteMaskGreen ? D3D11_COLOR_WRITE_ENABLE_GREEN : 0)) |
-		                              (colorWriteMaskBlue ? D3D11_COLOR_WRITE_ENABLE_BLUE : 0)) |
-		                             (colorWriteMaskAlpha ? D3D11_COLOR_WRITE_ENABLE_ALPHA : 0);
+		rtbd.RenderTargetWriteMask = (((colorWriteMaskRed[0] ? D3D11_COLOR_WRITE_ENABLE_RED : 0) |
+		                               (colorWriteMaskGreen[0] ? D3D11_COLOR_WRITE_ENABLE_GREEN : 0)) |
+		                               (colorWriteMaskBlue[0] ? D3D11_COLOR_WRITE_ENABLE_BLUE : 0)) |
+		                               (colorWriteMaskAlpha[0] ? D3D11_COLOR_WRITE_ENABLE_ALPHA : 0);
 
 		D3D11_BLEND_DESC blendDesc;
 		ZeroMemory(&blendDesc, sizeof(blendDesc));

--- a/Backends/Graphics4/Direct3D9/Sources/Kore/PipelineStateImpl.cpp
+++ b/Backends/Graphics4/Direct3D9/Sources/Kore/PipelineStateImpl.cpp
@@ -170,10 +170,10 @@ void PipelineStateImpl::set(Graphics4::PipelineState* pipeline) {
 	Microsoft::affirm(device->SetVertexShaderConstantF(halfPixelLocation, floats, 1));
 
 	DWORD flags = 0;
-	if (pipeline->colorWriteMaskRed) flags |= D3DCOLORWRITEENABLE_RED;
-	if (pipeline->colorWriteMaskGreen) flags |= D3DCOLORWRITEENABLE_GREEN;
-	if (pipeline->colorWriteMaskBlue) flags |= D3DCOLORWRITEENABLE_BLUE;
-	if (pipeline->colorWriteMaskAlpha) flags |= D3DCOLORWRITEENABLE_ALPHA;
+	if (pipeline->colorWriteMaskRed[0]) flags |= D3DCOLORWRITEENABLE_RED;
+	if (pipeline->colorWriteMaskGreen[0]) flags |= D3DCOLORWRITEENABLE_GREEN;
+	if (pipeline->colorWriteMaskBlue[0]) flags |= D3DCOLORWRITEENABLE_BLUE;
+	if (pipeline->colorWriteMaskAlpha[0]) flags |= D3DCOLORWRITEENABLE_ALPHA;
 
 	device->SetRenderState(D3DRS_COLORWRITEENABLE, flags);
 

--- a/Backends/Graphics4/OpenGL/Sources/Kore/PipelineStateImpl.cpp
+++ b/Backends/Graphics4/OpenGL/Sources/Kore/PipelineStateImpl.cpp
@@ -237,7 +237,11 @@ void PipelineStateImpl::set(Graphics4::PipelineState* pipeline) {
 		glStencilFunc(stencilFunc, pipeline->stencilReferenceValue, pipeline->stencilReadMask);
 	}
 
-	glColorMask(pipeline->colorWriteMaskRed, pipeline->colorWriteMaskGreen, pipeline->colorWriteMaskBlue, pipeline->colorWriteMaskAlpha);
+	#ifdef KORE_OPENGL_ES
+	glColorMask(pipeline->colorWriteMaskRed[0], pipeline->colorWriteMaskGreen[0], pipeline->colorWriteMaskBlue[0], pipeline->colorWriteMaskAlpha[0]);
+	#else
+	for (int i = 0; i < 8; ++i) glColorMaski(i, pipeline->colorWriteMaskRed[i], pipeline->colorWriteMaskGreen[i], pipeline->colorWriteMaskBlue[i], pipeline->colorWriteMaskAlpha[i]);
+	#endif
 
 	if (supportsConservativeRaster) {
 		if (pipeline->conservativeRasterization) {

--- a/Sources/Kore/Graphics4/PipelineState.cpp
+++ b/Sources/Kore/Graphics4/PipelineState.cpp
@@ -36,10 +36,10 @@ Graphics4::PipelineState::PipelineState() {
 	alphaBlendDestination = BlendZero;
 	// alphaBlendOperation = BlendingOperation.Add;
 
-	colorWriteMaskRed = true;
-	colorWriteMaskGreen = true;
-	colorWriteMaskBlue = true;
-	colorWriteMaskAlpha = true;
+	for (int i = 0; i < 8; ++i) colorWriteMaskRed[i] = true;
+	for (int i = 0; i < 8; ++i) colorWriteMaskGreen[i] = true;
+	for (int i = 0; i < 8; ++i) colorWriteMaskBlue[i] = true;
+	for (int i = 0; i < 8; ++i) colorWriteMaskAlpha[i] = true;
 
 	conservativeRasterization = false;
 }

--- a/Sources/Kore/Graphics4/PipelineState.h
+++ b/Sources/Kore/Graphics4/PipelineState.h
@@ -44,10 +44,10 @@ namespace Kore {
 			BlendingOperation alphaBlendDestination;
 			// BlendingOperation alphaBlendOperation;
 
-			bool colorWriteMaskRed;
-			bool colorWriteMaskGreen;
-			bool colorWriteMaskBlue;
-			bool colorWriteMaskAlpha;
+			bool colorWriteMaskRed[8]; // Per render target
+			bool colorWriteMaskGreen[8];
+			bool colorWriteMaskBlue[8];
+			bool colorWriteMaskAlpha[8];
 
 			bool conservativeRasterization;
 

--- a/Sources/Kore/Graphics5/PipelineState.cpp
+++ b/Sources/Kore/Graphics5/PipelineState.cpp
@@ -33,10 +33,10 @@ Graphics5::PipelineState::PipelineState() {
 	alphaBlendDestination = BlendZero;
 	// alphaBlendOperation = BlendingOperation.Add;
 
-	colorWriteMaskRed = true;
-	colorWriteMaskGreen = true;
-	colorWriteMaskBlue = true;
-	colorWriteMaskAlpha = true;
+	for (int i = 0; i < 8; ++i) colorWriteMaskRed[i] = true;
+	for (int i = 0; i < 8; ++i) colorWriteMaskGreen[i] = true;
+	for (int i = 0; i < 8; ++i) colorWriteMaskBlue[i] = true;
+	for (int i = 0; i < 8; ++i) colorWriteMaskAlpha[i] = true;
 }
 
 Graphics5::PipelineState::~PipelineState() {}

--- a/Sources/Kore/Graphics5/PipelineState.h
+++ b/Sources/Kore/Graphics5/PipelineState.h
@@ -43,10 +43,10 @@ namespace Kore {
 			BlendingOperation alphaBlendDestination;
 			// BlendingOperation alphaBlendOperation;
 
-			bool colorWriteMaskRed;
-			bool colorWriteMaskGreen;
-			bool colorWriteMaskBlue;
-			bool colorWriteMaskAlpha;
+			bool colorWriteMaskRed[8]; // Per render target
+			bool colorWriteMaskGreen[8];
+			bool colorWriteMaskBlue[8];
+			bool colorWriteMaskAlpha[8];
 
 			bool conservativeRasterization;
 


### PR DESCRIPTION
Allows to set color write mask for individual render targets when using MRT.

Current:
```c
pipeline->colorWriteMaskRed = false;
```

Patch:
```c
pipeline->colorWriteMaskRed[0] = false; // First render target
pipeline->colorWriteMaskRed[1] = true; // Second render target
```
