### PR TITLE
Add color attachment format to pipeline state

### DIFF
--- a/Backends/Graphics4/G4onG5/Sources/Kore/PipelineStateImpl.c
+++ b/Backends/Graphics4/G4onG5/Sources/Kore/PipelineStateImpl.c
@@ -43,11 +43,13 @@ void kinc_g4_pipeline_compile(kinc_g4_pipeline_t *pipe) {
 	pipe->impl._pipeline.cullMode = (kinc_g5_cull_mode_t)pipe->cull_mode;
 	pipe->impl._pipeline.depthMode = (kinc_g5_compare_mode_t)pipe->depth_mode;
 	pipe->impl._pipeline.depthWrite = pipe->depth_write;
+	pipe->impl._pipeline.colorAttachmentCount = pipe->color_attachment_count;
 	for (int i = 0; i < 8; ++i) {
 		pipe->impl._pipeline.colorWriteMaskRed[i] = pipe->color_write_mask_red[i];
 		pipe->impl._pipeline.colorWriteMaskGreen[i] = pipe->color_write_mask_green[i];
 		pipe->impl._pipeline.colorWriteMaskBlue[i] = pipe->color_write_mask_blue[i];
 		pipe->impl._pipeline.colorWriteMaskAlpha[i] = pipe->color_write_mask_alpha[i];
+		pipe->impl._pipeline.colorAttachment[i] = pipe->color_attachment[i];
 	}
 	kinc_g5_pipeline_compile(&pipe->impl._pipeline);
 }

--- a/Sources/Kore/Graphics4/PipelineState.cpp
+++ b/Sources/Kore/Graphics4/PipelineState.cpp
@@ -40,6 +40,9 @@ Graphics4::PipelineState::PipelineState() {
 	for (int i = 0; i < 8; ++i) colorWriteMaskBlue[i] = true;
 	for (int i = 0; i < 8; ++i) colorWriteMaskAlpha[i] = true;
 
+	colorAttachmentCount = 1;
+	for (int i = 0; i < 8; ++i) colorAttachment[i] = Target32Bit;
+
 	conservativeRasterization = false;
 }
 
@@ -87,11 +90,14 @@ void Graphics4::PipelineState::compile() {
 	kincPipeline.alpha_blend_source = (kinc_g4_blending_operation_t)alphaBlendSource;
 	kincPipeline.alpha_blend_destination = (kinc_g4_blending_operation_t)alphaBlendDestination;
 
+	kincPipeline.color_attachment_count = colorAttachmentCount;
+
 	for (int i = 0; i < 8; ++i) {
 		kincPipeline.color_write_mask_red[i] = colorWriteMaskRed[i];
 		kincPipeline.color_write_mask_green[i] = colorWriteMaskGreen[i];
 		kincPipeline.color_write_mask_blue[i] = colorWriteMaskBlue[i];
 		kincPipeline.color_write_mask_alpha[i] = colorWriteMaskAlpha[i];
+		kincPipeline.color_attachment[i] = (kinc_g4_render_target_format_t)colorAttachment[i];
 	}
 
 	kincPipeline.conservative_rasterization = conservativeRasterization;

--- a/Sources/Kore/Graphics4/PipelineState.h
+++ b/Sources/Kore/Graphics4/PipelineState.h
@@ -15,7 +15,7 @@ namespace Kore {
 		public:
 			PipelineState();
 			~PipelineState();
-			
+
 			VertexStructure* inputLayout[16];
 			Shader* vertexShader;
 			Shader* fragmentShader;
@@ -48,6 +48,9 @@ namespace Kore {
 			bool colorWriteMaskGreen[8];
 			bool colorWriteMaskBlue[8];
 			bool colorWriteMaskAlpha[8];
+
+			int colorAttachmentCount;
+			RenderTargetFormat colorAttachment[8];
 
 			bool conservativeRasterization;
 

--- a/Sources/Kore/Graphics5/PipelineState.cpp
+++ b/Sources/Kore/Graphics5/PipelineState.cpp
@@ -37,6 +37,9 @@ Graphics5::PipelineState::PipelineState() {
 	for (int i = 0; i < 8; ++i) colorWriteMaskGreen[i] = true;
 	for (int i = 0; i < 8; ++i) colorWriteMaskBlue[i] = true;
 	for (int i = 0; i < 8; ++i) colorWriteMaskAlpha[i] = true;
+
+	colorAttachmentCount = 1;
+	for (int i = 0; i < 8; ++i) colorAttachment[i] = Target32Bit;
 }
 
 Graphics5::PipelineState::~PipelineState() {}

--- a/Sources/Kore/Graphics5/PipelineState.h
+++ b/Sources/Kore/Graphics5/PipelineState.h
@@ -48,6 +48,9 @@ namespace Kore {
 			bool colorWriteMaskBlue[8];
 			bool colorWriteMaskAlpha[8];
 
+			int colorAttachmentCount;
+			RenderTargetFormat colorAttachment[8];
+
 			bool conservativeRasterization;
 
 			void compile();

--- a/Sources/kinc/graphics4/pipeline.c
+++ b/Sources/kinc/graphics4/pipeline.c
@@ -35,5 +35,8 @@ void kinc_g4_internal_pipeline_set_defaults(kinc_g4_pipeline_t *state) {
 	for (int i = 0; i < 8; ++i) state->color_write_mask_blue[i] = true;
 	for (int i = 0; i < 8; ++i) state->color_write_mask_alpha[i] = true;
 
+	state->color_attachment_count = 1;
+	for (int i = 0; i < 8; ++i) state->color_attachment[i] = KINC_G4_RENDER_TARGET_FORMAT_32BIT;
+
 	state->conservative_rasterization = false;
 }

--- a/Sources/kinc/graphics4/pipeline.h
+++ b/Sources/kinc/graphics4/pipeline.h
@@ -2,6 +2,7 @@
 
 #include <kinc/graphics4/constantlocation.h>
 #include <kinc/graphics4/textureunit.h>
+#include <kinc/graphics4/rendertarget.h>
 
 #include <Kore/PipelineStateImpl.h>
 
@@ -86,6 +87,9 @@ typedef struct kinc_g4_pipeline {
 	bool color_write_mask_green[8];
 	bool color_write_mask_blue[8];
 	bool color_write_mask_alpha[8];
+
+	int color_attachment_count;
+	kinc_g4_render_target_format_t color_attachment[8];
 
 	bool conservative_rasterization;
 

--- a/Sources/kinc/graphics5/pipeline.c
+++ b/Sources/kinc/graphics5/pipeline.c
@@ -34,4 +34,7 @@ void kinc_g5_internal_pipeline_init(kinc_g5_pipeline_t *pipe) {
 	for (int i = 0; i < 8; ++i) pipe->colorWriteMaskGreen[i] = true;
 	for (int i = 0; i < 8; ++i) pipe->colorWriteMaskBlue[i] = true;
 	for (int i = 0; i < 8; ++i) pipe->colorWriteMaskAlpha[i] = true;
+
+	pipe->colorAttachmentCount = 1;
+	for (int i = 0; i < 8; ++i) pipe->colorAttachment[i] = KINC_G5_RENDER_TARGET_FORMAT_32BIT;
 }

--- a/Sources/kinc/graphics5/pipeline.h
+++ b/Sources/kinc/graphics5/pipeline.h
@@ -47,6 +47,9 @@ typedef struct kinc_g5_pipeline {
 	bool colorWriteMaskBlue[8];
 	bool colorWriteMaskAlpha[8];
 
+	int colorAttachmentCount;
+	kinc_g5_render_target_format_t colorAttachment[8];
+
 	bool conservativeRasterization;
 
 	PipelineState5Impl impl;


### PR DESCRIPTION
G5 apis want us to specify the exact color attachment formats per pipeline, this exposes capability to do that. Defaults to `KINC_G4_RENDER_TARGET_FORMAT_32BIT`, existing behaviour is unchanged.