### PR TITLE
Handle network paths in filereader on Windows

### DIFF
--- a/Sources/kinc/io/filereader.winrt.cpp
+++ b/Sources/kinc/io/filereader.winrt.cpp
@@ -183,7 +183,8 @@ bool kinc_file_reader_open(kinc_file_reader_t *reader, const char *filename, int
 #endif
 
 #ifdef KORE_WINDOWS
-	bool isAbsolute = filename[1] == ':' && filename[2] == '\\';
+	// Drive letter or network
+	bool isAbsolute = (filename[1] == ':' && filename[2] == '\\') || (filename[0] == '\\' && filename[1] == '\\');
 #else
 	bool isAbsolute = filename[0] == '/';
 #endif


### PR DESCRIPTION
Marks path starting with `\\` as absolute on Windows, afterwards the file gets successfully loaded.