### PR TITLE
add KORE_NO_MAIN as option for kinc to be used as a library project

### DIFF
--- a/Backends/System/macOS/Sources/Kore/System.mm
+++ b/Backends/System/macOS/Sources/Kore/System.mm
@@ -255,6 +255,18 @@ const char* kinc_internal_save_path() {
 	return getSavePath();
 }
 
+#ifndef KORE_NO_MAIN
+int main(int argc, char** argv) {
+	::argc = argc;
+	::argv = argv;
+	@autoreleasepool {
+		myapp = [MyApplication sharedApplication];
+		[myapp performSelectorOnMainThread:@selector(run) withObject:nil waitUntilDone:YES];
+	}
+	return 0;
+}
+#endif
+
 int main(int argc, char** argv) {
 	::argc = argc;
 	::argv = argv;
@@ -287,16 +299,17 @@ void addMenubar() {
 	@autoreleasepool {
 		[self finishLaunching];
 		[[NSRunningApplication currentApplication] activateWithOptions:(NSApplicationActivateAllWindows | NSApplicationActivateIgnoringOtherApps)];
-
+		NSApp.activationPolicy = NSApplicationActivationPolicyRegular;
+		
 		hidManager = new Kore::HIDManager();
 		addMenubar();
 
-		// try {
+#ifdef KORE_NO_MAIN
+		if (init_callback != NULL)
+			init_callback();
+#else
 		kickstart(argc, argv);
-		//}
-		// catch (Kt::Exception& ex) {
-		//	printf("Exception caught");
-		//}
+#endif
 	}
 }
 

--- a/Sources/kinc/system.h
+++ b/Sources/kinc/system.h
@@ -42,6 +42,8 @@ double kinc_frequency();
 kinc_ticks_t kinc_timestamp();
 double kinc_time();
 
+void kinc_run(void (*value)());
+
 void kinc_start();
 bool kinc_internal_frame();
 void kinc_stop();


### PR DESCRIPTION
When KORE_NO_MAIN is defined it wipes out the main declaration so a calling app can use kinc as a library.