### PR TITLE
Check if kinc_acceleration_callback is assigned on iOS

### DIFF
--- a/Backends/System/iOS/Sources/Kore/GLView.mm
+++ b/Backends/System/iOS/Sources/Kore/GLView.mm
@@ -84,7 +84,7 @@ void initMetalCompute(id<MTLDevice> device, id<MTLCommandQueue> commandQueue);
 
 	backingWidth = frame.size.width * self.contentScaleFactor;
 	backingHeight = frame.size.height * self.contentScaleFactor;
-	
+
 	initTouches();
 
 	device = MTLCreateSystemDefaultDevice();
@@ -108,7 +108,7 @@ void initMetalCompute(id<MTLDevice> device, id<MTLCommandQueue> commandQueue);
 - (id)initWithFrame:(CGRect)frame {
 	self = [super initWithFrame:(CGRect)frame];
 	self.contentScaleFactor = [UIScreen mainScreen].scale;
-	
+
 	backingWidth = frame.size.width * self.contentScaleFactor;
 	backingHeight = frame.size.height * self.contentScaleFactor;
 
@@ -130,7 +130,7 @@ void initMetalCompute(id<MTLDevice> device, id<MTLCommandQueue> commandQueue);
 	glGenFramebuffersOES(1, &defaultFramebuffer);
 	glBindFramebufferOES(GL_FRAMEBUFFER_OES, defaultFramebuffer);
 	Kinc_Internal_windows[0].framebuffer = defaultFramebuffer;
-	
+
 	glGenRenderbuffersOES(1, &colorRenderbuffer);
 	glBindRenderbufferOES(GL_RENDERBUFFER_OES, colorRenderbuffer);
 	glFramebufferRenderbufferOES(GL_FRAMEBUFFER_OES, GL_COLOR_ATTACHMENT0_OES, GL_RENDERBUFFER_OES, colorRenderbuffer);
@@ -165,7 +165,7 @@ void initMetalCompute(id<MTLDevice> device, id<MTLCommandQueue> commandQueue);
 		CAMetalLayer* metalLayer = (CAMetalLayer*)self.layer;
 
 		drawable = [metalLayer nextDrawable];
-		
+
 		if (depthTexture == nil || depthTexture.width != drawable.texture.width || depthTexture.height != drawable.texture.height) {
 			MTLTextureDescriptor* descriptor = [MTLTextureDescriptor new];
 			descriptor.textureType = MTLTextureType2D;
@@ -202,7 +202,7 @@ void initMetalCompute(id<MTLDevice> device, id<MTLCommandQueue> commandQueue);
 		renderPassDescriptor.stencilAttachment.loadAction = MTLLoadActionDontCare;
 		renderPassDescriptor.stencilAttachment.storeAction = MTLStoreActionDontCare;
 		renderPassDescriptor.stencilAttachment.texture = depthTexture;
-		
+
 		// id <MTLCommandQueue> commandQueue = [device newCommandQueue];
 		commandBuffer = [commandQueue commandBuffer];
 		// if (drawable != nil) {
@@ -224,7 +224,9 @@ void initMetalCompute(id<MTLDevice> device, id<MTLCommandQueue> commandQueue);
 
 		if (acc.x != lastAccelerometerX || acc.y != lastAccelerometerY || acc.z != lastAccelerometerZ) {
 
-			(*kinc_acceleration_callback)(acc.x, acc.y, acc.z);
+			if (kinc_acceleration_callback != NULL) {
+				(*kinc_acceleration_callback)(acc.x, acc.y, acc.z);
+			}
 
 			lastAccelerometerX = acc.x;
 			lastAccelerometerY = acc.y;
@@ -243,7 +245,7 @@ void initMetalCompute(id<MTLDevice> device, id<MTLCommandQueue> commandQueue);
       [commandBuffer presentDrawable:drawable];
       [commandBuffer commit];
     }
-		
+
 		commandBuffer = nil;
     commandEncoder = nil;
 
@@ -453,7 +455,7 @@ namespace {
 		if (wait) {
 			[commandBuffer waitUntilCompleted];
 		}
-		
+
 		renderPassDescriptor = [MTLRenderPassDescriptor renderPassDescriptor];
 		renderPassDescriptor.colorAttachments[0].texture = renderTarget == nullptr ? drawable.texture : renderTarget->impl._tex;
 		renderPassDescriptor.colorAttachments[0].loadAction = MTLLoadActionLoad;
@@ -467,8 +469,8 @@ namespace {
 		renderPassDescriptor.stencilAttachment.loadAction = MTLLoadActionDontCare;
 		renderPassDescriptor.stencilAttachment.storeAction = MTLStoreActionDontCare;
 		renderPassDescriptor.stencilAttachment.texture = renderTarget == nullptr ? depthTexture : renderTarget->impl._depthTex;
-		
-		
+
+
 		commandBuffer = [commandQueue commandBuffer];
 		commandEncoder = [commandBuffer renderCommandEncoderWithDescriptor:renderPassDescriptor];
 	}


### PR DESCRIPTION
- When using Kinc directly, `kinc_acceleration_callback` is null by default.
- Added a null check to match Android behavior.