### PR TITLE
Added return status from socket open call so callers can know if the open failed.

### DIFF
--- a/Sources/Kore/Network/Socket.cpp
+++ b/Sources/Kore/Network/Socket.cpp
@@ -25,8 +25,8 @@ void Socket::init() {
 	kinc_socket_init(&sock);
 }
 
-void Socket::open(int port) {
-	kinc_socket_open(&sock, port);
+bool Socket::open(int port) {
+	return kinc_socket_open(&sock, port) != 0;
 }
 
 Socket::~Socket() {

--- a/Sources/Kore/Network/Socket.cpp
+++ b/Sources/Kore/Network/Socket.cpp
@@ -26,7 +26,7 @@ void Socket::init() {
 }
 
 bool Socket::open(int port) {
-	return kinc_socket_open(&sock, port) != 0;
+	return kinc_socket_open(&sock, port);
 }
 
 Socket::~Socket() {

--- a/Sources/Kore/Network/Socket.h
+++ b/Sources/Kore/Network/Socket.h
@@ -8,7 +8,7 @@ namespace Kore {
 		Socket();
 		~Socket();
 		void init();
-		void open(int port);
+		bool open(int port);
 
 		unsigned urlToInt(const char* url, int port);
 		void setBroadcastEnabled(bool enabled);

--- a/Sources/kinc/network/socket.cpp
+++ b/Sources/kinc/network/socket.cpp
@@ -52,7 +52,7 @@ void kinc_socket_init(kinc_socket_t *sock) {
 	initialized = true;
 }
 
-int kinc_socket_open(kinc_socket_t *sock, int port) {
+bool kinc_socket_open(kinc_socket_t *sock, int port) {
 #if defined(KORE_WINDOWS) || defined(KORE_WINDOWSAPP) || defined(KORE_POSIX)
 	sock->handle = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
 	if (sock->handle <= 0) {
@@ -110,7 +110,7 @@ int kinc_socket_open(kinc_socket_t *sock, int port) {
 			kinc_log(KINC_LOG_LEVEL_ERROR, "Unknown error.");
 		}
 #endif
-		return 0;
+		return false;
 	}
 
 	sockaddr_in address;
@@ -119,7 +119,7 @@ int kinc_socket_open(kinc_socket_t *sock, int port) {
 	address.sin_port = htons((unsigned short)port);
 	if (bind(sock->handle, (const sockaddr*)&address, sizeof(sockaddr_in)) < 0) {
 		kinc_log(KINC_LOG_LEVEL_ERROR, "Could not bind socket.");
-		return 0;
+		return false;
 	}
 #endif
 
@@ -127,17 +127,17 @@ int kinc_socket_open(kinc_socket_t *sock, int port) {
 	DWORD nonBlocking = 1;
 	if (ioctlsocket(sock->handle, FIONBIO, &nonBlocking) != 0) {
 		kinc_log(KINC_LOG_LEVEL_ERROR, "Could not set non-blocking mode.");
-		return 0;
+		return false;
 	}
 #elif defined(KORE_POSIX)
 	int nonBlocking = 1;
 	if (fcntl(sock->handle, F_SETFL, O_NONBLOCK, nonBlocking) == -1) {
 		kinc_log(KINC_LOG_LEVEL_ERROR, "Could not set non-blocking mode.");
-		return 0;
+		return false;
 	}
 #endif
 
-	return 1;
+	return true;
 }
 
 void kinc_socket_destroy(kinc_socket_t *sock) {

--- a/Sources/kinc/network/socket.cpp
+++ b/Sources/kinc/network/socket.cpp
@@ -52,7 +52,7 @@ void kinc_socket_init(kinc_socket_t *sock) {
 	initialized = true;
 }
 
-void kinc_socket_open(kinc_socket_t *sock, int port) {
+int kinc_socket_open(kinc_socket_t *sock, int port) {
 #if defined(KORE_WINDOWS) || defined(KORE_WINDOWSAPP) || defined(KORE_POSIX)
 	sock->handle = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
 	if (sock->handle <= 0) {
@@ -110,7 +110,7 @@ void kinc_socket_open(kinc_socket_t *sock, int port) {
 			kinc_log(KINC_LOG_LEVEL_ERROR, "Unknown error.");
 		}
 #endif
-		return;
+		return 0;
 	}
 
 	sockaddr_in address;
@@ -119,7 +119,7 @@ void kinc_socket_open(kinc_socket_t *sock, int port) {
 	address.sin_port = htons((unsigned short)port);
 	if (bind(sock->handle, (const sockaddr*)&address, sizeof(sockaddr_in)) < 0) {
 		kinc_log(KINC_LOG_LEVEL_ERROR, "Could not bind socket.");
-		return;
+		return 0;
 	}
 #endif
 
@@ -127,15 +127,17 @@ void kinc_socket_open(kinc_socket_t *sock, int port) {
 	DWORD nonBlocking = 1;
 	if (ioctlsocket(sock->handle, FIONBIO, &nonBlocking) != 0) {
 		kinc_log(KINC_LOG_LEVEL_ERROR, "Could not set non-blocking mode.");
-		return;
+		return 0;
 	}
 #elif defined(KORE_POSIX)
 	int nonBlocking = 1;
 	if (fcntl(sock->handle, F_SETFL, O_NONBLOCK, nonBlocking) == -1) {
 		kinc_log(KINC_LOG_LEVEL_ERROR, "Could not set non-blocking mode.");
-		return;
+		return 0;
 	}
 #endif
+
+	return 1;
 }
 
 void kinc_socket_destroy(kinc_socket_t *sock) {
@@ -145,6 +147,7 @@ void kinc_socket_destroy(kinc_socket_t *sock) {
 	close(sock->handle);
 #endif
 	destroy();
+	initialized = false;
 }
 
 unsigned kinc_url_to_int(const char *url, int port) {

--- a/Sources/kinc/network/socket.h
+++ b/Sources/kinc/network/socket.h
@@ -26,7 +26,7 @@ typedef struct {
 
 void kinc_socket_init(kinc_socket_t *socket);
 void kinc_socket_destroy(kinc_socket_t *socket);
-void kinc_socket_open(kinc_socket_t *socket, int port);
+int kinc_socket_open(kinc_socket_t *socket, int port);
 void kinc_socket_set_broadcast_enabled(kinc_socket_t *socket, bool enabled);
 void kinc_socket_send(kinc_socket_t *socket, unsigned address, int port, const unsigned char *data, int size);
 void kinc_socket_send_url(kinc_socket_t *socket, const char *url, int port, const unsigned char *data, int size);

--- a/Sources/kinc/network/socket.h
+++ b/Sources/kinc/network/socket.h
@@ -26,7 +26,7 @@ typedef struct {
 
 void kinc_socket_init(kinc_socket_t *socket);
 void kinc_socket_destroy(kinc_socket_t *socket);
-int kinc_socket_open(kinc_socket_t *socket, int port);
+bool kinc_socket_open(kinc_socket_t *socket, int port);
 void kinc_socket_set_broadcast_enabled(kinc_socket_t *socket, bool enabled);
 void kinc_socket_send(kinc_socket_t *socket, unsigned address, int port, const unsigned char *data, int size);
 void kinc_socket_send_url(kinc_socket_t *socket, const char *url, int port, const unsigned char *data, int size);


### PR DESCRIPTION
This is useful for networking applications, such as game servers, to know if the socket open wasn't successful.  This is usually because the port being used is already being used by something else.  The game server can then choose another one.  Previously there was no indication that the game server would not receive any traffic because the socket open failed.
