### PR TITLE
fix delete from render target  Direct3D11

### DIFF
--- a/Backends/Graphics4/Direct3D11/Sources/Kore/RenderTargetImpl.cpp
+++ b/Backends/Graphics4/Direct3D11/Sources/Kore/RenderTargetImpl.cpp
@@ -313,11 +313,12 @@ Graphics4::RenderTarget::RenderTarget(int cubeMapSize, int depthBufferBits, bool
 Graphics4::RenderTarget::~RenderTarget() {
 	for (int i = 0; i < 6; i++) {
 		if (renderTargetViewRender[i] != nullptr) renderTargetViewRender[i]->Release();
-		if (renderTargetViewSample[i] != nullptr) renderTargetViewSample[i]->Release();
+		if (renderTargetViewSample[i] != nullptr && renderTargetViewSample[i] != renderTargetViewRender[i]) renderTargetViewSample[i]->Release();
 		if (depthStencilView[i] != nullptr) depthStencilView[i]->Release();
 	}
 	if (renderTargetSRV != nullptr) renderTargetSRV->Release();
 	if (depthStencilSRV != nullptr) depthStencilSRV->Release();
+	if (textureRender != nullptr) textureRender->Release();
 }
 
 void Graphics4::RenderTarget::useColorAsTexture(TextureUnit unit) {


### PR DESCRIPTION
Ignore if renderTargetViewSample[i] its the same pointer of renderTargetViewRender[i] to avoid error when Releaseing (see line 241)
Plus release from GPU memory all stuff from the render target when deleted Direct3D11