### PR TITLE
D3D12 & G4onG5 work

### DIFF
--- a/Backends/Graphics4/G4onG5/Sources/Kore/G4.c
+++ b/Backends/Graphics4/G4onG5/Sources/Kore/G4.c
@@ -24,8 +24,10 @@ uint64_t frameNumber = 0;
 bool waitAfterNextDraw = false;
 
 #define bufferCount 2
+#define renderTargetCount 8
 static int currentBuffer = -1;
 static kinc_g5_render_target_t framebuffers[bufferCount];
+static kinc_g5_render_target_t *currentRenderTargets[renderTargetCount];
 
 static kinc_g5_constant_buffer_t vertexConstantBuffer;
 static kinc_g5_constant_buffer_t fragmentConstantBuffer;
@@ -99,7 +101,7 @@ void kinc_g4_set_texture3d_addressing(kinc_g4_texture_unit_t unit, kinc_g4_textu
 }
 
 void kinc_g4_clear(unsigned flags, unsigned color, float depth, int stencil) {
-	kinc_g5_command_list_clear(&commandList, &framebuffers[currentBuffer], flags, color, depth, stencil);
+	kinc_g5_command_list_clear(&commandList, currentRenderTargets[0], flags, color, depth, stencil);
 }
 
 void kinc_g4_begin(int window) {
@@ -268,17 +270,16 @@ bool kinc_g4_non_pow2_textures_supported() {
 }
 
 void kinc_g4_restore_render_target() {
-	kinc_g5_render_target_t *renderTargets[1] = {&framebuffers[currentBuffer]};
-	kinc_g5_command_list_set_render_targets(&commandList, renderTargets, 1);
+	currentRenderTargets[0] = &framebuffers[currentBuffer];
+	kinc_g5_command_list_set_render_targets(&commandList, currentRenderTargets, 1);
 }
 
 void kinc_g4_set_render_targets(kinc_g4_render_target_t **targets, int count) {
-	kinc_g5_render_target_t *renderTargets[16];
 	for (int i = 0; i < count; ++i) {
-		renderTargets[i] = &targets[i]->impl._renderTarget;
-		kinc_g5_command_list_texture_to_render_target_barrier(&commandList, renderTargets[i]);
+		currentRenderTargets[i] = &targets[i]->impl._renderTarget;
+		kinc_g5_command_list_texture_to_render_target_barrier(&commandList, currentRenderTargets[i]);
 	}
-	kinc_g5_command_list_set_render_targets(&commandList, renderTargets, count);
+	kinc_g5_command_list_set_render_targets(&commandList, currentRenderTargets, count);
 }
 
 void kinc_g4_set_render_target_face(kinc_g4_render_target_t *texture, int face) {

--- a/Backends/Graphics4/G4onG5/Sources/Kore/G4.c
+++ b/Backends/Graphics4/G4onG5/Sources/Kore/G4.c
@@ -112,6 +112,7 @@ void kinc_g4_begin(int window) {
 	currentBuffer = (currentBuffer + 1) % bufferCount;
 
 	kinc_g5_begin(&framebuffers[currentBuffer], window);
+	currentRenderTargets[0] = &framebuffers[currentBuffer];
 	// commandList = new Graphics5::CommandList;
 	kinc_g5_command_list_begin(&commandList);
 	kinc_g5_command_list_framebuffer_to_render_target_barrier(&commandList, &framebuffers[currentBuffer]);

--- a/Backends/Graphics4/G4onG5/Sources/Kore/PipelineStateImpl.c
+++ b/Backends/Graphics4/G4onG5/Sources/Kore/PipelineStateImpl.c
@@ -7,6 +7,7 @@
 #include <kinc/graphics4/shader.h>
 
 void kinc_g4_pipeline_init(kinc_g4_pipeline_t *pipe) {
+	kinc_g4_internal_pipeline_set_defaults(pipe);
 	kinc_g5_pipeline_init(&pipe->impl._pipeline);
 }
 

--- a/Backends/Graphics4/G4onG5/Sources/Kore/TextureImpl.c
+++ b/Backends/Graphics4/G4onG5/Sources/Kore/TextureImpl.c
@@ -12,6 +12,8 @@ void kinc_g4_texture_init_from_image(kinc_g4_texture_t *texture, kinc_image_t *i
 	kinc_g5_texture_init_from_image(&texture->impl._texture, image);
 	texture->tex_width = texture->impl._texture.texWidth;
 	texture->tex_height = texture->impl._texture.texHeight;
+	texture->tex_depth = 1;
+	texture->format = image->format;
 }
 
 void kinc_g4_texture_init_from_image3d(kinc_g4_texture_t *texture, kinc_image_t *image) {}
@@ -21,6 +23,8 @@ void kinc_g4_texture_init(kinc_g4_texture_t *texture, int width, int height, kin
 	kinc_g5_texture_init(&texture->impl._texture, width, height, format);
 	texture->tex_width = texture->impl._texture.texWidth;
 	texture->tex_height = texture->impl._texture.texHeight;
+	texture->tex_depth = 1;
+	texture->format = format;
 }
 
 void kinc_g4_texture_init3d(kinc_g4_texture_t *texture, int width, int height, int depth, kinc_image_format_t format) {}

--- a/Backends/Graphics4/G4onG5/Sources/Kore/TextureImpl.c
+++ b/Backends/Graphics4/G4onG5/Sources/Kore/TextureImpl.c
@@ -14,6 +14,8 @@ void kinc_g4_texture_init_from_image(kinc_g4_texture_t *texture, kinc_image_t *i
 	texture->tex_height = texture->impl._texture.texHeight;
 }
 
+void kinc_g4_texture_init_from_image3d(kinc_g4_texture_t *texture, kinc_image_t *image) {}
+
 void kinc_g4_texture_init(kinc_g4_texture_t *texture, int width, int height, kinc_image_format_t format) {
 	texture->impl._uploaded = false;
 	kinc_g5_texture_init(&texture->impl._texture, width, height, format);

--- a/Backends/Graphics5/Direct3D12/Sources/Kore/Direct3D12.cpp
+++ b/Backends/Graphics5/Direct3D12/Sources/Kore/Direct3D12.cpp
@@ -285,12 +285,13 @@ namespace {
 
 void kinc_g5_destroy(int window) {}
 
-void kinc_g5_init(int window, int depthBufferBits, int stencilBufferBits, bool vsync) {
+void kinc_g5_init(int window, int depthBufferBits, int stencilBufferBits, bool verticalSync) {
 #ifdef KORE_WINDOWS
 	HWND hwnd = kinc_windows_window_handle(window);
 #else
 	HWND hwnd = nullptr;
 #endif
+	vsync = verticalSync;
 	renderTargetWidth = kinc_width();
 	renderTargetHeight = kinc_height();
 	initialize(renderTargetWidth, renderTargetHeight, hwnd);
@@ -394,7 +395,7 @@ void Graphics5::setTextureMagnificationFilter(TextureUnit texunit, TextureFilter
 	bilinearFiltering = filter != TextureFilter::PointFilter;
 }
 bool kinc_g5_swap_buffers() {
-	kinc_microsoft_affirm(swapChain->Present(1, 0));
+	kinc_microsoft_affirm(swapChain->Present(vsync, 0));
 	return true;
 }
 

--- a/Backends/Graphics5/Direct3D12/Sources/Kore/Direct3D12.cpp
+++ b/Backends/Graphics5/Direct3D12/Sources/Kore/Direct3D12.cpp
@@ -391,9 +391,6 @@ extern "C" void kinc_internal_resize(int window, int width, int height) {}
 
 extern "C" void kinc_internal_change_framebuffer(int window, kinc_framebuffer_options_t *frame) {}
 
-void Graphics5::setTextureMagnificationFilter(TextureUnit texunit, TextureFilter filter) {
-	bilinearFiltering = filter != TextureFilter::PointFilter;
-}
 bool kinc_g5_swap_buffers() {
 	kinc_microsoft_affirm(swapChain->Present(vsync, 0));
 	return true;
@@ -403,9 +400,13 @@ void kinc_g5_flush() {}
 
 void kinc_g5_set_texture_operation(kinc_g5_texture_operation_t operation, kinc_g5_texture_argument_t arg1, kinc_g5_texture_argument_t arg2) {}
 
-void kinc_g5_set_texture_magnification_filter(kinc_g5_texture_unit_t texunit, kinc_g5_texture_filter_t filter) {}
+void kinc_g5_set_texture_magnification_filter(kinc_g5_texture_unit_t texunit, kinc_g5_texture_filter_t filter) {
+	bilinearFiltering = filter != KINC_G5_TEXTURE_FILTER_POINT;
+}
 
-void kinc_g5_set_texture_minification_filter(kinc_g5_texture_unit_t texunit, kinc_g5_texture_filter_t filter) {}
+void kinc_g5_set_texture_minification_filter(kinc_g5_texture_unit_t texunit, kinc_g5_texture_filter_t filter) {
+	bilinearFiltering = filter != KINC_G5_TEXTURE_FILTER_POINT;
+}
 
 void kinc_g5_set_texture_mipmap_filter(kinc_g5_texture_unit_t texunit, kinc_g5_mipmap_filter_t filter) {}
 

--- a/Backends/Graphics5/Direct3D12/Sources/Kore/Direct3D12.cpp
+++ b/Backends/Graphics5/Direct3D12/Sources/Kore/Direct3D12.cpp
@@ -70,7 +70,7 @@ struct RenderEnvironment {
 void createSwapChain(RenderEnvironment* env, const DXGI_SWAP_CHAIN_DESC1* desc);
 #endif
 
-void createSamplers();
+void createSamplersAndHeaps();
 extern bool bilinearFiltering;
 
 namespace {
@@ -221,7 +221,7 @@ namespace {
 		kinc_microsoft_affirm(D3D12SerializeRootSignature(&descRootSignature, D3D_ROOT_SIGNATURE_VERSION_1, &rootBlob, &errorBlob));
 		device->CreateRootSignature(0, rootBlob->GetBufferPointer(), rootBlob->GetBufferSize(), IID_GRAPHICS_PPV_ARGS(&rootSignature));
 
-		createSamplers();
+		createSamplersAndHeaps();
 	}
 
 	void initialize(int width, int height, HWND window) {

--- a/Backends/Graphics5/Direct3D12/Sources/Kore/PipelineState5Impl.cpp
+++ b/Backends/Graphics5/Direct3D12/Sources/Kore/PipelineState5Impl.cpp
@@ -40,11 +40,7 @@ void kinc_g5_internal_setConstants(ID3D12GraphicsCommandList *commandList, kinc_
 }
 
 void kinc_g5_pipeline_init(kinc_g5_pipeline_t *pipe) {
-	pipe->vertexShader = nullptr;
-	pipe->fragmentShader = nullptr;
-	pipe->geometryShader = nullptr;
-	pipe->tessellationEvaluationShader = nullptr;
-	pipe->tessellationControlShader = nullptr;
+	kinc_g5_internal_pipeline_init(pipe);
 }
 
 void kinc_g5_pipeline_destroy(kinc_g5_pipeline_t *pipe) {

--- a/Backends/Graphics5/Direct3D12/Sources/Kore/RenderTarget5Impl.cpp
+++ b/Backends/Graphics5/Direct3D12/Sources/Kore/RenderTarget5Impl.cpp
@@ -64,10 +64,11 @@ static DXGI_FORMAT convertFormat(kinc_g5_render_target_format_t format) {
 
 void kinc_g5_render_target_init(kinc_g5_render_target_t *render_target, int width, int height, int depthBufferBits, bool antialiasing,
                                 kinc_g5_render_target_format_t format, int stencilBufferBits,
-                                      int contextId) {
+                                int contextId) {
 	render_target->texWidth = render_target->width = width;
 	render_target->texHeight = render_target->height = height;
 	render_target->impl.stage = 0;
+	render_target->impl.stage_depth = -1;
 
 	render_target->impl.resourceState = RenderTargetResourceStateUndefined;
 
@@ -167,8 +168,9 @@ void kinc_g5_render_target_init(kinc_g5_render_target_t *render_target, int widt
 }
 
 void kinc_g5_render_target_init_cube(kinc_g5_render_target_t *render_target, int cubeMapSize, int depthBufferBits, bool antialiasing, kinc_g5_render_target_format_t format, int stencilBufferBits,
-                                      int contextId) {
+                                     int contextId) {
 	render_target->impl.stage = 0;
+	render_target->impl.stage_depth = -1;
 }
 
 void kinc_g5_render_target_destroy(kinc_g5_render_target_t *render_target) {
@@ -180,30 +182,8 @@ void kinc_g5_render_target_destroy(kinc_g5_render_target_t *render_target) {
 	render_target->impl.srvDescriptorHeap->Release();
 }
 
-namespace {
-	void graphicsFlushAndWait() {
-		/*commandList->Close();
-
-		ID3D12CommandList* commandLists[] = {commandList};
-		commandQueue->ExecuteCommandLists(std::extent<decltype(commandLists)>::value, commandLists);
-
-		const UINT64 fenceValue = currentFenceValue;
-		commandQueue->Signal(frameFences[currentBackBuffer], fenceValue);
-		fenceValues[currentBackBuffer] = fenceValue;
-		++currentFenceValue;
-
-		waitForFence(frameFences[currentBackBuffer], fenceValues[currentBackBuffer], frameFenceEvents[currentBackBuffer]);
-
-		commandList->Reset(commandAllocators[currentBackBuffer], nullptr);
-		commandList->OMSetRenderTargets(1, &renderTargetDescriptorHeap->GetCPUDescriptorHandleForHeapStart(), true, nullptr);
-		commandList->RSSetViewports(1, &viewport);
-		commandList->RSSetScissorRects(1, &rectScissor);*/
-	}
-}
-
 void kinc_g5_render_target_use_color_as_texture(kinc_g5_render_target_t *render_target, kinc_g5_texture_unit_t unit) {
 	if (unit.impl.unit < 0) return;
-	graphicsFlushAndWait();
 	render_target->impl.stage = unit.impl.unit;
 	currentRenderTargets[render_target->impl.stage] = render_target;
 	currentTextures[render_target->impl.stage] = nullptr;
@@ -211,7 +191,6 @@ void kinc_g5_render_target_use_color_as_texture(kinc_g5_render_target_t *render_
 
 void kinc_g5_render_target_use_depth_as_texture(kinc_g5_render_target_t *render_target, kinc_g5_texture_unit_t unit) {
 	if (unit.impl.unit < 0) return;
-	graphicsFlushAndWait();
 	render_target->impl.stage_depth = unit.impl.unit;
 	currentRenderTargets[render_target->impl.stage_depth] = render_target;
 	currentTextures[render_target->impl.stage_depth] = nullptr;

--- a/Backends/Graphics5/Direct3D12/Sources/Kore/RenderTarget5Impl.cpp
+++ b/Backends/Graphics5/Direct3D12/Sources/Kore/RenderTarget5Impl.cpp
@@ -98,7 +98,7 @@ void kinc_g5_render_target_init(kinc_g5_render_target_t *render_target, int widt
 
 	descriptorHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
 	descriptorHeapDesc.NodeMask = 0;
-	descriptorHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE;
+	descriptorHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
 
 	device->CreateDescriptorHeap(&descriptorHeapDesc, IID_GRAPHICS_PPV_ARGS(&render_target->impl.srvDescriptorHeap));
 
@@ -121,7 +121,7 @@ void kinc_g5_render_target_init(kinc_g5_render_target_t *render_target, int widt
 		device->CreateDescriptorHeap(&dsvHeapDesc, IID_GRAPHICS_PPV_ARGS(&render_target->impl.depthStencilDescriptorHeap));
 
 		CD3DX12_RESOURCE_DESC depthTexture(D3D12_RESOURCE_DIMENSION_TEXTURE2D, 0, width, height, 1, 1, DXGI_FORMAT_D32_FLOAT, 1, 0,
-		                                   D3D12_TEXTURE_LAYOUT_UNKNOWN, D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL | D3D12_RESOURCE_FLAG_DENY_SHADER_RESOURCE);
+		                                   D3D12_TEXTURE_LAYOUT_UNKNOWN, D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL);
 
 		D3D12_CLEAR_VALUE clearValue;
 		clearValue.Format = DXGI_FORMAT_D32_FLOAT;
@@ -133,10 +133,28 @@ void kinc_g5_render_target_init(kinc_g5_render_target_t *render_target, int widt
 
 		device->CreateDepthStencilView(render_target->impl.depthStencilTexture, nullptr,
 		                               render_target->impl.depthStencilDescriptorHeap->GetCPUDescriptorHandleForHeapStart());
+
+		D3D12_DESCRIPTOR_HEAP_DESC srvDepthHeapDesc = {};
+		srvDepthHeapDesc.NumDescriptors = 1;
+		srvDepthHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;
+		srvDepthHeapDesc.NodeMask = 0;
+		srvDepthHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
+		device->CreateDescriptorHeap(&srvDepthHeapDesc, IID_GRAPHICS_PPV_ARGS(&render_target->impl.srvDepthDescriptorHeap));
+
+		D3D12_SHADER_RESOURCE_VIEW_DESC srvDepthViewDesc = {};
+		srvDepthViewDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
+		srvDepthViewDesc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
+		srvDepthViewDesc.Format = DXGI_FORMAT_R32_FLOAT;
+		srvDepthViewDesc.Texture2D.MipLevels = 1;
+		srvDepthViewDesc.Texture2D.MostDetailedMip = 0;
+		srvDepthViewDesc.Texture2D.ResourceMinLODClamp = 0.0f;
+		device->CreateShaderResourceView(render_target->impl.depthStencilTexture, &srvDepthViewDesc,
+		                                 render_target->impl.srvDepthDescriptorHeap->GetCPUDescriptorHandleForHeapStart());
 	}
 	else {
 		render_target->impl.depthStencilDescriptorHeap = nullptr;
 		render_target->impl.depthStencilTexture = nullptr;
+		render_target->impl.srvDepthDescriptorHeap = nullptr;
 	}
 
 	render_target->impl.scissor = {0, 0, width, height};
@@ -191,6 +209,12 @@ void kinc_g5_render_target_use_color_as_texture(kinc_g5_render_target_t *render_
 	currentTextures[render_target->impl.stage] = nullptr;
 }
 
-void kinc_g5_render_target_use_depth_as_texture(kinc_g5_render_target_t *render_target, kinc_g5_texture_unit_t unit) {}
+void kinc_g5_render_target_use_depth_as_texture(kinc_g5_render_target_t *render_target, kinc_g5_texture_unit_t unit) {
+	if (unit.impl.unit < 0) return;
+	graphicsFlushAndWait();
+	render_target->impl.stage_depth = unit.impl.unit;
+	currentRenderTargets[render_target->impl.stage_depth] = render_target;
+	currentTextures[render_target->impl.stage_depth] = nullptr;
+}
 
 void kinc_g5_render_target_set_depth_stencil_from(kinc_g5_render_target_t *render_target, kinc_g5_render_target_t *source) {}

--- a/Backends/Graphics5/Direct3D12/Sources/Kore/RenderTarget5Impl.cpp
+++ b/Backends/Graphics5/Direct3D12/Sources/Kore/RenderTarget5Impl.cpp
@@ -180,6 +180,11 @@ void kinc_g5_render_target_destroy(kinc_g5_render_target_t *render_target) {
 	render_target->impl.renderTarget->Release();
 	render_target->impl.renderTargetDescriptorHeap->Release();
 	render_target->impl.srvDescriptorHeap->Release();
+	if (render_target->impl.depthStencilTexture != NULL) {
+		render_target->impl.depthStencilTexture->Release();
+		render_target->impl.depthStencilDescriptorHeap->Release();
+		render_target->impl.srvDepthDescriptorHeap->Release();
+	}
 }
 
 void kinc_g5_render_target_use_color_as_texture(kinc_g5_render_target_t *render_target, kinc_g5_texture_unit_t unit) {

--- a/Backends/Graphics5/Direct3D12/Sources/Kore/RenderTarget5Impl.cpp
+++ b/Backends/Graphics5/Direct3D12/Sources/Kore/RenderTarget5Impl.cpp
@@ -217,4 +217,8 @@ void kinc_g5_render_target_use_depth_as_texture(kinc_g5_render_target_t *render_
 	currentTextures[render_target->impl.stage_depth] = nullptr;
 }
 
-void kinc_g5_render_target_set_depth_stencil_from(kinc_g5_render_target_t *render_target, kinc_g5_render_target_t *source) {}
+void kinc_g5_render_target_set_depth_stencil_from(kinc_g5_render_target_t *render_target, kinc_g5_render_target_t *source) {
+	render_target->impl.depthStencilDescriptorHeap = source->impl.depthStencilDescriptorHeap;
+	render_target->impl.srvDepthDescriptorHeap = source->impl.srvDepthDescriptorHeap;
+	render_target->impl.depthStencilTexture = source->impl.depthStencilTexture;
+}

--- a/Backends/Graphics5/Direct3D12/Sources/Kore/RenderTarget5Impl.h
+++ b/Backends/Graphics5/Direct3D12/Sources/Kore/RenderTarget5Impl.h
@@ -30,10 +30,12 @@ typedef struct {
 	struct ID3D12DescriptorHeap *renderTargetDescriptorHeap;
 	struct ID3D12DescriptorHeap *srvDescriptorHeap;
 	struct ID3D12DescriptorHeap *depthStencilDescriptorHeap;
+	struct ID3D12DescriptorHeap *srvDepthDescriptorHeap;
 	struct ID3D12Resource *depthStencilTexture;
 	struct D3D12Viewport viewport;
 	struct D3D12Rect scissor;
 	int stage;
+	int stage_depth;
 	enum RenderTargetResourceState resourceState;
 } RenderTarget5Impl;
 


### PR DESCRIPTION
Added a primitive descriptor heap handling at `kinc_g5_internal_set_textures`, still needs to be replaced with something proper. Can mostly run the whole deferred renderer on D3D12 now which is wild.