### PR TITLE
Fixes OpenGL error messages when calling Graphics4::setVertexBuffers …

### DIFF
--- a/Backends/Graphics4/OpenGL/Sources/Kore/VertexBufferImpl.cpp
+++ b/Backends/Graphics4/OpenGL/Sources/Kore/VertexBufferImpl.cpp
@@ -211,8 +211,9 @@ int VertexBufferImpl::setVertexAttributes(int offset) {
 			break;
 		}
 	}
-	for (int index = actualIndex; index < 16; ++index) {
-		glDisableVertexAttribArray(offset + index); // TODO: Can cause problems, please anaylze
+	int count = 16 - offset;
+	for (int index = actualIndex; index < count; ++index) {
+		glDisableVertexAttribArray(offset + index);
 		glCheckErrors();
 	}
 	return actualIndex;


### PR DESCRIPTION
…with more than one buffer. I think an even cleaner way would be to use the value returned from GL_MAX_VERTEX_ATTRIBS instead of the hardcoded 16, but I couldn't find the time to fully explore this yet.