### PR TITLE
Add WebGPU backend

### DIFF
--- a/Backends/Graphics5/WebGPU/Sources/Kore/CommandList5Impl.c
+++ b/Backends/Graphics5/WebGPU/Sources/Kore/CommandList5Impl.c
@@ -1,0 +1,114 @@
+#include "pch.h"
+
+#include <string.h>
+#include <kinc/graphics5/commandlist.h>
+#include <kinc/graphics5/indexbuffer.h>
+#include <kinc/graphics5/pipeline.h>
+#include <kinc/graphics5/vertexbuffer.h>
+#include <kinc/system.h>
+
+extern WGPUDevice device;
+extern WGPUQueue queue;
+extern WGPUSwapChain swapChain;
+
+void kinc_g5_command_list_init(kinc_g5_command_list_t *list) {}
+
+void kinc_g5_command_list_destroy(kinc_g5_command_list_t *list) {}
+
+void kinc_g5_command_list_begin(kinc_g5_command_list_t *list) {
+	WGPUCommandEncoderDescriptor ceDesc;
+	memset(&ceDesc, 0, sizeof(ceDesc));
+	list->impl.encoder = wgpuDeviceCreateCommandEncoder(device, &ceDesc);
+
+	WGPURenderPassColorAttachmentDescriptor attachment;
+	memset(&attachment, 0, sizeof(attachment));
+	attachment.attachment = wgpuSwapChainGetCurrentTextureView(swapChain);;
+	attachment.loadOp = WGPULoadOp_Clear;
+	attachment.storeOp = WGPUStoreOp_Store;
+	WGPUColor color = {0, 0, 0, 1};
+	attachment.clearColor = color;
+
+	WGPURenderPassDescriptor passDesc;
+	memset(&passDesc, 0, sizeof(passDesc));
+	passDesc.colorAttachmentCount = 1;
+	passDesc.colorAttachments = &attachment;
+
+	list->impl.pass = wgpuCommandEncoderBeginRenderPass(list->impl.encoder, &passDesc);
+}
+
+void kinc_g5_command_list_end(kinc_g5_command_list_t *list) {
+	wgpuRenderPassEncoderEndPass(list->impl.pass);
+
+	WGPUCommandBufferDescriptor cbDesc;
+	memset(&cbDesc, 0, sizeof(cbDesc));
+	WGPUCommandBuffer commands = wgpuCommandEncoderFinish(list->impl.encoder, &cbDesc);
+	wgpuQueueSubmit(queue, 1, &commands);
+}
+
+void kinc_g5_command_list_clear(kinc_g5_command_list_t *list, struct kinc_g5_render_target *renderTarget, unsigned flags, unsigned color, float depth,
+                                int stencil) {
+	
+}
+
+void kinc_g5_command_list_render_target_to_framebuffer_barrier(kinc_g5_command_list_t *list, struct kinc_g5_render_target *renderTarget) {}
+void kinc_g5_command_list_framebuffer_to_render_target_barrier(kinc_g5_command_list_t *list, struct kinc_g5_render_target *renderTarget) {}
+void kinc_g5_command_list_texture_to_render_target_barrier(kinc_g5_command_list_t *list, struct kinc_g5_render_target *renderTarget) {}
+void kinc_g5_command_list_render_target_to_texture_barrier(kinc_g5_command_list_t *list, struct kinc_g5_render_target *renderTarget) {}
+
+void kinc_g5_command_list_draw_indexed_vertices(kinc_g5_command_list_t *list) {
+	wgpuRenderPassEncoderDrawIndexed(list->impl.pass, list->impl.indexCount, 1, 0, 0, 0);
+}
+
+void kinc_g5_command_list_draw_indexed_vertices_from_to(kinc_g5_command_list_t *list, int start, int count) {
+	
+}
+
+void kinc_g5_command_list_viewport(kinc_g5_command_list_t *list, int x, int y, int width, int height) {
+	
+}
+
+void kinc_g5_command_list_scissor(kinc_g5_command_list_t *list, int x, int y, int width, int height) {
+	
+}
+
+void kinc_g5_command_list_disable_scissor(kinc_g5_command_list_t *list) {}
+
+void kinc_g5_command_list_set_pipeline(kinc_g5_command_list_t *list, struct kinc_g5_pipeline *pipeline) {
+	wgpuRenderPassEncoderSetPipeline(list->impl.pass, pipeline->impl.pipeline);
+}
+
+void kinc_g5_command_list_set_pipeline_layout(kinc_g5_command_list_t *list) {}
+
+void kinc_g5_command_list_set_vertex_buffers(kinc_g5_command_list_t *list, struct kinc_g5_vertex_buffer **buffers, int *offsets, int count) {
+	wgpuRenderPassEncoderSetVertexBuffer(list->impl.pass, 0, buffers[0]->impl.buffer, 0);
+}
+
+void kinc_g5_command_list_set_index_buffer(kinc_g5_command_list_t *list, struct kinc_g5_index_buffer *buffer) {
+	list->impl.indexCount = kinc_g5_index_buffer_count(buffer);
+	wgpuRenderPassEncoderSetIndexBuffer(list->impl.pass, buffer->impl.buffer, 0);
+}
+
+void kinc_g5_command_list_set_render_targets(kinc_g5_command_list_t *list, struct kinc_g5_render_target **targets, int count) {
+	
+}
+
+void kinc_g5_command_list_upload_index_buffer(kinc_g5_command_list_t *list, struct kinc_g5_index_buffer *buffer) {}
+void kinc_g5_command_list_upload_vertex_buffer(kinc_g5_command_list_t *list, struct kinc_g5_vertex_buffer *buffer) {}
+void kinc_g5_command_list_upload_texture(kinc_g5_command_list_t *list, struct kinc_g5_texture *texture) {}
+void kinc_g5_command_list_get_render_target_pixels(kinc_g5_command_list_t *list, kinc_g5_render_target_t *render_target, uint8_t *data) {}
+
+void kinc_g5_command_list_execute(kinc_g5_command_list_t *list) {
+	
+}
+
+void kinc_g5_command_list_execute_and_wait(kinc_g5_command_list_t *list) {
+	
+}
+
+void kinc_g5_command_list_set_vertex_constant_buffer(kinc_g5_command_list_t *list, struct kinc_g5_constant_buffer *buffer, int offset, size_t size) {
+	
+}
+
+void kinc_g5_command_list_set_fragment_constant_buffer(kinc_g5_command_list_t *list, struct kinc_g5_constant_buffer *buffer, int offset, size_t size) {
+	
+}

--- a/Backends/Graphics5/WebGPU/Sources/Kore/CommandList5Impl.h
+++ b/Backends/Graphics5/WebGPU/Sources/Kore/CommandList5Impl.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "pch.h"
+#include <webgpu/webgpu.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+	WGPUCommandEncoder encoder;
+	WGPURenderPassEncoder pass;
+	int indexCount;
+} CommandList5Impl;
+
+#ifdef __cplusplus
+}
+#endif

--- a/Backends/Graphics5/WebGPU/Sources/Kore/ComputeImpl.cpp
+++ b/Backends/Graphics5/WebGPU/Sources/Kore/ComputeImpl.cpp
@@ -1,0 +1,47 @@
+#include "pch.h"
+
+#include "ComputeImpl.h"
+
+#include <kinc/compute/compute.h>
+#include <kinc/math/core.h>
+
+void kinc_compute_shader_init(kinc_compute_shader_t *shader, void *source, int length) {}
+
+void kinc_compute_shader_destroy(kinc_compute_shader_t *shader) {}
+
+kinc_compute_constant_location_t kinc_compute_shader_get_constant_location(kinc_compute_shader_t *shader, const char *name) {
+	kinc_compute_constant_location_t location;
+	location.impl.nothing = 0;
+	return location;
+}
+
+kinc_compute_texture_unit_t kinc_compute_shader_get_texture_unit(kinc_compute_shader_t *shader, const char *name) {
+	kinc_compute_texture_unit_t unit;
+	unit.impl.nothing = 0;
+	return unit;
+}
+
+void kinc_compute_set_bool(kinc_compute_constant_location_t location, bool value) {}
+void kinc_compute_set_int(kinc_compute_constant_location_t location, int value) {}
+void kinc_compute_set_float(kinc_compute_constant_location_t location, float value) {}
+void kinc_compute_set_float2(kinc_compute_constant_location_t location, float value1, float value2) {}
+void kinc_compute_set_float3(kinc_compute_constant_location_t location, float value1, float value2, float value3) {}
+void kinc_compute_set_float4(kinc_compute_constant_location_t location, float value1, float value2, float value3, float value4) {}
+void kinc_compute_set_floats(kinc_compute_constant_location_t location, float *values, int count) {}
+void kinc_compute_set_matrix4(kinc_compute_constant_location_t location, kinc_matrix4x4_t *value) {}
+void kinc_compute_set_matrix3(kinc_compute_constant_location_t location, kinc_matrix3x3_t *value) {}
+void kinc_compute_set_texture(kinc_compute_texture_unit_t unit, kinc_g4_texture *texture, kinc_compute_access_t access) {}
+void kinc_compute_set_render_target(kinc_compute_texture_unit_t unit, kinc_g4_render_target *texture, kinc_compute_access_t access) {}
+void kinc_compute_set_sampled_texture(kinc_compute_texture_unit_t unit, kinc_g4_texture *texture) {}
+void kinc_compute_set_sampled_render_target(kinc_compute_texture_unit_t unit, kinc_g4_render_target *target) {}
+void kinc_compute_set_sampled_depth_from_render_target(kinc_compute_texture_unit_t unit, kinc_g4_render_target *target) {}
+void kinc_compute_set_texture_addressing(kinc_compute_texture_unit_t unit, kinc_g4_texture_direction_t dir, kinc_g4_texture_addressing_t addressing) {}
+void kinc_compute_set_texture_magnification_filter(kinc_compute_texture_unit_t unit, kinc_g4_texture_filter_t filter) {}
+void kinc_compute_set_texture_minification_filter(kinc_compute_texture_unit_t unit, kinc_g4_texture_filter_t filter) {}
+void kinc_compute_set_texture_mipmap_filter(kinc_compute_texture_unit_t unit, kinc_g4_mipmap_filter_t filter) {}
+void kinc_compute_set_texture3d_addressing(kinc_compute_texture_unit_t unit, kinc_g4_texture_direction_t dir, kinc_g4_texture_addressing_t addressing) {}
+void kinc_compute_set_texture3d_magnification_filter(kinc_compute_texture_unit_t unit, kinc_g4_texture_filter_t filter) {}
+void kinc_compute_set_texture3d_minification_filter(kinc_compute_texture_unit_t unit, kinc_g4_texture_filter_t filter) {}
+void kinc_compute_set_texture3d_mipmap_filter(kinc_compute_texture_unit_t unit, kinc_g4_mipmap_filter_t filter) {}
+void kinc_compute_set_shader(kinc_compute_shader_t *shader) {}
+void kinc_compute(int x, int y, int z) {}

--- a/Backends/Graphics5/WebGPU/Sources/Kore/ComputeImpl.h
+++ b/Backends/Graphics5/WebGPU/Sources/Kore/ComputeImpl.h
@@ -1,0 +1,13 @@
+#pragma once
+
+typedef struct {
+	int nothing;
+} kinc_compute_constant_location_impl_t;
+
+typedef struct {
+	int nothing;
+} kinc_compute_texture_unit_impl_t;
+
+typedef struct {
+	int nothing;
+} kinc_compute_shader_impl_t;

--- a/Backends/Graphics5/WebGPU/Sources/Kore/ConstantBuffer5Impl.c
+++ b/Backends/Graphics5/WebGPU/Sources/Kore/ConstantBuffer5Impl.c
@@ -1,0 +1,36 @@
+#include "pch.h"
+
+#include <kinc/graphics5/constantbuffer.h>
+
+#include <stdlib.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+bool kinc_g5_transposeMat3 = false;
+bool kinc_g5_transposeMat4 = false;
+
+void kinc_g5_constant_buffer_init(kinc_g5_constant_buffer_t *buffer, int size) {
+	
+}
+
+void kinc_g5_constant_buffer_destroy(kinc_g5_constant_buffer_t *buffer) {}
+
+void kinc_g5_constant_buffer_lock_all(kinc_g5_constant_buffer_t *buffer) {
+	kinc_g5_constant_buffer_lock(buffer, 0, kinc_g5_constant_buffer_size(buffer));
+}
+
+void kinc_g5_constant_buffer_lock(kinc_g5_constant_buffer_t *buffer, int start, int count) {}
+
+void kinc_g5_constant_buffer_unlock(kinc_g5_constant_buffer_t *buffer) {
+	
+}
+
+int kinc_g5_constant_buffer_size(kinc_g5_constant_buffer_t *buffer) {
+	return 0;
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/Backends/Graphics5/WebGPU/Sources/Kore/ConstantBuffer5Impl.h
+++ b/Backends/Graphics5/WebGPU/Sources/Kore/ConstantBuffer5Impl.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+	
+} ConstantBuffer5Impl;
+
+#ifdef __cplusplus
+}
+#endif

--- a/Backends/Graphics5/WebGPU/Sources/Kore/Graphics5Impl.h
+++ b/Backends/Graphics5/WebGPU/Sources/Kore/Graphics5Impl.h
@@ -1,0 +1,6 @@
+#pragma once
+
+#include "IndexBuffer5Impl.h"
+#include "RenderTarget5Impl.h"
+#include "Texture5Impl.h"
+#include "VertexBuffer5Impl.h"

--- a/Backends/Graphics5/WebGPU/Sources/Kore/IndexBuffer5Impl.c
+++ b/Backends/Graphics5/WebGPU/Sources/Kore/IndexBuffer5Impl.c
@@ -1,0 +1,41 @@
+#include "pch.h"
+
+#include "IndexBuffer5Impl.h"
+
+#include <string.h>
+#include <stdlib.h>
+#include <kinc/graphics5/indexbuffer.h>
+
+extern WGPUDevice device;
+
+kinc_g5_index_buffer_t *kinc_g5_internal_current_index_buffer = NULL;
+
+void kinc_g5_index_buffer_init(kinc_g5_index_buffer_t *buffer, int count, bool gpuMemory) {
+	buffer->impl.count = count;
+}
+
+void kinc_g5_index_buffer_destroy(kinc_g5_index_buffer_t *buffer) {
+	
+}
+
+int *kinc_g5_index_buffer_lock(kinc_g5_index_buffer_t *buffer) {
+	WGPUBufferDescriptor bDesc;
+	memset(&bDesc, 0, sizeof(bDesc));
+	bDesc.size = buffer->impl.count * sizeof(int);
+	bDesc.usage = WGPUBufferUsage_Index | WGPUBufferUsage_CopyDst;
+	WGPUCreateBufferMappedResult mapped = wgpuDeviceCreateBufferMapped(device, &bDesc);
+	buffer->impl.buffer = mapped.buffer;
+	return mapped.data;
+}
+
+void kinc_g5_index_buffer_unlock(kinc_g5_index_buffer_t *buffer) {
+	wgpuBufferUnmap(buffer->impl.buffer);
+}
+
+void kinc_g5_internal_index_buffer_set(kinc_g5_index_buffer_t *buffer) {
+	
+}
+
+int kinc_g5_index_buffer_count(kinc_g5_index_buffer_t *buffer) {
+	return buffer->impl.count;
+}

--- a/Backends/Graphics5/WebGPU/Sources/Kore/IndexBuffer5Impl.h
+++ b/Backends/Graphics5/WebGPU/Sources/Kore/IndexBuffer5Impl.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <webgpu/webgpu.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+	WGPUBuffer buffer;
+	int count;
+} IndexBuffer5Impl;
+
+#ifdef __cplusplus
+}
+#endif

--- a/Backends/Graphics5/WebGPU/Sources/Kore/PipelineState5Impl.c
+++ b/Backends/Graphics5/WebGPU/Sources/Kore/PipelineState5Impl.c
@@ -1,0 +1,118 @@
+#include "pch.h"
+
+#include <string.h>
+#include <kinc/graphics5/pipeline.h>
+#include <kinc/graphics5/constantlocation.h>
+
+extern WGPUDevice device;
+
+void kinc_g5_pipeline_init(kinc_g5_pipeline_t *pipe) {
+	kinc_g5_internal_pipeline_init(pipe);
+}
+
+kinc_g5_constant_location_t kinc_g5_pipeline_get_constant_location(kinc_g5_pipeline_t *pipe, const char* name) {
+	kinc_g5_constant_location_t location;
+	return location;
+}
+
+kinc_g5_texture_unit_t kinc_g5_pipeline_get_texture_unit(kinc_g5_pipeline_t *pipe, const char *name) {
+	kinc_g5_texture_unit_t unit;
+	return unit;
+}
+
+void kinc_g5_pipeline_compile(kinc_g5_pipeline_t *pipe) {
+	WGPUColorStateDescriptor csDesc;
+	memset(&csDesc, 0, sizeof(csDesc));
+	csDesc.format = WGPUTextureFormat_BGRA8Unorm;
+	csDesc.writeMask = WGPUColorWriteMask_All;
+	csDesc.colorBlend.operation = WGPUBlendOperation_Add;
+	csDesc.colorBlend.srcFactor = WGPUBlendFactor_One;
+	csDesc.colorBlend.dstFactor = WGPUBlendFactor_Zero;
+	csDesc.alphaBlend.operation = WGPUBlendOperation_Add;
+	csDesc.alphaBlend.srcFactor = WGPUBlendFactor_One;
+	csDesc.alphaBlend.dstFactor = WGPUBlendFactor_Zero;
+
+	WGPUPipelineLayoutDescriptor plDesc;
+	memset(&plDesc, 0, sizeof(plDesc));
+	plDesc.bindGroupLayoutCount = 0;
+	plDesc.bindGroupLayouts = NULL;
+
+	WGPUProgrammableStageDescriptor vertDesc;
+	memset(&vertDesc, 0, sizeof(vertDesc));
+	vertDesc.module = pipe->vertexShader->impl.module;
+	vertDesc.entryPoint = "main";
+
+	WGPUProgrammableStageDescriptor fragDesc;
+	memset(&fragDesc, 0, sizeof(fragDesc));
+	fragDesc.module = pipe->fragmentShader->impl.module;
+	fragDesc.entryPoint = "main";
+
+	WGPUVertexAttributeDescriptor vaDesc[8];
+	memset(&vaDesc[0], 0, sizeof(vaDesc[0]) * 8);
+	uint64_t offset = 0;
+	for (int i = 0; i < pipe->inputLayout[0]->size; ++i) {
+		vaDesc[i].shaderLocation = i;
+		vaDesc[i].offset = offset;
+		switch (pipe->inputLayout[0]->elements[i].data) {
+		case KINC_G4_VERTEX_DATA_FLOAT1:
+			vaDesc[i].format = WGPUVertexFormat_Float;
+			offset += 4;
+			break;
+		case KINC_G4_VERTEX_DATA_FLOAT2:
+			vaDesc[i].format = WGPUVertexFormat_Float2;
+			offset += 8;
+			break;
+		case KINC_G4_VERTEX_DATA_FLOAT3:
+			vaDesc[i].format = WGPUVertexFormat_Float3;
+			offset += 12;
+			break;
+		case KINC_G4_VERTEX_DATA_FLOAT4:
+			vaDesc[i].format = WGPUVertexFormat_Float4;
+			offset += 16;
+			break;
+		case KINC_G4_VERTEX_DATA_COLOR:
+			vaDesc[i].format = WGPUVertexFormat_UChar4Norm;
+			offset += 4;
+			break;
+		case KINC_G4_VERTEX_DATA_SHORT2_NORM:
+			vaDesc[i].format = WGPUVertexFormat_Short2Norm;
+			offset += 4;
+			break;
+		case KINC_G4_VERTEX_DATA_SHORT4_NORM:
+			vaDesc[i].format = WGPUVertexFormat_Short4Norm;
+			offset += 8;
+			break;
+		}
+	}
+
+	WGPUVertexBufferLayoutDescriptor vbDesc;
+	memset(&vbDesc, 0, sizeof(vbDesc));
+	vbDesc.arrayStride = offset;
+	vbDesc.attributeCount = pipe->inputLayout[0]->size;
+	vbDesc.attributes = &vaDesc[0];
+
+	WGPUVertexStateDescriptor vsDest;
+	memset(&vsDest, 0, sizeof(vsDest));
+	vsDest.indexFormat = WGPUIndexFormat_Uint32;
+	vsDest.vertexBufferCount = 1;
+	vsDest.vertexBuffers = &vbDesc;
+
+	WGPURasterizationStateDescriptor rsDesc;
+	memset(&rsDesc, 0, sizeof(rsDesc));
+	rsDesc.frontFace = WGPUFrontFace_CW;
+	rsDesc.cullMode = WGPUCullMode_None;
+
+	WGPURenderPipelineDescriptor rpDesc;
+	memset(&rpDesc, 0, sizeof(rpDesc));
+	rpDesc.layout = wgpuDeviceCreatePipelineLayout(device, &plDesc);
+	rpDesc.vertexStage = vertDesc;
+	rpDesc.fragmentStage = &fragDesc;
+	rpDesc.colorStateCount = 1;
+	rpDesc.colorStates = &csDesc;
+	rpDesc.primitiveTopology = WGPUPrimitiveTopology_TriangleList;
+	rpDesc.vertexState = &vsDest;
+	rpDesc.sampleCount = 1;
+	rpDesc.rasterizationState = &rsDesc;
+	rpDesc.sampleMask = 0xffffffff;
+	pipe->impl.pipeline = wgpuDeviceCreateRenderPipeline(device, &rpDesc);
+}

--- a/Backends/Graphics5/WebGPU/Sources/Kore/PipelineState5Impl.h
+++ b/Backends/Graphics5/WebGPU/Sources/Kore/PipelineState5Impl.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <webgpu/webgpu.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+	WGPURenderPipeline pipeline;
+} PipelineState5Impl;
+
+typedef struct {
+	int vertexOffset;
+	int fragmentOffset;
+} ConstantLocation5Impl;
+
+#ifdef __cplusplus
+}
+#endif

--- a/Backends/Graphics5/WebGPU/Sources/Kore/RenderTarget5Impl.c
+++ b/Backends/Graphics5/WebGPU/Sources/Kore/RenderTarget5Impl.c
@@ -1,0 +1,24 @@
+#include "pch.h"
+
+#include <kinc/graphics5/rendertarget.h>
+#include <kinc/log.h>
+
+void kinc_g5_render_target_init(kinc_g5_render_target_t *renderTarget, int width, int height, int depthBufferBits, bool antialiasing,
+                                kinc_g5_render_target_format_t format, int stencilBufferBits, int contextId) {
+	
+}
+
+void kinc_g5_render_target_init_cube(kinc_g5_render_target_t *renderTarget, int cubeMapSize, int depthBufferBits, bool antialiasing,
+                                     kinc_g5_render_target_format_t format, int stencilBufferBits, int contextId) {}
+
+void kinc_g5_render_target_destroy(kinc_g5_render_target_t *renderTarget) {}
+
+void kinc_g5_render_target_use_color_as_texture(kinc_g5_render_target_t *renderTarget, kinc_g5_texture_unit_t unit) {}
+
+void kinc_g5_render_target_use_depth_as_texture(kinc_g5_render_target_t *renderTarget, kinc_g5_texture_unit_t unit) {}
+
+void kinc_g5_render_target_set_depth_stencil_from(kinc_g5_render_target_t *renderTarget, kinc_g5_render_target_t *source) {}
+
+void kinc_g5_render_target_get_pixels(kinc_g5_render_target_t *renderTarget, uint8_t *data) {}
+
+void kinc_g5_render_target_generate_mipmaps(kinc_g5_render_target_t *renderTarget, int levels) {}

--- a/Backends/Graphics5/WebGPU/Sources/Kore/RenderTarget5Impl.h
+++ b/Backends/Graphics5/WebGPU/Sources/Kore/RenderTarget5Impl.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+	
+} RenderTarget5Impl;
+
+#ifdef __cplusplus
+}
+#endif

--- a/Backends/Graphics5/WebGPU/Sources/Kore/Shader5Impl.c
+++ b/Backends/Graphics5/WebGPU/Sources/Kore/Shader5Impl.c
@@ -1,0 +1,14 @@
+#include "pch.h"
+
+#include <string.h>
+#include <kinc/graphics5/shader.h>
+
+extern WGPUDevice device;
+
+void kinc_g5_shader_init(kinc_g5_shader_t *shader, void *source, size_t length, kinc_g5_shader_type_t type) {
+	WGPUShaderModuleDescriptor smDesc;
+	memset(&smDesc, 0, sizeof(smDesc));
+	smDesc.codeSize = length / 4;
+	smDesc.code = source;
+	shader->impl.module = wgpuDeviceCreateShaderModule(device, &smDesc);
+}

--- a/Backends/Graphics5/WebGPU/Sources/Kore/Shader5Impl.h
+++ b/Backends/Graphics5/WebGPU/Sources/Kore/Shader5Impl.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <webgpu/webgpu.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct WGPUShaderModuleImpl;
+
+typedef struct {
+	WGPUShaderModule module;
+} Shader5Impl;
+
+#ifdef __cplusplus
+}
+#endif

--- a/Backends/Graphics5/WebGPU/Sources/Kore/Texture5Impl.c
+++ b/Backends/Graphics5/WebGPU/Sources/Kore/Texture5Impl.c
@@ -1,0 +1,58 @@
+#include "pch.h"
+
+#include "Texture5Impl.h"
+
+#include <kinc/graphics5/texture.h>
+
+void kinc_g5_texture_init(kinc_g5_texture_t *texture, int width, int height, kinc_image_format_t format) {
+
+	// WGPUExtent3D size = {};
+	// size.width = kinc_width();
+	// size.height = kinc_height();
+	// size.depth = 1;
+
+	// WGPUTextureDescriptor tDesc = {};
+	// tDesc.sampleCount = 1;
+	// tDesc.format = WGPUTextureFormat_BGRA8Unorm;
+	// tDesc.usage = WGPUTextureUsage_OutputAttachment;
+	// tDesc.size = size;
+	// tDesc.dimension = WGPUTextureDimension_2D;
+	// tDesc.mipLevelCount = 1;
+	// tDesc.arrayLayerCount = 1;
+	// WGPUTexture texture = wgpuDeviceCreateTexture(device, &tDesc);
+
+	// WGPUTextureViewDescriptor tvDesc = {};
+	// tvDesc.format = WGPUTextureFormat_BGRA8Unorm;
+	// tvDesc.dimension = WGPUTextureViewDimension_2D;
+ 	// WGPUTextureView textureView = wgpuTextureCreateView(texture, &tvDesc);
+
+}
+void kinc_g5_texture_init3d(kinc_g5_texture_t *texture, int width, int height, int depth, kinc_image_format_t format) {}
+void kinc_g5_texture_init_from_image(kinc_g5_texture_t *texture, kinc_image_t *image) {}
+void kinc_g5_texture_init_from_encoded_data(kinc_g5_texture_t *texture, void *data, int size, const char *format, bool readable) {}
+void kinc_g5_texture_init_from_data(kinc_g5_texture_t *texture, void *data, int width, int height, int format, bool readable) {}
+void kinc_g5_texture_destroy(kinc_g5_texture_t *texture) {}
+
+// void Texture5Impl::unmipmap() {
+//	mipmap = false;
+//}
+
+// void Graphics5::Texture::_set(TextureUnit unit) {}
+
+// void Texture5Impl::unset() {}
+
+uint8_t *kinc_g5_texture_lock(kinc_g5_texture_t *texture) {
+	return NULL;
+}
+
+void kinc_g5_texture_unlock(kinc_g5_texture_t *texture) {}
+
+void kinc_g5_texture_clear(kinc_g5_texture_t *texture, int x, int y, int z, int width, int height, int depth, unsigned color) {}
+
+int kinc_g5_texture_stride(kinc_g5_texture_t *texture) {
+	return 32;
+}
+
+void kinc_g5_texture_generate_mipmaps(kinc_g5_texture_t *texture, int levels) {}
+
+void kinc_g5_texture_set_mipmap(kinc_g5_texture_t *texture, kinc_g5_texture_t *mipmap, int level) {}

--- a/Backends/Graphics5/WebGPU/Sources/Kore/Texture5Impl.h
+++ b/Backends/Graphics5/WebGPU/Sources/Kore/Texture5Impl.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+} TextureUnit5Impl;
+
+typedef struct {
+} Texture5Impl;
+
+#ifdef __cplusplus
+}
+#endif

--- a/Backends/Graphics5/WebGPU/Sources/Kore/VertexBuffer5Impl.c
+++ b/Backends/Graphics5/WebGPU/Sources/Kore/VertexBuffer5Impl.c
@@ -1,0 +1,74 @@
+#include "pch.h"
+
+#include <stdlib.h>
+#include <string.h>
+#include <kinc/graphics5/vertexbuffer.h>
+#include <kinc/log.h>
+
+extern WGPUDevice device;
+
+kinc_g5_vertex_buffer_t *kinc_g5_internal_current_vertex_buffer = NULL;
+
+void kinc_g5_vertex_buffer_init(kinc_g5_vertex_buffer_t *buffer, int count, kinc_g5_vertex_structure_t *structure, bool gpuMemory, int instanceDataStepRate) {
+	buffer->impl.count = count;
+	buffer->impl.stride = 0;
+	for (int i = 0; i < structure->size; ++i) {
+		switch (structure->elements[i].data) {
+		case KINC_G4_VERTEX_DATA_FLOAT1:
+			buffer->impl.stride += 1 * 4;
+			break;
+		case KINC_G4_VERTEX_DATA_FLOAT2:
+			buffer->impl.stride += 2 * 4;
+			break;
+		case KINC_G4_VERTEX_DATA_FLOAT3:
+			buffer->impl.stride += 3 * 4;
+			break;
+		case KINC_G4_VERTEX_DATA_FLOAT4:
+			buffer->impl.stride += 4 * 4;
+			break;
+		case KINC_G4_VERTEX_DATA_COLOR:
+			buffer->impl.stride += 1 * 4;
+			break;
+		case KINC_G4_VERTEX_DATA_SHORT2_NORM:
+			buffer->impl.stride += 2 * 2;
+			break;
+		case KINC_G4_VERTEX_DATA_SHORT4_NORM:
+			buffer->impl.stride += 4 * 2;
+			break;
+		}
+	}
+}
+
+void kinc_g5_vertex_buffer_destroy(kinc_g5_vertex_buffer_t *buffer) {
+	
+}
+
+float *kinc_g5_vertex_buffer_lock_all(kinc_g5_vertex_buffer_t *buffer) {
+	WGPUBufferDescriptor bDesc;
+	memset(&bDesc, 0, sizeof(bDesc));
+	bDesc.size = buffer->impl.count * buffer->impl.stride * sizeof(float);
+	bDesc.usage = WGPUBufferUsage_Vertex | WGPUBufferUsage_CopyDst;
+	WGPUCreateBufferMappedResult mapped = wgpuDeviceCreateBufferMapped(device, &bDesc);
+	buffer->impl.buffer = mapped.buffer;
+	return mapped.data;
+}
+
+float *kinc_g5_vertex_buffer_lock(kinc_g5_vertex_buffer_t *buffer, int start, int count) {
+	return NULL;
+}
+
+void kinc_g5_vertex_buffer_unlock_all(kinc_g5_vertex_buffer_t *buffer) {
+	wgpuBufferUnmap(buffer->impl.buffer);
+}
+
+void kinc_g5_vertex_buffer_unlock(kinc_g5_vertex_buffer_t* buffer, int count) {
+	
+}
+
+int kinc_g5_vertex_buffer_count(kinc_g5_vertex_buffer_t *buffer) {
+	return buffer->impl.count;
+}
+
+int kinc_g5_vertex_buffer_stride(kinc_g5_vertex_buffer_t *buffer) {
+	return buffer->impl.stride;
+}

--- a/Backends/Graphics5/WebGPU/Sources/Kore/VertexBuffer5Impl.h
+++ b/Backends/Graphics5/WebGPU/Sources/Kore/VertexBuffer5Impl.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <webgpu/webgpu.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+	WGPUBuffer buffer;
+	int count;
+	int stride;
+} VertexBuffer5Impl;
+
+#ifdef __cplusplus
+}
+#endif

--- a/Backends/Graphics5/WebGPU/Sources/Kore/WebGPU.c
+++ b/Backends/Graphics5/WebGPU/Sources/Kore/WebGPU.c
@@ -1,0 +1,106 @@
+#include "pch.h"
+
+#include <string.h>
+#include <emscripten.h>
+#include <emscripten/html5.h>
+#include <webgpu/webgpu.h>
+#include <kinc/graphics5/graphics.h>
+#include <kinc/graphics5/pipeline.h>
+#include <kinc/math/core.h>
+#include <kinc/system.h>
+#include <kinc/log.h>
+
+int renderTargetWidth;
+int renderTargetHeight;
+int newRenderTargetWidth;
+int newRenderTargetHeight;
+
+WGPUDevice device;
+WGPUQueue queue;
+WGPUSwapChain swapChain;
+
+void kinc_g5_destroy(int windowId) {}
+
+void kinc_internal_g5_resize(int window, int width, int height) {}
+
+void kinc_g5_init(int window, int depthBufferBits, int stencilBufferBits, bool vsync) {
+	newRenderTargetWidth = renderTargetWidth = kinc_width();
+	newRenderTargetHeight = renderTargetHeight = kinc_height();
+
+	device = emscripten_webgpu_get_device();
+	queue = wgpuDeviceCreateQueue(device);
+
+	WGPUSurfaceDescriptorFromHTMLCanvasId canvasDesc;
+	memset(&canvasDesc, 0, sizeof(canvasDesc));
+	canvasDesc.id = "canvas";
+
+	WGPUSurfaceDescriptor surfDesc;
+	memset(&surfDesc, 0, sizeof(surfDesc));
+	surfDesc.nextInChain = &canvasDesc;
+	WGPUInstance instance = 0;
+	WGPUSurface surface = wgpuInstanceCreateSurface(instance, &surfDesc);
+
+	WGPUSwapChainDescriptor scDesc;
+	memset(&scDesc, 0, sizeof(scDesc));
+	scDesc.usage = WGPUTextureUsage_OutputAttachment;
+	scDesc.format = WGPUTextureFormat_BGRA8Unorm;
+	scDesc.width = kinc_width();
+	scDesc.height = kinc_height();
+	scDesc.presentMode = WGPUPresentMode_VSync;
+	swapChain = wgpuDeviceCreateSwapChain(device, surface, &scDesc);
+}
+
+void kinc_g5_draw_indexed_vertices_instanced(int instanceCount) {}
+
+void kinc_g5_draw_indexed_vertices_instanced_from_to(int instanceCount, int start, int count) {}
+
+void kinc_g5_draw_indexed_vertices_instanced_from_to_from(int instanceCount, int start, int count, int vertex_offset) {}
+
+void kinc_g5_set_texture_addressing(kinc_g5_texture_unit_t unit, kinc_g5_texture_direction_t dir, kinc_g5_texture_addressing_t addressing) {}
+
+void kinc_g5_begin(kinc_g5_render_target_t *renderTarget, int window) {}
+
+void kinc_g5_end(int window) {}
+
+bool kinc_g5_swap_buffers() {
+	return true;
+}
+
+void kinc_g5_flush() {}
+
+void kinc_g5_set_texture_operation(kinc_g5_texture_operation_t operation, kinc_g5_texture_argument_t arg1, kinc_g5_texture_argument_t arg2) {}
+
+void kinc_g5_set_texture_magnification_filter(kinc_g5_texture_unit_t texunit, kinc_g5_texture_filter_t filter) {}
+
+void kinc_g5_set_texture_minification_filter(kinc_g5_texture_unit_t texunit, kinc_g5_texture_filter_t filter) {}
+
+void kinc_g5_set_texture_mipmap_filter(kinc_g5_texture_unit_t texunit, kinc_g5_mipmap_filter_t filter) {}
+
+bool kinc_g5_render_targets_inverted_y() {
+	return false;
+}
+bool kinc_g5_non_pow2_textures_qupported() {
+	return true;
+}
+
+void kinc_g5_set_render_target_face(kinc_g5_render_target_t *texture, int face) {}
+
+void kinc_g5_set_texture(kinc_g5_texture_unit_t unit, kinc_g5_texture_t *texture) {
+	
+}
+
+void kinc_g5_set_image_texture(kinc_g5_texture_unit_t unit, kinc_g5_texture_t *texture) {}
+
+bool kinc_g5_init_occlusion_query(unsigned *occlusionQuery) {
+	return false;
+}
+
+void kinc_g5_delete_occlusion_query(unsigned occlusionQuery) {}
+
+void kinc_g5_render_occlusion_query(unsigned occlusionQuery, int triangles) {}
+
+bool kinc_g5_are_query_results_available(unsigned occlusionQuery) {
+	return false;
+}
+
+void kinc_g5_get_query_result(unsigned occlusionQuery, unsigned *pixelCount) {}

--- a/Backends/Graphics5/WebGPU/Sources/Kore/WebGPU.h
+++ b/Backends/Graphics5/WebGPU/Sources/Kore/WebGPU.h
@@ -1,0 +1,4 @@
+#pragma once
+
+#include <kinc/graphics5/graphics.h>
+#include <kinc/math/matrix.h>

--- a/Backends/Graphics5/WebGPU/Sources/Kore/pch.h
+++ b/Backends/Graphics5/WebGPU/Sources/Kore/pch.h
@@ -1,0 +1,1 @@
+#include <Kore/pch.h>

--- a/kincfile.js
+++ b/kincfile.js
@@ -295,13 +295,24 @@ else if (platform === Platform.Android) {
 	project.addLib('OpenMAXAL');
 }
 else if (platform === Platform.HTML5) {
-	g4 = true;
 	project.addDefine('KORE_HTML5');
 	addBackend('System/HTML5');
-	addBackend('Graphics4/OpenGL');
-	project.addExclude('Backends/Graphics4/OpenGL/Sources/GL/**');
-	project.addDefine('KORE_OPENGL');
-	project.addDefine('KORE_OPENGL_ES');
+	if (graphics === GraphicsApi.WebGPU) {
+		g4 = true;
+		g5 = true;
+		addBackend('Graphics5/WebGPU');
+		project.addDefine('KORE_WEBGPU');
+	}
+	else if (graphics === GraphicsApi.OpenGL || graphics === GraphicsApi.Default) {
+		g4 = true;
+		addBackend('Graphics4/OpenGL');
+		project.addExclude('Backends/Graphics4/OpenGL/Sources/GL/**');
+		project.addDefine('KORE_OPENGL');
+		project.addDefine('KORE_OPENGL_ES');
+	}
+	else {
+		throw new Error('Graphics API ' + graphics + ' is not available for HTML5.');
+	}
 }
 else if (platform === Platform.Linux) {
 	project.addDefine('KORE_LINUX');


### PR DESCRIPTION
Just the basics, gets the red triangle running!

- Tested on example: https://github.com/luboslenco/ShaderG5-Kinc
- `node Kinc/make html5 -g webgpu` to build + compile with [emscripten](https://github.com/Kode/Kinc/blob/master/.github/workflows/html5-webgpu.yml)
- Uses spirv shaders for now
- See [implementation status](https://github.com/gpuweb/gpuweb/wiki/Implementation-Status) of WebGPU in browsers

To go with https://github.com/Kode/kincmake/pull/91.

Edit: As of now [webgpu.h](https://github.com/emscripten-core/emscripten/blob/master/system/include/webgpu/webgpu.h) in emscripten is a bit outdated which results in https://github.com/webgpu-native/webgpu-headers/pull/34 - the latest one can be found [here](https://github.com/webgpu-native/webgpu-headers/blob/master/webgpu.h).