### PR TITLE
Some optimizations on image.c buffer and stb_image to use less memory.

### DIFF
--- a/Sources/kinc/libs/stb_image.h
+++ b/Sources/kinc/libs/stb_image.h
@@ -4894,7 +4894,9 @@ static int stbi__parse_png_file(stbi__png *z, int scan, int req_comp)
                stbi_uc *p;
                if (idata_limit == 0) idata_limit = c.length > 4096 ? c.length : 4096;
                while (ioff + c.length > idata_limit)
-                  idata_limit *= 2;
+                  //Originally this was idata_limit *= 2. Changed to append a constant size on realloc instead of doubleing everytime.
+                  //This saves some space on the image.c buffer.
+                  idata_limit += 1 << 16;
                STBI_NOTUSED(idata_limit_old);
                p = (stbi_uc *) STBI_REALLOC_SIZED(z->idata, idata_limit_old, idata_limit); if (p == NULL) return stbi__err("outofmem", "Out of memory");
                z->idata = p;


### PR DESCRIPTION
Now it is possible to load some larger png, but still have some limitations.

When stb_image runs out of allocated memory, it asks to reallocate the double it had before. It quickly runs out when loading larger files. Changed it to realloc a fixed amount, saving some memory in the process. 

Made some changes to image.c realloc to just append data in case the pointer being reallocated is the same as the last one allocated (as it is most of the times when loading images).

It also prevents some crashes by avoiding memcpy in case there is no more memory available.

Kind of related to #407 and #408, but didn't solve the problem completely.