### PR TITLE
Fix data-length in HTTP requests under Windows

### DIFF
--- a/Backends/System/Windows/Sources/Kore/Http.cpp
+++ b/Backends/System/Windows/Sources/Kore/Http.cpp
@@ -58,7 +58,7 @@ void Kore::httpRequest(const char* url, const char* path, const char* data, int 
 		if (header) {
 			MultiByteToWideChar(CP_UTF8, 0, header, -1, wheader, 4096);
 		}
-		DWORD optionalLength = (data != 0 && strlen(data) > 0) ? (DWORD)strlen(data) + 1 : 0;
+		DWORD optionalLength = (data != 0 && strlen(data) > 0) ? (DWORD)strlen(data) : 0;
 		bResults = WinHttpSendRequest(hRequest, header == 0 ? WINHTTP_NO_ADDITIONAL_HEADERS : wheader, header == 0 ? 0 : -1L,
 		                              data == 0 ? WINHTTP_NO_REQUEST_DATA : (LPVOID)data, optionalLength, optionalLength, 0);
 	}


### PR DESCRIPTION
When sending a data string in an HTTP request under Windows the data-length is one off.
Steps to reproduce:
- Send a simple PUT request with data to localhost
- Analyze network packages (for example with wireshark)
- Compare the data-length field with the actual data or with the same field in the html5 version