### PR TITLE
Fix window lock up on window feature change

### DIFF
--- a/Backends/System/Windows/Sources/Kore/Window.c
+++ b/Backends/System/Windows/Sources/Kore/Window.c
@@ -278,6 +278,7 @@ void kinc_window_change_features(int window_index, int features) {
 	win->features = features;
 	SetWindowLong(win->handle, GWL_STYLE, getStyle(features));
 	SetWindowLong(win->handle, GWL_EXSTYLE, getExStyle(features));
+	kinc_window_show(window_index);
 }
 
 void kinc_window_change_mode(int window_index, kinc_window_mode_t mode) {


### PR DESCRIPTION
Provided by ustance. This corrects a window lockup that occurs (specifically on Windows 7, perhaps other versions of Windows as well) whenever kinc_window_change_features is called.