### PR TITLE
D3D11 texture mipmaps

### DIFF
--- a/Backends/Graphics4/Direct3D11/Sources/Kore/Direct3D11.winrt.cpp
+++ b/Backends/Graphics4/Direct3D11/Sources/Kore/Direct3D11.winrt.cpp
@@ -803,6 +803,7 @@ void Graphics4::setTextureMagnificationFilter(TextureUnit unit, TextureFilter fi
 	}
 
 	lastSamplers[unit.unit].Filter = d3d11filter;
+	lastSamplers[unit.unit].MaxAnisotropy = d3d11filter == D3D11_FILTER_ANISOTROPIC ? D3D11_REQ_MAXANISOTROPY : 0;
 
 	ID3D11SamplerState* sampler = getSamplerState(lastSamplers[unit.unit]);
 	context->PSSetSamplers(unit.unit, 1, &sampler);
@@ -866,6 +867,7 @@ void Graphics4::setTextureMinificationFilter(TextureUnit unit, TextureFilter fil
 	}
 
 	lastSamplers[unit.unit].Filter = d3d11filter;
+	lastSamplers[unit.unit].MaxAnisotropy = d3d11filter == D3D11_FILTER_ANISOTROPIC ? D3D11_REQ_MAXANISOTROPY : 0;
 
 	ID3D11SamplerState* sampler = getSamplerState(lastSamplers[unit.unit]);
 	context->PSSetSamplers(unit.unit, 1, &sampler);
@@ -929,6 +931,7 @@ void Graphics4::setTextureMipmapFilter(TextureUnit unit, MipmapFilter filter) {
 	}
 
 	lastSamplers[unit.unit].Filter = d3d11filter;
+	lastSamplers[unit.unit].MaxAnisotropy = d3d11filter == D3D11_FILTER_ANISOTROPIC ? D3D11_REQ_MAXANISOTROPY : 0;
 
 	ID3D11SamplerState* sampler = getSamplerState(lastSamplers[unit.unit]);
 	context->PSSetSamplers(unit.unit, 1, &sampler);

--- a/Backends/Graphics4/Direct3D11/Sources/Kore/TextureImpl.h
+++ b/Backends/Graphics4/Direct3D11/Sources/Kore/TextureImpl.h
@@ -13,11 +13,13 @@ namespace Kore {
 
 	class TextureImpl {
 	public:
+		TextureImpl();
 		~TextureImpl();
+		void enableMipmaps(int texWidth, int texHeight, int format);
 		void unmipmap();
 		void unset();
 
-		bool mipmap;
+		bool hasMipmaps;
 		int stage;
 		ID3D11Texture2D* texture;
 		ID3D11ShaderResourceView* view;


### PR DESCRIPTION
- `Texture::generateMipmaps()` works now
- `Texture::setMipmap()` works now
- Anisotropic filter + `Texture::generateMipmaps()` gives perfect results

We can make this a little nicer by adding a mipmaps option when creating an image (right now it has to create a new texture resource), but I think it's better to tackle it together with some general textures api cleanup.