### PR TITLE
Set optimized clear value for render targets in D3D12

### DIFF
--- a/Backends/Graphics5/Direct3D12/Sources/Kore/RenderTarget5Impl.cpp
+++ b/Backends/Graphics5/Direct3D12/Sources/Kore/RenderTarget5Impl.cpp
@@ -75,9 +75,16 @@ void kinc_g5_render_target_init(kinc_g5_render_target_t *render_target, int widt
 
 	DXGI_FORMAT dxgiFormat = convertFormat(format);
 
+	D3D12_CLEAR_VALUE clearValue;
+	clearValue.Format = dxgiFormat;
+	clearValue.Color[0] = 0.0f;
+	clearValue.Color[1] = 0.0f;
+	clearValue.Color[2] = 0.0f;
+	clearValue.Color[3] = 1.0f;
+
 	device->CreateCommittedResource(&CD3DX12_HEAP_PROPERTIES(D3D12_HEAP_TYPE_DEFAULT), D3D12_HEAP_FLAG_NONE,
 	    &CD3DX12_RESOURCE_DESC::Tex2D(dxgiFormat, render_target->texWidth, render_target->texHeight, 1, 1, 1, 0, D3D12_RESOURCE_FLAG_ALLOW_RENDER_TARGET),
-	                                D3D12_RESOURCE_STATE_COMMON, nullptr, IID_GRAPHICS_PPV_ARGS(&render_target->impl.renderTarget));
+	                                D3D12_RESOURCE_STATE_COMMON, &clearValue, IID_GRAPHICS_PPV_ARGS(&render_target->impl.renderTarget));
 
 	D3D12_RENDER_TARGET_VIEW_DESC view;
 	const D3D12_RESOURCE_DESC resourceDesc = render_target->impl.renderTarget->GetDesc();


### PR DESCRIPTION
Gets rid of the warnings generated on every clear:
`D3D12 WARNING: ID3D12CommandList::ClearRenderTargetView: The application did not pass any clear value to resource creation.`

A warning for non-black clear is still generated:
`D3D12 WARNING: ID3D12CommandList::ClearRenderTargetView: The clear values do not match those passed to resource creation.`

Black color clear should also be faster now.