### PR TITLE
get_render_target_pixels for D3D12

### DIFF
--- a/Backends/Graphics4/G4onG5/Sources/Kore/RenderTargetImpl.c
+++ b/Backends/Graphics4/G4onG5/Sources/Kore/RenderTargetImpl.c
@@ -44,6 +44,8 @@ void kinc_g4_render_target_set_depth_stencil_from(kinc_g4_render_target_t *rende
 	kinc_g5_render_target_set_depth_stencil_from(&render_target->impl._renderTarget, &source->impl._renderTarget);
 }
 
-void kinc_g4_render_target_get_pixels(kinc_g4_render_target_t *render_target, uint8_t *data) {}
+void kinc_g4_render_target_get_pixels(kinc_g4_render_target_t *render_target, uint8_t *data) {
+	kinc_g5_command_list_get_render_target_pixels(&commandList, &render_target->impl._renderTarget, data);
+}
 
 void kinc_g4_render_target_generate_mipmaps(kinc_g4_render_target_t *render_target, int levels) {}

--- a/Backends/Graphics5/Direct3D12/Sources/Kore/RenderTarget5Impl.cpp
+++ b/Backends/Graphics5/Direct3D12/Sources/Kore/RenderTarget5Impl.cpp
@@ -69,6 +69,7 @@ void kinc_g5_render_target_init(kinc_g5_render_target_t *render_target, int widt
 	render_target->texHeight = render_target->height = height;
 	render_target->impl.stage = 0;
 	render_target->impl.stage_depth = -1;
+	render_target->impl.renderTargetReadback = nullptr;
 
 	render_target->impl.resourceState = RenderTargetResourceStateUndefined;
 

--- a/Backends/Graphics5/Direct3D12/Sources/Kore/RenderTarget5Impl.h
+++ b/Backends/Graphics5/Direct3D12/Sources/Kore/RenderTarget5Impl.h
@@ -27,6 +27,7 @@ enum RenderTargetResourceState { RenderTargetResourceStateUndefined, RenderTarge
 
 typedef struct {
 	struct ID3D12Resource *renderTarget;
+	struct ID3D12Resource *renderTargetReadback;
 	struct ID3D12DescriptorHeap *renderTargetDescriptorHeap;
 	struct ID3D12DescriptorHeap *srvDescriptorHeap;
 	struct ID3D12DescriptorHeap *depthStencilDescriptorHeap;

--- a/Backends/Graphics5/G5onG4/Sources/Kore/CommandList5Impl.c
+++ b/Backends/Graphics5/G5onG4/Sources/Kore/CommandList5Impl.c
@@ -134,3 +134,4 @@ void kinc_g5_command_list_set_render_targets(kinc_g5_command_list_t *list, struc
 void kinc_g5_command_list_upload_index_buffer(kinc_g5_command_list_t *list, struct kinc_g5_index_buffer *buffer) {}
 void kinc_g5_command_list_upload_vertex_buffer(kinc_g5_command_list_t *list, struct kinc_g5_vertex_buffer *buffer) {}
 void kinc_g5_command_list_upload_texture(kinc_g5_command_list_t *list, struct kinc_g5_texture *texture) {}
+void kinc_g5_command_list_get_render_target_pixels(kinc_g5_command_list_t *list, kinc_g5_render_target_t *render_target, uint8_t *data) {}

--- a/Backends/Graphics5/Metal/Sources/Kore/CommandList5Impl.mm
+++ b/Backends/Graphics5/Metal/Sources/Kore/CommandList5Impl.mm
@@ -97,6 +97,8 @@ void kinc_g5_command_list_upload_vertex_buffer(kinc_g5_command_list_t *list, str
 
 void kinc_g5_command_list_upload_texture(kinc_g5_command_list_t *list, struct kinc_g5_texture *texture) {}
 
+void kinc_g5_command_list_get_render_target_pixels(kinc_g5_command_list_t *list, kinc_g5_render_target_t *render_target, uint8_t *data) {}
+
 void kinc_g5_command_list_execute(kinc_g5_command_list_t *list) {
 	newRenderPass(lastRenderTarget, false);
 }

--- a/Backends/Graphics5/Vulkan/Sources/Kore/CommandList5Impl.cpp
+++ b/Backends/Graphics5/Vulkan/Sources/Kore/CommandList5Impl.cpp
@@ -581,6 +581,8 @@ void kinc_g5_command_list_upload_vertex_buffer(kinc_g5_command_list_t *list, str
 
 void kinc_g5_command_list_upload_texture(kinc_g5_command_list_t *list, struct kinc_g5_texture *texture) {}
 
+void kinc_g5_command_list_get_render_target_pixels(kinc_g5_command_list_t *list, kinc_g5_render_target_t *render_target, uint8_t *data) {}
+
 void kinc_g5_command_list_texture_to_render_target_barrier(kinc_g5_command_list_t *list, struct kinc_g5_render_target *renderTarget) {}
 
 void kinc_g5_command_list_render_target_to_texture_barrier(kinc_g5_command_list_t *list, struct kinc_g5_render_target *renderTarget) {}

--- a/Sources/kinc/graphics5/commandlist.h
+++ b/Sources/kinc/graphics5/commandlist.h
@@ -20,6 +20,7 @@ struct kinc_g5_pipeline;
 struct kinc_g5_render_target;
 struct kinc_g5_texture;
 struct kinc_g5_vertex_buffer;
+struct kinc_g5_render_target;
 
 typedef struct kinc_g5_command_list {
 	CommandList5Impl impl;
@@ -53,6 +54,7 @@ void kinc_g5_command_list_set_fragment_constant_buffer(kinc_g5_command_list_t *l
 void kinc_g5_command_list_set_pipeline_layout(kinc_g5_command_list_t *list);
 void kinc_g5_command_list_execute(kinc_g5_command_list_t *list);
 void kinc_g5_command_list_execute_and_wait(kinc_g5_command_list_t *list);
+void kinc_g5_command_list_get_render_target_pixels(kinc_g5_command_list_t *list, struct kinc_g5_render_target *render_target, uint8_t *data);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Pixel reading for D3D12 render targets. It's fully working but not sure on the implementation details regarding G5 api:
- Adds `kinc_g5_command_list_get_render_target_pixels` function.
- It does resource barriers on it's own.
- Calls `graphicsFlushAndWait`. Perf wise it appears to be on par with D3D11 though.