### PR TITLE
Fix OpenGL for Xcode 11 + manual dpi handling on macOS

### DIFF
--- a/Backends/System/macOS/Sources/Kore/BasicOpenGLView.mm
+++ b/Backends/System/macOS/Sources/Kore/BasicOpenGLView.mm
@@ -280,12 +280,16 @@ namespace {
 namespace {
 	int getMouseX(NSEvent* event) {
 		// TODO (DK) map [theEvent window] to window id instead of 0
-		return static_cast<int>([event locationInWindow].x);
+		NSWindow* window = [[NSApplication sharedApplication] mainWindow];
+		float scale = [window backingScaleFactor];
+		return static_cast<int>([event locationInWindow].x * scale);
 	}
 
 	int getMouseY(NSEvent* event) {
 		// TODO (DK) map [theEvent window] to window id instead of 0
-		return static_cast<int>(kinc_height() - [event locationInWindow].y);
+		NSWindow* window = [[NSApplication sharedApplication] mainWindow];
+		float scale = [window backingScaleFactor];
+		return static_cast<int>(kinc_height() - [event locationInWindow].y * scale);
 	}
 
 	bool controlKeyMouseButton = false;
@@ -387,7 +391,7 @@ namespace {
 
 	[self prepareOpenGL];
 	[[self openGLContext] makeCurrentContext];
-	[self setWantsBestResolutionOpenGLSurface:NO];
+	[self setWantsBestResolutionOpenGLSurface:YES];
 	return self;
 }
 #else

--- a/Backends/System/macOS/Sources/Kore/BasicOpenGLView.mm
+++ b/Backends/System/macOS/Sources/Kore/BasicOpenGLView.mm
@@ -386,7 +386,8 @@ namespace {
 	self = [super initWithFrame:frameRect pixelFormat:pf];
 
 	[self prepareOpenGL];
-	//[[self openGLContext] makeCurrentContext];
+	[[self openGLContext] makeCurrentContext];
+	[self setWantsBestResolutionOpenGLSurface:NO];
 	return self;
 }
 #else

--- a/Backends/System/macOS/Sources/Kore/System.mm
+++ b/Backends/System/macOS/Sources/Kore/System.mm
@@ -125,8 +125,8 @@ void swapBuffersMac(int windowId) {
 }
 
 int createWindow(kinc_window_options_t *options) {
-	int width = options->width;
-	int height = options->height;
+	int width = options->width / [[NSScreen mainScreen] backingScaleFactor];
+	int height = options->height / [[NSScreen mainScreen] backingScaleFactor];
 	int styleMask = NSTitledWindowMask | NSClosableWindowMask;
 	if ((options->window_features & KINC_WINDOW_FEATURE_RESIZEABLE) || (options->window_features & KINC_WINDOW_FEATURE_MAXIMIZABLE)) {
 		styleMask |= NSResizableWindowMask;
@@ -198,7 +198,7 @@ int kinc_init(const char* name, int width, int height, kinc_window_options_t *wi
 	}
 
 	win->width = width;
-    win->height = height;
+	win->height = height;
 	if (win->title == NULL) {
 		win->title = name;
 	}
@@ -210,12 +210,14 @@ int kinc_init(const char* name, int width, int height, kinc_window_options_t *wi
 
 int kinc_window_width(int window_index) {
 	NSWindow* window = windows[window_index].handle;
-	return [[window contentView] frame].size.width;
+	float scale = [window backingScaleFactor];
+	return [[window contentView] frame].size.width * scale;
 }
 
 int kinc_window_height(int window_index) {
 	NSWindow* window = windows[window_index].handle;
-	return [[window contentView] frame].size.height;
+	float scale = [window backingScaleFactor];
+	return [[window contentView] frame].size.height * scale;
 }
 
 void kinc_load_url(const char* url) {


### PR DESCRIPTION
    [[self openGLContext] makeCurrentContext];
Fixes the black screen when compiling with Xcode 11.

    [self setWantsBestResolutionOpenGLSurface:NO];
Otherwise Kinc draws to 1/4 part of the window (apparently the default value of this changed).