### PR TITLE
Add index buffer format

### DIFF
--- a/Backends/Graphics4/Direct3D11/Sources/Kore/IndexBufferImpl.cpp
+++ b/Backends/Graphics4/Direct3D11/Sources/Kore/IndexBufferImpl.cpp
@@ -9,7 +9,7 @@
 #include <Windows.h>
 #include <d3d11.h>
 
-void kinc_g4_index_buffer_init(kinc_g4_index_buffer_t *buffer, int count) {
+void kinc_g4_index_buffer_init(kinc_g4_index_buffer_t *buffer, int count, kinc_g4_index_buffer_format_t format) {
 	buffer->impl.count = count;
 	buffer->impl.indices = new int[count];
 

--- a/Backends/Graphics4/Direct3D9/Sources/Kore/IndexBufferImpl.cpp
+++ b/Backends/Graphics4/Direct3D9/Sources/Kore/IndexBufferImpl.cpp
@@ -9,7 +9,7 @@
 
 struct kinc_g4_index_buffer *kinc_internal_current_index_buffer = NULL;
 
-void kinc_g4_index_buffer_init(kinc_g4_index_buffer_t *buffer, int count) {
+void kinc_g4_index_buffer_init(kinc_g4_index_buffer_t *buffer, int count, kinc_g4_index_buffer_format_t format) {
 	buffer->impl.myCount = count;
 	kinc_microsoft_affirm(
 	    device->CreateIndexBuffer(sizeof(int) * count, D3DUSAGE_DYNAMIC | D3DUSAGE_WRITEONLY, D3DFMT_INDEX32, D3DPOOL_DEFAULT, &buffer->impl.ib, 0));

--- a/Backends/Graphics4/G4onG5/Sources/Kore/IndexBufferImpl.c
+++ b/Backends/Graphics4/G4onG5/Sources/Kore/IndexBufferImpl.c
@@ -6,7 +6,7 @@
 
 extern kinc_g5_command_list_t commandList;
 
-void kinc_g4_index_buffer_init(kinc_g4_index_buffer_t *buffer, int count) {
+void kinc_g4_index_buffer_init(kinc_g4_index_buffer_t *buffer, int count, kinc_g4_index_buffer_format_t format) {
 	kinc_g5_index_buffer_init(&buffer->impl._buffer, count, true);
 }
 

--- a/Backends/Graphics4/OpenGL/Sources/Kore/IndexBufferImpl.h
+++ b/Backends/Graphics4/OpenGL/Sources/Kore/IndexBufferImpl.h
@@ -7,9 +7,7 @@ extern "C" {
 #endif
 
 typedef struct {
-#if defined(KORE_ANDROID) || defined(KORE_PI)
 	uint16_t *shortData;
-#endif
 	int *data;
 	int myCount;
 	unsigned bufferId;

--- a/Backends/Graphics4/OpenGL/Sources/Kore/OpenGL.cpp
+++ b/Backends/Graphics4/OpenGL/Sources/Kore/OpenGL.cpp
@@ -313,11 +313,12 @@ void kinc_g4_draw_indexed_vertices() {
 
 void kinc_g4_draw_indexed_vertices_from_to(int start, int count) {
 #ifdef KORE_OPENGL_ES
-#if defined(KORE_ANDROID) || defined(KORE_PI)
-	glDrawElements(GL_TRIANGLES, count, GL_UNSIGNED_SHORT, (void *)(start * sizeof(uint16_t)));
-#else
-	glDrawElements(GL_TRIANGLES, count, GL_UNSIGNED_INT, (void *)(start * sizeof(uint32_t)));
-#endif
+	if (Kinc_Internal_CurrentIndexBuffer->impl.shortData != NULL) {
+		glDrawElements(GL_TRIANGLES, count, GL_UNSIGNED_SHORT, (void *)(start * sizeof(uint16_t)));
+	}
+	else {
+		glDrawElements(GL_TRIANGLES, count, GL_UNSIGNED_INT, (void *)(start * sizeof(uint32_t)));
+	}
 	glCheckErrors();
 #else
 	if (Kinc_Internal_ProgramUsesTessellation) {
@@ -333,12 +334,12 @@ void kinc_g4_draw_indexed_vertices_from_to(int start, int count) {
 
 void kinc_g4_draw_indexed_vertices_from_to_from(int start, int count, int vertex_offset) {
 #ifdef KORE_OPENGL_ES
-	// TODO
-#if defined(KORE_ANDROID) || defined(KORE_PI)
-	glDrawElements(GL_TRIANGLES, count, GL_UNSIGNED_SHORT, (void *)(start * sizeof(uint16_t)));
-#else
-	glDrawElements(GL_TRIANGLES, count, GL_UNSIGNED_INT, (void *)(start * sizeof(uint32_t)));
-#endif
+	if (Kinc_Internal_CurrentIndexBuffer->impl.shortData != NULL) {
+		glDrawElements(GL_TRIANGLES, count, GL_UNSIGNED_SHORT, (void *)(start * sizeof(uint16_t)));
+	}
+	else {
+		glDrawElements(GL_TRIANGLES, count, GL_UNSIGNED_INT, (void *)(start * sizeof(uint32_t)));
+	}
 	glCheckErrors();
 #else
 	if (Kinc_Internal_ProgramUsesTessellation) {

--- a/Backends/Graphics4/OpenGL/Sources/Kore/OpenGLWindow.c
+++ b/Backends/Graphics4/OpenGL/Sources/Kore/OpenGLWindow.c
@@ -128,7 +128,7 @@ void Kinc_Internal_initWindowsGLContext(int window, int depthBufferBits, int ste
 			vertices[7] = -1.0f;
 			kinc_g4_vertex_buffer_unlock_all(&windowVertexBuffer);
 
-			kinc_g4_index_buffer_init(&windowIndexBuffer, 6);
+			kinc_g4_index_buffer_init(&windowIndexBuffer, 6, KINC_G4_INDEX_BUFFER_FORMAT_32BIT);
 			int *indices = kinc_g4_index_buffer_lock(&windowIndexBuffer);
 			indices[0] = 0;
 			indices[1] = 1;

--- a/Backends/Graphics5/G5onG4/Sources/Kore/IndexBuffer5Impl.c
+++ b/Backends/Graphics5/G5onG4/Sources/Kore/IndexBuffer5Impl.c
@@ -10,7 +10,7 @@ kinc_g5_index_buffer_t *kinc_g5_internal_current_index_buffer = NULL;
 
 void kinc_g5_index_buffer_init(kinc_g5_index_buffer_t *buffer, int count, bool gpuMemory) {
 	buffer->impl.myCount = count;
-	kinc_g4_index_buffer_init(&buffer->impl.buffer, count);
+	kinc_g4_index_buffer_init(&buffer->impl.buffer, count, KINC_G4_INDEX_BUFFER_FORMAT_32BIT);
 }
 
 void kinc_g5_index_buffer_destroy(kinc_g5_index_buffer_t *buffer) {

--- a/Sources/Kore/Graphics4/IndexBuffer.cpp
+++ b/Sources/Kore/Graphics4/IndexBuffer.cpp
@@ -6,7 +6,11 @@ using namespace Kore;
 using namespace Kore::Graphics4;
 
 IndexBuffer::IndexBuffer(int count) {
-	kinc_g4_index_buffer_init(&kincBuffer, count);
+#if defined(KORE_ANDROID) || defined(KORE_PI)
+	kinc_g4_index_buffer_init(&kincBuffer, count, KINC_G4_INDEX_BUFFER_FORMAT_16BIT);
+#else
+	kinc_g4_index_buffer_init(&kincBuffer, count, KINC_G4_INDEX_BUFFER_FORMAT_32BIT);
+#endif
 }
 
 IndexBuffer::~IndexBuffer() {

--- a/Sources/kinc/graphics4/indexbuffer.h
+++ b/Sources/kinc/graphics4/indexbuffer.h
@@ -6,11 +6,16 @@
 extern "C" {
 #endif
 
+typedef enum kinc_g4_index_buffer_format {
+	KINC_G4_INDEX_BUFFER_FORMAT_32BIT,
+	KINC_G4_INDEX_BUFFER_FORMAT_16BIT
+} kinc_g4_index_buffer_format_t;
+
 typedef struct kinc_g4_index_buffer {
 	kinc_g4_index_buffer_impl_t impl;
 } kinc_g4_index_buffer_t;
 
-void kinc_g4_index_buffer_init(kinc_g4_index_buffer_t *buffer, int count);
+void kinc_g4_index_buffer_init(kinc_g4_index_buffer_t *buffer, int count, kinc_g4_index_buffer_format_t format);
 void kinc_g4_index_buffer_destroy(kinc_g4_index_buffer_t *buffer);
 int *kinc_g4_index_buffer_lock(kinc_g4_index_buffer_t *buffer);
 void kinc_g4_index_buffer_unlock(kinc_g4_index_buffer_t *buffer);


### PR DESCRIPTION
Grounds for index buffer formats:
- `kinc_g4_index_buffer_init()` now takes `kinc_g4_index_buffer_format_t`
- `KINC_G4_INDEX_BUFFER_FORMAT_32BIT` or `KINC_G4_INDEX_BUFFER_FORMAT_16BIT` can be passed
- Imlemented for G4 / OpenGL
- For Kore, existing behavior should be unchanged

Related: https://github.com/Kode/Kinc/issues/471