### PR TITLE
Improve raytracing api

### DIFF
--- a/Backends/Graphics5/Direct3D12/Sources/Kore/CommandList5Impl.cpp
+++ b/Backends/Graphics5/Direct3D12/Sources/Kore/CommandList5Impl.cpp
@@ -76,9 +76,11 @@ namespace {
 		waitForFence(renderFence, renderFenceValue, renderFenceEvent);
 		commandAllocator->Reset();
 		list->impl._commandList->Reset(commandAllocator, nullptr);
-		list->impl._commandList->OMSetRenderTargets(1, &renderTarget->impl.renderTargetDescriptorHeap->GetCPUDescriptorHandleForHeapStart(), true, nullptr);
-		list->impl._commandList->RSSetViewports(1, (D3D12_VIEWPORT *)&renderTarget->impl.viewport);
-		list->impl._commandList->RSSetScissorRects(1, (D3D12_RECT *)&renderTarget->impl.scissor);
+		if (renderTarget != nullptr) {
+			list->impl._commandList->OMSetRenderTargets(1, &renderTarget->impl.renderTargetDescriptorHeap->GetCPUDescriptorHandleForHeapStart(), true, nullptr);
+			list->impl._commandList->RSSetViewports(1, (D3D12_VIEWPORT *)&renderTarget->impl.viewport);
+			list->impl._commandList->RSSetScissorRects(1, (D3D12_RECT *)&renderTarget->impl.scissor);
+		}
 	}
 
 	void graphicsFlushAndWait(kinc_g5_command_list *list, ID3D12CommandAllocator *commandAllocator, kinc_g5_render_target_t *renderTarget) {

--- a/Backends/Graphics5/Direct3D12/Sources/Kore/RayTraceImpl.h
+++ b/Backends/Graphics5/Direct3D12/Sources/Kore/RayTraceImpl.h
@@ -20,11 +20,6 @@ typedef struct {
 	ID3D12Resource* top_level_accel;
 } kinc_raytrace_acceleration_structure_impl_t;
 
-typedef struct {
-	ID3D12Resource* _texture;
-	D3D12_GPU_DESCRIPTOR_HANDLE _texture_handle;
-} kinc_raytrace_target_impl_t;
-
 #ifdef __cplusplus
 }
 #endif

--- a/Sources/kinc/graphics5/raytrace.h
+++ b/Sources/kinc/graphics5/raytrace.h
@@ -14,26 +14,20 @@ typedef struct kinc_raytrace_pipeline {
 } kinc_raytrace_pipeline_t;
 
 void kinc_raytrace_pipeline_init(kinc_raytrace_pipeline_t *pipeline, kinc_g5_command_list_t *command_list, void *ray_shader, int ray_shader_size, kinc_g5_constant_buffer_t *constant_buffer);
+void kinc_raytrace_pipeline_destroy(kinc_raytrace_pipeline_t *pipeline);
 
 typedef struct kinc_raytrace_acceleration_structure {
 	kinc_raytrace_acceleration_structure_impl_t impl;
 } kinc_raytrace_acceleration_structure_t;
 
 void kinc_raytrace_acceleration_structure_init(kinc_raytrace_acceleration_structure_t *accel, kinc_g5_command_list_t *command_list, kinc_g5_vertex_buffer_t *vb, kinc_g5_index_buffer_t *ib);
-
-typedef struct kinc_raytrace_target {
-	int _width;
-	int _height;
-	kinc_raytrace_target_impl_t impl;
-} kinc_raytrace_target_t;
-
-void kinc_raytrace_target_init(kinc_raytrace_target_t *target, int width, int height);
+void kinc_raytrace_acceleration_structure_destroy(kinc_raytrace_acceleration_structure_t *accel);
 
 void kinc_raytrace_set_acceleration_structure(kinc_raytrace_acceleration_structure_t *accel);
 void kinc_raytrace_set_pipeline(kinc_raytrace_pipeline_t *pipeline);
-void kinc_raytrace_set_target(kinc_raytrace_target_t *output);
+void kinc_raytrace_set_target(kinc_g5_texture_t *output);
 void kinc_raytrace_dispatch_rays(kinc_g5_command_list_t *command_list);
-void kinc_raytrace_copy_target(kinc_g5_command_list_t *command_list, kinc_g5_render_target_t *render_target, kinc_raytrace_target_t *output);
+void kinc_raytrace_copy(kinc_g5_command_list_t *command_list, kinc_g5_render_target_t *target, kinc_g5_texture_t *source);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Celebrating DXR on Xbox. 🎉 
- Fixed compilation
- `kinc_g5_texture_t` is used for output now
- Added `destroy()` functions
- Updated example at https://github.com/luboslenco/RayTraceG5-Kinc