### PR TITLE
Fix calling metal when the app is in the background on iOS.

### DIFF
--- a/Backends/System/iOS/Sources/Kore/GLView.mm
+++ b/Backends/System/iOS/Sources/Kore/GLView.mm
@@ -238,10 +238,14 @@ void initMetalCompute(id<MTLDevice> device, id<MTLCommandQueue> commandQueue);
 #ifdef KORE_METAL
 - (void)end {
 	@autoreleasepool {
-		[commandEncoder endEncoding];
-		[commandBuffer presentDrawable:drawable];
-		[commandBuffer commit];
+    if (commandEncoder != nil && commandBuffer != nil) {
+      [commandEncoder endEncoding];
+      [commandBuffer presentDrawable:drawable];
+      [commandBuffer commit];
+    }
+		
 		commandBuffer = nil;
+    commandEncoder = nil;
 
 		// if (drawable != nil) {
 		//	[commandBuffer waitUntilScheduled];

--- a/Backends/System/iOS/Sources/Kore/GLViewController.h
+++ b/Backends/System/iOS/Sources/Kore/GLViewController.h
@@ -12,4 +12,6 @@
 
 - (void)loadView;
 
+- (void)setVisible:(BOOL)value;
+
 @end

--- a/Backends/System/iOS/Sources/Kore/GLViewController.mm
+++ b/Backends/System/iOS/Sources/Kore/GLViewController.mm
@@ -12,17 +12,31 @@
 
 static GLView* glView;
 
+static bool visible;
+
 void beginGL() {
+  #ifdef KORE_METAL
+	if (!visible) {
+		return;
+	}
+  #endif
 	[glView begin];
 }
 
 void endGL() {
+  #ifdef KORE_METAL
+	if (!visible) {
+		return;
+	}
+  #endif
 	[glView end];
 }
 
 #ifdef KORE_METAL
 void newRenderPass(kinc_g5_render_target_t *renderTarget, bool wait) {
-	[glView newRenderPass: renderTarget wait: wait];
+	if (visible) {
+		[glView newRenderPass: renderTarget wait: wait];
+	}
 }
 #endif
 
@@ -61,7 +75,12 @@ id getMetalEncoder() {
 @implementation GLViewController
 
 - (void)loadView {
+	visible = true;
 	self.view = glView = [[GLView alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
+}
+
+- (void)setVisible:(BOOL)value {
+	visible = value;
 }
 
 @end

--- a/Backends/System/iOS/Sources/Kore/KoreAppDelegate.mm
+++ b/Backends/System/iOS/Sources/Kore/KoreAppDelegate.mm
@@ -11,6 +11,7 @@
 @implementation KoreAppDelegate
 
 static UIWindow* window;
+static GLViewController* glViewController;
 
 void loadURL(const char* url) {
 	[[UIApplication sharedApplication] openURL:[NSURL URLWithString:[NSString stringWithUTF8String:url]]];
@@ -44,7 +45,7 @@ void loadURL(const char* url) {
 
 	// glView = [[GLView alloc] initWithFrame:CGRectMake(0, 0, Kore::max(screenBounds.size.width, screenBounds.size.height), Kore::max(screenBounds.size.width,
 	// screenBounds.size.height))];
-	GLViewController* glViewController = [[GLViewController alloc] init];
+	glViewController = [[GLViewController alloc] init];
 #ifndef KORE_TVOS
 	glViewController.view.multipleTouchEnabled = YES;
 #endif
@@ -102,6 +103,7 @@ sharedApplication].statusBarOrientation);
 }
 */
 - (void)applicationWillEnterForeground:(UIApplication*)application {
+	[glViewController setVisible:YES];
 	Kore::System::_foregroundCallback();
 }
 
@@ -117,6 +119,7 @@ sharedApplication].statusBarOrientation);
 }
 
 - (void)applicationDidEnterBackground:(UIApplication*)application {
+	[glViewController setVisible:NO];
 	Kore::System::_backgroundCallback();
 }
 


### PR DESCRIPTION
When using metal on iOS if you send your app to the background you get a bunch of warnings in the console: "Execution of the command buffer was aborted due to an error during execution. Insufficient Permission (to submit GPU work from background) (IOAF code 6)".

This pull request adds a check to see if the app is in the background and if it is it stops calling `begin()` `end()` and `newRenderPass()`.

I'm not sure if this is the best solution but it works well in my app.