### PR TITLE
Handle window resize for D3D12

### DIFF
--- a/Backends/Graphics5/Metal/Sources/Kore/Metal.mm
+++ b/Backends/Graphics5/Metal/Sources/Kore/Metal.mm
@@ -16,6 +16,13 @@ using namespace Kore;
 id getMetalDevice();
 id getMetalEncoder();
 
+extern "C" {
+	int renderTargetWidth;
+	int renderTargetHeight;
+	int newRenderTargetWidth;
+	int newRenderTargetHeight;
+}
+
 namespace {
 	// bool fullscreen;
 	// TextureFilter minFilters[32];

--- a/Backends/Graphics5/Vulkan/Sources/Kore/Vulkan.cpp
+++ b/Backends/Graphics5/Vulkan/Sources/Kore/Vulkan.cpp
@@ -48,6 +48,13 @@
 
 #define APP_NAME_STR_LEN 80
 
+extern "C" {
+	int renderTargetWidth;
+	int renderTargetHeight;
+	int newRenderTargetWidth;
+	int newRenderTargetHeight;
+}
+
 VkDevice device;
 VkFormat format;
 VkFormat depth_format;


### PR DESCRIPTION
The simplest solution I found so far, including G4onG5 support:
- Window resize is detected in `kinc_internal_resize`
- `G4.c` releases framebuffers so the swapchain can get re-created
- `Direct3D12.cpp ` re-creates swapchain
- `G4.c`  re-creates framebuffers