### PR TITLE
Work around the internal counter of ShowCursor.

### DIFF
--- a/Backends/System/Windows/Sources/Kore/Input/Mouse.cpp
+++ b/Backends/System/Windows/Sources/Kore/Input/Mouse.cpp
@@ -28,7 +28,11 @@ bool Mouse::canLock(int windowId) {
 }
 
 void Mouse::show(bool truth) {
-	ShowCursor(truth);
+  // Work around the internal counter of ShowCursor
+	if (truth)
+		while (ShowCursor(truth) < 0);
+	else
+		while (ShowCursor(truth) >= 0);
 }
 
 void Mouse::setPosition(int windowId, int x, int y) {


### PR DESCRIPTION
As discussed - the internal counter of ShowCursor can lead to unexpected behavior when calling Mouse::show multiple times.