### PR TITLE
Fixed a bug that caused loading textures from memory to crash the video driver.

### DIFF
--- a/Sources/Kore/Graphics4/Texture.cpp
+++ b/Sources/Kore/Graphics4/Texture.cpp
@@ -76,8 +76,8 @@ Graphics4::Texture::Texture(void *data, int width, int height, int depth, Format
 	}
 }
 
-Graphics4::Texture::Texture(void *data, int size, const char *format, bool readable) {
-	BufferReader reader(data, size);
+Graphics4::Texture::Texture(void *filedata, int size, const char *format, bool readable) {
+	BufferReader reader(filedata, size);
 	Image::init(reader, format, readable);
 	
 	kinc_image_t image;


### PR DESCRIPTION
Texture data was being taken from the file data rather than the converted image.