### PR TITLE
iPhone audio playback fix.

### DIFF
--- a/Backends/System/macOS/Sources/Kore/Audio.cpp
+++ b/Backends/System/macOS/Sources/Kore/Audio.cpp
@@ -101,6 +101,8 @@ void kinc_a2_init() {
 		return;
 	}
 
+	kinc_a2_samples_per_second = static_cast<int>(deviceFormat.mSampleRate);
+
 	initialized = true;
 
 	kinc_log(KINC_LOG_LEVEL_INFO, "mSampleRate = %g\n", deviceFormat.mSampleRate);

--- a/Sources/Kore/Audio2/Audio.cpp
+++ b/Sources/Kore/Audio2/Audio.cpp
@@ -40,6 +40,10 @@ namespace {
 			}
 		}
 	}
+
+	void sample_rate_changed() {
+		Audio2::samplesPerSecond = kinc_a2_samples_per_second;
+	}
 }
 
 void Audio2::init() {
@@ -50,6 +54,9 @@ void Audio2::init() {
 	buffer.data = new u8[buffer.dataSize];
 	Audio2::samplesPerSecond = kinc_a2_samples_per_second;
 	kinc_a2_set_callback(audio);
+	#ifdef KORE_IOS
+	kinc_a2_set_sample_rate_callback(sample_rate_changed);
+	#endif
 }
 
 void Audio2::update() {

--- a/Sources/kinc/audio2/audio.h
+++ b/Sources/kinc/audio2/audio.h
@@ -22,6 +22,7 @@ typedef struct {
 
 void kinc_a2_init();
 void kinc_a2_set_callback(void (*kinc_a2_audio_callback)(kinc_a2_buffer_t *buffer, int samples));
+void kinc_a2_set_sample_rate_callback(void (*kinc_a2_sample_rate_callback)());
 extern int kinc_a2_samples_per_second;
 void kinc_a2_update();
 void kinc_a2_shutdown();


### PR DESCRIPTION
On newer iPhones the internal speaker sample rate is locked at 48000hz but when you plug in / connect headphones it goes to 44100hz. When using `Audio.play()` it messes up the playback speed. This pull request adds a listener for when the sample rate changes so the playback speed stays the same. It also sets the correct sample rate at the start. At the moment it is always 44100hz.

There is also a small change in Kha needed to make the audio channel always a `ResamplingAudioChannel` on iOS. I'll create a pull request for this there.