### PR TITLE
Detach unused framebuffers for OpenGL

### DIFF
--- a/Backends/Graphics4/OpenGL/Sources/Kore/OpenGL.cpp
+++ b/Backends/Graphics4/OpenGL/Sources/Kore/OpenGL.cpp
@@ -729,6 +729,11 @@ void kinc_g4_set_render_targets(kinc_g4_render_target_t **targets, int count) {
 #endif
 		glCheckErrors();
 	}
+
+	for (int i = count; i < 8; ++i) {
+		glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0 + i, GL_TEXTURE_2D, 0, 0);
+		glCheckErrors();
+	}
 }
 
 void kinc_g4_set_render_target_face(kinc_g4_render_target_t *texture, int face) {


### PR DESCRIPTION
Had evil stuff happening with random (previously-bound) render targets getting modified.

From https://www.khronos.org/registry/OpenGL-Refpages/es2.0/xhtml/glFramebufferTexture2D.xml:
> If texture is 0, the current image, if any, attached to the attachment logical buffer of the currently bound framebuffer object is detached.