### PR TITLE
release resources

### DIFF
--- a/Backends/Graphics4/Direct3D11/Sources/Kore/RenderTargetImpl.cpp
+++ b/Backends/Graphics4/Direct3D11/Sources/Kore/RenderTargetImpl.cpp
@@ -340,6 +340,8 @@ void kinc_g4_render_target_destroy(kinc_g4_render_target_t *renderTarget) {
 	if (renderTarget->impl.depthStencil != nullptr) renderTarget->impl.depthStencil->Release();
 	if (renderTarget->impl.textureRender != nullptr) renderTarget->impl.textureRender->Release();
 	if (renderTarget->impl.textureStaging != nullptr) renderTarget->impl.textureStaging->Release();
+	if (renderTarget->impl.textureSample != nullptr && renderTarget->impl.textureSample != renderTarget->impl.textureRender) 
+		renderTarget->impl.textureSample->Release();
 }
 
 void kinc_g4_render_target_use_color_as_texture(kinc_g4_render_target_t *renderTarget, kinc_g4_texture_unit_t unit) {

--- a/Backends/Graphics4/OpenGL/Sources/Kore/IndexBufferImpl.c
+++ b/Backends/Graphics4/OpenGL/Sources/Kore/IndexBufferImpl.c
@@ -26,6 +26,7 @@ void Kinc_Internal_IndexBufferUnset(kinc_g4_index_buffer_t *buffer) {
 
 void kinc_g4_index_buffer_destroy(kinc_g4_index_buffer_t *buffer) {
 	Kinc_Internal_IndexBufferUnset(buffer);
+	glDeleteBuffers(1, &buffer->impl.bufferId);
 	free(buffer->impl.data);
 }
 

--- a/Backends/Graphics4/OpenGL/Sources/Kore/VertexBufferImpl.c
+++ b/Backends/Graphics4/OpenGL/Sources/Kore/VertexBufferImpl.c
@@ -78,6 +78,7 @@ void Kinc_Internal_G4_VertexBuffer_Unset(kinc_g4_vertex_buffer_t *buffer);
 
 void kinc_g4_vertex_buffer_destroy(kinc_g4_vertex_buffer_t *buffer) {
 	Kinc_Internal_G4_VertexBuffer_Unset(buffer);
+	glDeleteBuffers(1, &buffer->impl.bufferId);
 	free(buffer->impl.data);
 }
 

--- a/Sources/Kore/Graphics4/PipelineState.cpp
+++ b/Sources/Kore/Graphics4/PipelineState.cpp
@@ -43,7 +43,9 @@ Graphics4::PipelineState::PipelineState() {
 	conservativeRasterization = false;
 }
 
-Graphics4::PipelineState::~PipelineState() {}
+Graphics4::PipelineState::~PipelineState() {
+	kinc_g4_pipeline_destroy(&kincPipeline);
+}
 
 void Kore_Internal_ConvertVertexStructure(kinc_g4_vertex_structure_t *target, const Graphics4::VertexStructure *source);
 


### PR DESCRIPTION
delete index and vertex buffer in opengl and destroy textures and pipelines in 3D11