### PR TITLE
Added callbacks for pause, background etc. for macOS.

### DIFF
--- a/Backends/System/macOS/Sources/Kore/BasicOpenGLView.mm
+++ b/Backends/System/macOS/Sources/Kore/BasicOpenGLView.mm
@@ -494,10 +494,14 @@ void initMetalCompute(id<MTLDevice> device, id<MTLCommandQueue> commandBuffer);
 
 - (void)end {
 	@autoreleasepool {
-		[commandEncoder endEncoding];
-		[commandBuffer presentDrawable:drawable];
-		[commandBuffer commit];
-
+    if (commandBuffer != nil && commandEncoder != nil) {
+      [commandEncoder endEncoding];
+      [commandBuffer presentDrawable:drawable];
+      [commandBuffer commit];
+    }
+    
+    commandBuffer = nil;
+    commandEncoder = nil;
 		//if (drawable != nil) {
 		//	[commandBuffer waitUntilScheduled];
 		//	[drawable present];

--- a/Backends/System/macOS/Sources/Kore/System.mm
+++ b/Backends/System/macOS/Sources/Kore/System.mm
@@ -108,6 +108,11 @@ bool kinc_internal_handle_messages() {
 		[myapp sendEvent:event];
 		[myapp updateWindows];
 	}
+  
+  // Sleep for a frame to limit the calls when the window is not visible.
+  if (!window.visible) {
+    [NSThread sleepForTimeInterval: 1.0 / 60];
+  }
 	return true;
 }
 


### PR DESCRIPTION
Added pause and resume callbacks when the window loses focus.
Added background and foreground callbacks when you minimize the window.

Fixed crash when you minimize the window when using Metal on macOS.