### PR TITLE
Option to use standard malloc for image load

### DIFF
--- a/Sources/kinc/image.c
+++ b/Sources/kinc/image.c
@@ -46,9 +46,11 @@ static void *buffer_realloc(void *p, size_t size) {
 
 static void buffer_free(void *p) {}
 
+#ifndef KINC_IMAGE_STANDARD_MALLOC
 #define STBI_MALLOC(sz) buffer_malloc(sz)
 #define STBI_REALLOC(p, newsz) buffer_realloc(p, newsz)
 #define STBI_FREE(p) buffer_free(p)
+#endif
 
 #define STB_IMAGE_IMPLEMENTATION
 #include <kinc/libs/stb_image.h>


### PR DESCRIPTION
Allows to handle loading big images (exceeding [BUFFER_SIZE](https://github.com/Kode/Kinc/blob/master/Sources/kinc/image.c#L17)) using standard allocators by defining `KINC_IMAGE_STANDARD_MALLOC`.

Related: https://github.com/Kode/Kinc/issues/407