### PR TITLE
Create depth texture only when requested for Metal

### DIFF
--- a/Backends/Graphics5/Metal/Sources/Kore/Metal.mm
+++ b/Backends/Graphics5/Metal/Sources/Kore/Metal.mm
@@ -23,6 +23,8 @@ id<CAMetalDrawable> drawable;
 id<MTLCommandBuffer> commandBuffer;
 id<MTLRenderCommandEncoder> commandEncoder;
 id<MTLTexture> depthTexture;
+int depthBits;
+int stencilBits;
 
 id getMetalEncoder() {
 	return commandEncoder;
@@ -37,7 +39,8 @@ extern "C" void kinc_internal_resize(int window, int width, int height) {
 }
 
 void kinc_g5_init(int window, int depthBufferBits, int stencilBufferBits, bool vsync) {
-
+	depthBits = depthBufferBits;
+	stencilBits = stencilBufferBits;
 }
 
 void kinc_g5_flush() {}
@@ -50,7 +53,7 @@ void kinc_g5_begin(kinc_g5_render_target_t *renderTarget, int window) {
 	CAMetalLayer* metalLayer = getMetalLayer();
 	drawable = [metalLayer nextDrawable];
 
-	if (depthTexture == nil || depthTexture.width != drawable.texture.width || depthTexture.height != drawable.texture.height) {
+	if (depthBits > 0 && (depthTexture == nil || depthTexture.width != drawable.texture.width || depthTexture.height != drawable.texture.height)) {
 		MTLTextureDescriptor* descriptor = [MTLTextureDescriptor new];
 		descriptor.textureType = MTLTextureType2D;
 		descriptor.width = drawable.texture.width;

--- a/Backends/Graphics5/Metal/Sources/Kore/PipelineState5Impl.mm
+++ b/Backends/Graphics5/Metal/Sources/Kore/PipelineState5Impl.mm
@@ -127,8 +127,14 @@ void kinc_g5_pipeline_compile(kinc_g5_pipeline_t *pipeline) {
 			| (pipeline->colorWriteMaskBlue[i] ? MTLColorWriteMaskBlue : 0)
 			| (pipeline->colorWriteMaskAlpha[i] ? MTLColorWriteMaskAlpha : 0);
 	}
-	renderPipelineDesc.depthAttachmentPixelFormat = MTLPixelFormatDepth32Float_Stencil8;
-	renderPipelineDesc.stencilAttachmentPixelFormat = MTLPixelFormatDepth32Float_Stencil8;
+	if (pipeline->depthAttachmentBits > 0) {
+		renderPipelineDesc.depthAttachmentPixelFormat = MTLPixelFormatDepth32Float_Stencil8;
+		renderPipelineDesc.stencilAttachmentPixelFormat = MTLPixelFormatDepth32Float_Stencil8;
+	}
+	else {
+		renderPipelineDesc.depthAttachmentPixelFormat = MTLPixelFormatInvalid;
+		renderPipelineDesc.stencilAttachmentPixelFormat = MTLPixelFormatInvalid;
+	}
 
 	float offset = 0;
 	MTLVertexDescriptor* vertexDescriptor = [[MTLVertexDescriptor alloc] init];

--- a/Backends/Graphics5/Metal/Sources/Kore/RenderTarget5Impl.mm
+++ b/Backends/Graphics5/Metal/Sources/Kore/RenderTarget5Impl.mm
@@ -52,8 +52,8 @@ void kinc_g5_render_target_init(kinc_g5_render_target_t *target, int width, int 
 
 	target->impl._tex = [device newTextureWithDescriptor:descriptor];
 
-    target->impl._samplerDesc = (MTLSamplerDescriptor*)[[MTLSamplerDescriptor alloc] init];
-    MTLSamplerDescriptor* desc = (MTLSamplerDescriptor*) target->impl._samplerDesc;
+	target->impl._samplerDesc = (MTLSamplerDescriptor*)[[MTLSamplerDescriptor alloc] init];
+	MTLSamplerDescriptor* desc = (MTLSamplerDescriptor*) target->impl._samplerDesc;
 	desc.minFilter = MTLSamplerMinMagFilterNearest;
 	desc.magFilter = MTLSamplerMinMagFilterLinear;
 	desc.sAddressMode = MTLSamplerAddressModeRepeat;
@@ -65,18 +65,20 @@ void kinc_g5_render_target_init(kinc_g5_render_target_t *target, int width, int 
 	desc.lodMaxClamp = FLT_MAX;
 	target->impl._sampler = [device newSamplerStateWithDescriptor:desc];
 
-	MTLTextureDescriptor* depthDescriptor = [MTLTextureDescriptor new];
-	depthDescriptor.textureType = MTLTextureType2D;
-	depthDescriptor.width = width;
-	depthDescriptor.height = height;
-	depthDescriptor.depth = 1;
-	depthDescriptor.pixelFormat = MTLPixelFormatDepth32Float_Stencil8;
-	depthDescriptor.arrayLength = 1;
-	depthDescriptor.mipmapLevelCount = 1;
-	depthDescriptor.usage = MTLTextureUsageRenderTarget | MTLTextureUsageShaderRead;
-	depthDescriptor.resourceOptions = MTLResourceStorageModePrivate;
+	if (depthBufferBits > 0) {
+		MTLTextureDescriptor* depthDescriptor = [MTLTextureDescriptor new];
+		depthDescriptor.textureType = MTLTextureType2D;
+		depthDescriptor.width = width;
+		depthDescriptor.height = height;
+		depthDescriptor.depth = 1;
+		depthDescriptor.pixelFormat = MTLPixelFormatDepth32Float_Stencil8;
+		depthDescriptor.arrayLength = 1;
+		depthDescriptor.mipmapLevelCount = 1;
+		depthDescriptor.usage = MTLTextureUsageRenderTarget | MTLTextureUsageShaderRead;
+		depthDescriptor.resourceOptions = MTLResourceStorageModePrivate;
 
-	target->impl._depthTex = [device newTextureWithDescriptor:depthDescriptor];
+		target->impl._depthTex = [device newTextureWithDescriptor:depthDescriptor];
+	}
 }
 
 void kinc_g5_render_target_init_cube(kinc_g5_render_target_t *target, int cubeMapSize, int depthBufferBits, bool antialiasing,


### PR DESCRIPTION
All is perfect now in Metal land but there is a catch - graphics2 in Kha will need to set `pipeline.depthStencilAttachment` properly to match render target to keep Metal happy.