### PR TITLE
fix loading bug in Kore/Audio1/Sound

### DIFF
--- a/Sources/Kore/Audio1/Sound.cpp
+++ b/Sources/Kore/Audio1/Sound.cpp
@@ -99,10 +99,14 @@ namespace {
 
 Sound::Sound(const char *filename) : left(0), right(0), size(0), length(0), myVolume(1) {
 	FileReader file(filename);
-	Sound(file, filename);
+	load(file, filename);
 }
 
 Sound::Sound(Reader &file, const char *filename) : left(0), right(0), size(0), length(0), myVolume(1) {
+	load(file, filename);
+}
+
+void Sound::load(Reader &file, const char *filename) {
 	size_t filenameLength = strlen(filename);
 	u8* data = nullptr;
 

--- a/Sources/Kore/Audio1/Sound.h
+++ b/Sources/Kore/Audio1/Sound.h
@@ -9,6 +9,7 @@ namespace Kore {
 		Sound(const char *filename);
 		Sound(Reader &file, const char *filename);
 		~Sound();
+		void load(Reader &file, const char *filename);
 		Audio2::BufferFormat format;
 		float volume();
 		void setVolume(float value);


### PR DESCRIPTION
It should be a delegating constructor, not a local variable.