### PR TITLE
Fix shader delete for OpenGL

### DIFF
--- a/Backends/Graphics4/OpenGL/Sources/Kore/ShaderImpl.cpp
+++ b/Backends/Graphics4/OpenGL/Sources/Kore/ShaderImpl.cpp
@@ -22,10 +22,8 @@ ShaderImpl::ShaderImpl(void* data, int length) : length(length), _glid(0), fromS
 ShaderImpl::ShaderImpl(const char* source) : source(source), length((int)strlen(source)), _glid(0), fromSource(true) {}
 
 ShaderImpl::~ShaderImpl() {
-	if (!fromSource) {
-		delete[] source;
-		source = nullptr;
-	}
+	if (!fromSource) delete[] source;
+	source = nullptr;
 	if (_glid != 0) glDeleteShader(_glid);
 }
 

--- a/Backends/Graphics4/OpenGL/Sources/Kore/ShaderImpl.cpp
+++ b/Backends/Graphics4/OpenGL/Sources/Kore/ShaderImpl.cpp
@@ -10,7 +10,7 @@
 
 using namespace Kore;
 
-ShaderImpl::ShaderImpl(void* data, int length) : length(length), _glid(0) {
+ShaderImpl::ShaderImpl(void* data, int length) : length(length), _glid(0), fromSource(false) {
 	char* source = new char[length + 1];
 	for (int i = 0; i < length; ++i) {
 		source[i] = ((char*)data)[i];
@@ -19,11 +19,13 @@ ShaderImpl::ShaderImpl(void* data, int length) : length(length), _glid(0) {
 	this->source = source;
 }
 
-ShaderImpl::ShaderImpl(const char* source) : source(source), length((int)strlen(source)), _glid(0) {}
+ShaderImpl::ShaderImpl(const char* source) : source(source), length((int)strlen(source)), _glid(0), fromSource(true) {}
 
 ShaderImpl::~ShaderImpl() {
-	delete[] source;
-	source = nullptr;
+	if (!fromSource) {
+		delete[] source;
+		source = nullptr;
+	}
 	if (_glid != 0) glDeleteShader(_glid);
 }
 

--- a/Backends/Graphics4/OpenGL/Sources/Kore/ShaderImpl.h
+++ b/Backends/Graphics4/OpenGL/Sources/Kore/ShaderImpl.h
@@ -15,6 +15,7 @@ namespace Kore {
 		uint _glid;
 		const char* source;
 		int length;
+		bool fromSource;
 		friend class Graphics4::PipelineState;
 		friend class PipelineStateImpl;
 	};


### PR DESCRIPTION
Only delete `source` if it was allocated in the class, otherwise bad things happen.