### PR TITLE
Log tag for android

### DIFF
--- a/Sources/kinc/log.c
+++ b/Sources/kinc/log.c
@@ -43,13 +43,13 @@ void kinc_log_args(kinc_log_level_t level, const char *format, va_list args) {
 #ifdef KORE_ANDROID
 	switch (level) {
 	case KINC_LOG_LEVEL_INFO:
-		__android_log_vprint(ANDROID_LOG_INFO, kinc_application_name(), format, args);
+		__android_log_vprint(ANDROID_LOG_INFO, "kinc", format, args);
 		break;
 	case KINC_LOG_LEVEL_WARNING:
-		__android_log_vprint(ANDROID_LOG_WARN, kinc_application_name(), format, args);
+		__android_log_vprint(ANDROID_LOG_WARN, "kinc", format, args);
 		break;
 	case KINC_LOG_LEVEL_ERROR:
-		__android_log_vprint(ANDROID_LOG_ERROR, kinc_application_name(), format, args);
+		__android_log_vprint(ANDROID_LOG_ERROR, "kinc", format, args);
 		break;
 	}
 #endif

--- a/Sources/kinc/log.c
+++ b/Sources/kinc/log.c
@@ -43,13 +43,13 @@ void kinc_log_args(kinc_log_level_t level, const char *format, va_list args) {
 #ifdef KORE_ANDROID
 	switch (level) {
 	case KINC_LOG_LEVEL_INFO:
-		__android_log_vprint(ANDROID_LOG_INFO, "kinc", format, args);
+		__android_log_vprint(ANDROID_LOG_INFO, "Kinc", format, args);
 		break;
 	case KINC_LOG_LEVEL_WARNING:
-		__android_log_vprint(ANDROID_LOG_WARN, "kinc", format, args);
+		__android_log_vprint(ANDROID_LOG_WARN, "Kinc", format, args);
 		break;
 	case KINC_LOG_LEVEL_ERROR:
-		__android_log_vprint(ANDROID_LOG_ERROR, "kinc", format, args);
+		__android_log_vprint(ANDROID_LOG_ERROR, "Kinc", format, args);
 		break;
 	}
 #endif


### PR DESCRIPTION
You can't do `adb logcat -s Kinc Application` because of space.