### PR TITLE
Add kinc_g5_texture_init_non_sampled_access

### DIFF
--- a/Backends/Graphics5/G5onG4/Sources/Kore/Texture5Impl.c
+++ b/Backends/Graphics5/G5onG4/Sources/Kore/Texture5Impl.c
@@ -9,6 +9,7 @@ void kinc_g5_texture_init3d(kinc_g5_texture_t *texture, int width, int height, i
 void kinc_g5_texture_init_from_image(kinc_g5_texture_t *texture, kinc_image_t *image) {}
 void kinc_g5_texture_init_from_encoded_data(kinc_g5_texture_t *texture, void *data, int size, const char *format, bool readable) {}
 void kinc_g5_texture_init_from_data(kinc_g5_texture_t *texture, void *data, int width, int height, int format, bool readable) {}
+void kinc_g5_texture_init_non_sampled_access(kinc_g5_texture_t *texture, int width, int height, kinc_image_format_t format) {}
 void kinc_g5_texture_destroy(kinc_g5_texture_t *texture) {}
 
 // void Texture5Impl::unmipmap() {

--- a/Backends/Graphics5/Metal/Sources/Kore/Texture5Impl.mm
+++ b/Backends/Graphics5/Metal/Sources/Kore/Texture5Impl.mm
@@ -31,7 +31,7 @@ namespace {
 
 static void create(kinc_g5_texture_t *texture, int width, int height, int format, bool writable) {
 	id<MTLDevice> device = getMetalDevice();
-	
+
 	MTLTextureDescriptor* descriptor = [MTLTextureDescriptor texture2DDescriptorWithPixelFormat:convert((kinc_image_format_t)format) width:width height:height mipmapped:NO];
 	descriptor.textureType = MTLTextureType2D;
 	descriptor.width = width;
@@ -44,9 +44,9 @@ static void create(kinc_g5_texture_t *texture, int width, int height, int format
 	if (writable) {
 		descriptor.usage = MTLTextureUsageShaderWrite | MTLTextureUsageShaderRead;
 	}
-	
+
 	texture->impl._tex = [device newTextureWithDescriptor:descriptor];
-	
+
 	texture->impl._samplerDesc = (MTLSamplerDescriptor*)[[MTLSamplerDescriptor alloc] init];
     MTLSamplerDescriptor* desc = (MTLSamplerDescriptor*) texture->impl._samplerDesc;
 	desc.minFilter = MTLSamplerMinMagFilterNearest;
@@ -90,6 +90,8 @@ void kinc_g5_texture_init_from_image(kinc_g5_texture_t *texture, kinc_image *ima
 	[tex replaceRegion:MTLRegionMake2D(0, 0, texture->texWidth, texture->texHeight) mipmapLevel:0 slice:0 withBytes:image->data bytesPerRow:kinc_g5_texture_stride(texture) bytesPerImage:kinc_g5_texture_stride(texture) * texture->texHeight];
 }
 
+void kinc_g5_texture_init_non_sampled_access(kinc_g5_texture_t *texture, int width, int height, kinc_image_format_t format) {}
+
 void kinc_g5_texture_destroy(kinc_g5_texture_t *texture) {
 	texture->impl._sampler = nil;
 	texture->impl._tex = nil;
@@ -112,7 +114,7 @@ void kinc_g5_internal_set_texture_descriptor(kinc_g5_texture_t *texture, kinc_g5
         default:
             desc.minFilter = MTLSamplerMinMagFilterLinear;
     }
-    
+
     switch(descriptor.filter_magnification) {
         case KINC_G5_TEXTURE_FILTER_POINT:
             desc.magFilter = MTLSamplerMinMagFilterNearest;
@@ -135,7 +137,7 @@ void kinc_g5_internal_set_texture_descriptor(kinc_g5_texture_t *texture, kinc_g5
             desc.sAddressMode = MTLSamplerAddressModeClampToBorderColor;
             break;
     }
-    
+
     switch(descriptor.addressing_v) {
         case KINC_G5_TEXTURE_ADDRESSING_REPEAT:
             desc.tAddressMode = MTLSamplerAddressModeRepeat;

--- a/Backends/Graphics5/Vulkan/Sources/Kore/Texture5Impl.cpp
+++ b/Backends/Graphics5/Vulkan/Sources/Kore/Texture5Impl.cpp
@@ -309,6 +309,10 @@ void kinc_g5_texture_init3d(kinc_g5_texture_t* texture, int width, int height, i
 
 }
 
+void kinc_g5_texture_init_non_sampled_access(kinc_g5_texture_t *texture, int width, int height, kinc_image_format_t format) {
+
+}
+
 void kinc_g5_texture_destroy(kinc_g5_texture_t *texture) {}
 
 void kinc_g5_internal_texture_set(kinc_g5_texture_t *texture, int unit) {}

--- a/Backends/Graphics5/WebGPU/Sources/Kore/Texture5Impl.c
+++ b/Backends/Graphics5/WebGPU/Sources/Kore/Texture5Impl.c
@@ -31,6 +31,7 @@ void kinc_g5_texture_init3d(kinc_g5_texture_t *texture, int width, int height, i
 void kinc_g5_texture_init_from_image(kinc_g5_texture_t *texture, kinc_image_t *image) {}
 void kinc_g5_texture_init_from_encoded_data(kinc_g5_texture_t *texture, void *data, int size, const char *format, bool readable) {}
 void kinc_g5_texture_init_from_data(kinc_g5_texture_t *texture, void *data, int width, int height, int format, bool readable) {}
+void kinc_g5_texture_init_non_sampled_access(kinc_g5_texture_t *texture, int width, int height, kinc_image_format_t format) {}
 void kinc_g5_texture_destroy(kinc_g5_texture_t *texture) {}
 
 // void Texture5Impl::unmipmap() {

--- a/Sources/kinc/graphics5/texture.h
+++ b/Sources/kinc/graphics5/texture.h
@@ -22,6 +22,7 @@ void kinc_g5_texture_init3d(kinc_g5_texture_t *texture, int width, int height, i
 void kinc_g5_texture_init_from_image(kinc_g5_texture_t *texture, kinc_image_t *image);
 //void kinc_g5_texture_init_from_encoded_data(kinc_g5_texture_t *texture, void *data, int size, const char *format, bool readable);
 //void kinc_g5_texture_init_from_data(kinc_g5_texture_t *texture, void *data, int width, int height, int format, bool readable);
+void kinc_g5_texture_init_non_sampled_access(kinc_g5_texture_t *texture, int width, int height, kinc_image_format_t format);
 void kinc_g5_texture_destroy(kinc_g5_texture_t *texture);
 #ifdef KORE_ANDROID
 void kinc_g5_texture_init_from_id(kinc_g5_texture_t *texture, unsigned texid);


### PR DESCRIPTION
- Allows to create non-sampled / unordered access textures usable for compute / raytracing
- Created as `kinc_g5_texture`, since [D3D12 docs](https://docs.microsoft.com/en-us/windows/win32/api/d3d12/ne-d3d12-d3d12_resource_flags) discourage using it as a render target
- Created via `kinc_g5_texture_init_non_sampled_access` to prevent api changes
- Implemented for D3D12

Feedback on naming / placement welcome!