### PR TITLE
Improve Vulkan backend

### DIFF
--- a/Backends/Graphics4/G4onG5/Sources/Kore/RenderTargetImpl.c
+++ b/Backends/Graphics4/G4onG5/Sources/Kore/RenderTargetImpl.c
@@ -15,10 +15,6 @@ void kinc_g4_render_target_init(kinc_g4_render_target_t *render_target, int widt
 	                           stencilBufferBits, contextId);
 	render_target->texWidth = render_target->width = width;
 	render_target->texHeight = render_target->height = height;
-	if (contextId >= 0) {
-		kinc_g5_command_list_texture_to_render_target_barrier(&commandList, &render_target->impl._renderTarget);
-		kinc_g5_command_list_clear(&commandList, &render_target->impl._renderTarget, KINC_G5_CLEAR_COLOR, 0, 0.0f, 0);
-	}
 }
 
 void kinc_g4_render_target_init_cube(kinc_g4_render_target_t *render_target, int cubeMapSize, int depthBufferBits, bool antialiasing,

--- a/Backends/Graphics5/Vulkan/Sources/Kore/CommandList5Impl.cpp
+++ b/Backends/Graphics5/Vulkan/Sources/Kore/CommandList5Impl.cpp
@@ -610,7 +610,7 @@ void kinc_g5_command_list_set_render_targets(kinc_g5_command_list_t *list, struc
 
 		VkAttachmentDescription attachments[9];
 		for (int i = 0; i < count; ++i) {
-			attachments[i].format = VK_FORMAT_B8G8R8A8_UNORM;
+			attachments[i].format = targets[i]->impl.format;
 			attachments[i].samples = VK_SAMPLE_COUNT_1_BIT;
 			attachments[i].loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
 			attachments[i].storeOp = VK_ATTACHMENT_STORE_OP_STORE;

--- a/Backends/Graphics5/Vulkan/Sources/Kore/CommandList5Impl.cpp
+++ b/Backends/Graphics5/Vulkan/Sources/Kore/CommandList5Impl.cpp
@@ -240,8 +240,10 @@ void kinc_g5_command_list_begin(kinc_g5_command_list_t *list) {
 
 	VkViewport viewport;
 	memset(&viewport, 0, sizeof(viewport));
+	viewport.x = 0;
+	viewport.y = (float)kinc_height();
 	viewport.width = (float)kinc_width();
-	viewport.height = (float)kinc_height();
+	viewport.height = -(float)kinc_height();
 	viewport.minDepth = (float)0.0f;
 	viewport.maxDepth = (float)1.0f;
 	vkCmdSetViewport(list->impl._buffer, 0, 1, &viewport);

--- a/Backends/Graphics5/Vulkan/Sources/Kore/CommandList5Impl.cpp
+++ b/Backends/Graphics5/Vulkan/Sources/Kore/CommandList5Impl.cpp
@@ -39,7 +39,7 @@ namespace {
 	VkRenderPass mrtRenderPass;
 }
 
-void demo_set_image_layout(VkImage image, VkImageAspectFlags aspectMask, VkImageLayout old_image_layout, VkImageLayout new_image_layout) {
+void set_image_layout(VkImage image, VkImageAspectFlags aspectMask, VkImageLayout old_image_layout, VkImageLayout new_image_layout) {
 	VkResult err;
 
 	if (setup_cmd == VK_NULL_HANDLE) {
@@ -125,7 +125,7 @@ void demo_set_image_layout(VkImage image, VkImageAspectFlags aspectMask, VkImage
 	vkCmdPipelineBarrier(setup_cmd, srcStageMask, dstStageMask, 0, 0, nullptr, 0, nullptr, 1, &image_memory_barrier);
 }
 
-void demo_setup_init_cmd() {
+void setup_init_cmd() {
 	if (setup_cmd == VK_NULL_HANDLE) {
 		VkCommandBufferAllocateInfo cmd = {};
 		cmd.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
@@ -158,7 +158,7 @@ void demo_setup_init_cmd() {
 	}
 }
 
-void demo_flush_init_cmd() {
+void flush_init_cmd() {
 	VkResult err;
 
 	if (setup_cmd == VK_NULL_HANDLE) return;

--- a/Backends/Graphics5/Vulkan/Sources/Kore/CommandList5Impl.cpp
+++ b/Backends/Graphics5/Vulkan/Sources/Kore/CommandList5Impl.cpp
@@ -24,7 +24,7 @@ extern VkRenderPass render_pass;
 extern VkDescriptorSet desc_set;
 extern uint32_t current_buffer;
 extern VkDescriptorPool desc_pools[3];
-void createDescriptorSet(struct PipelineState5Impl_s *pipeline, VkDescriptorSet &desc_set);
+void createDescriptorSet(VkDescriptorSet &desc_set);
 void setImageLayout(VkCommandBuffer _buffer, VkImage image, VkImageAspectFlags aspectMask, VkImageLayout oldImageLayout, VkImageLayout newImageLayout);
 VkCommandBuffer setup_cmd;
 
@@ -113,8 +113,8 @@ void demo_set_image_layout(VkImage image, VkImageAspectFlags aspectMask, VkImage
 		image_memory_barrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT | VK_ACCESS_INPUT_ATTACHMENT_READ_BIT;
 	}
 
-	VkPipelineStageFlags srcStageMask = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;
-	VkPipelineStageFlags dstStageMask = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;
+	VkPipelineStageFlags srcStageMask = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
+	VkPipelineStageFlags dstStageMask = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
 	if (new_image_layout == VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL) {
 		dstStageMask = VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT | VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT;
 	}
@@ -489,65 +489,6 @@ namespace {
 				i++;
 			}
 		}
-
-		/*VkResult err = vkEndCommandBuffer(_buffer);
-		assert(!err);
-
-		VkFence nullFence = VK_NULL_HANDLE;
-		VkPipelineStageFlags pipe_stage_flags = VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT;
-		VkSubmitInfo submit_info = {};
-		submit_info.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
-		submit_info.pNext = NULL;
-		submit_info.waitSemaphoreCount = 1;
-		submit_info.pWaitSemaphores = &presentCompleteSemaphore;
-		submit_info.pWaitDstStageMask = &pipe_stage_flags;
-		submit_info.commandBufferCount = 1;
-		submit_info.pCommandBuffers = &_buffer;
-		submit_info.signalSemaphoreCount = 0;
-		submit_info.pSignalSemaphores = NULL;
-
-		err = vkQueueSubmit(queue, 1, &submit_info, nullFence);
-		assert(!err);
-
-		VkCommandBufferInheritanceInfo cmd_buf_hinfo = {};
-		cmd_buf_hinfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_INHERITANCE_INFO;
-		cmd_buf_hinfo.pNext = NULL;
-		cmd_buf_hinfo.renderPass = VK_NULL_HANDLE;
-		cmd_buf_hinfo.subpass = 0;
-		cmd_buf_hinfo.framebuffer = VK_NULL_HANDLE;
-		cmd_buf_hinfo.occlusionQueryEnable = VK_FALSE;
-		cmd_buf_hinfo.queryFlags = 0;
-		cmd_buf_hinfo.pipelineStatistics = 0;
-
-		VkCommandBufferBeginInfo cmd_buf_info = {};
-		cmd_buf_info.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
-		cmd_buf_info.pNext = NULL;
-		cmd_buf_info.flags = 0;
-		cmd_buf_info.pInheritanceInfo = &cmd_buf_hinfo;
-
-		VkClearValue clear_values[2];
-		memset(clear_values, 0, sizeof(VkClearValue) * 2);
-		clear_values[0].color.float32[0] = 0.0f;
-		clear_values[0].color.float32[1] = 0.0f;
-		clear_values[0].color.float32[2] = 0.0f;
-		clear_values[0].color.float32[3] = 1.0f;
-		clear_values[1].depthStencil.depth = 1.0;
-		clear_values[1].depthStencil.stencil = 0;
-
-		VkRenderPassBeginInfo rp_begin = {};
-		rp_begin.sType = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO;
-		rp_begin.pNext = NULL;
-		rp_begin.renderPass = render_pass;
-		rp_begin.framebuffer = framebuffers[current_buffer];
-		rp_begin.renderArea.offset.x = 0;
-		rp_begin.renderArea.offset.y = 0;
-		rp_begin.renderArea.extent.width = currentRenderTargets[0]->width;
-		rp_begin.renderArea.extent.height = currentRenderTargets[0]->height;
-		rp_begin.clearValueCount = 2;
-		rp_begin.pClearValues = clear_values;
-
-		err = vkBeginCommandBuffer(_buffer, &cmd_buf_info);
-		assert(!err);*/
 	}
 }
 
@@ -642,7 +583,7 @@ void kinc_g5_command_list_set_render_targets(kinc_g5_command_list_t *list, struc
 		for (int i = 0; i < count; ++i) {
 			attachments[i].format = targets[i]->impl.format;
 			attachments[i].samples = VK_SAMPLE_COUNT_1_BIT;
-			attachments[i].loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
+			attachments[i].loadOp = VK_ATTACHMENT_LOAD_OP_LOAD;
 			attachments[i].storeOp = VK_ATTACHMENT_STORE_OP_STORE;
 			attachments[i].stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
 			attachments[i].stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
@@ -652,7 +593,7 @@ void kinc_g5_command_list_set_render_targets(kinc_g5_command_list_t *list, struc
 		}
 		attachments[count].format = VK_FORMAT_D16_UNORM;
 		attachments[count].samples = VK_SAMPLE_COUNT_1_BIT;
-		attachments[count].loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
+		attachments[count].loadOp = VK_ATTACHMENT_LOAD_OP_LOAD;
 		attachments[count].storeOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
 		attachments[count].stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
 		attachments[count].stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
@@ -759,7 +700,7 @@ void kinc_g5_command_list_set_vertex_constant_buffer(kinc_g5_command_list_t *lis
 void kinc_g5_command_list_set_fragment_constant_buffer(kinc_g5_command_list_t *list, struct kinc_g5_constant_buffer *buffer, int offset, size_t size) {
 	lastFragmentConstantBufferOffset = offset;
 
-	createDescriptorSet(&currentPipeline->impl, desc_set);
+	createDescriptorSet(desc_set);
 	uint32_t offsets[2] = {lastVertexConstantBufferOffset, lastFragmentConstantBufferOffset};
 	vkCmdBindDescriptorSets(list->impl._buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, currentPipeline->impl.pipeline_layout, 0, 1, &desc_set, 2, offsets);
 }

--- a/Backends/Graphics5/Vulkan/Sources/Kore/CommandList5Impl.cpp
+++ b/Backends/Graphics5/Vulkan/Sources/Kore/CommandList5Impl.cpp
@@ -152,11 +152,6 @@ void Kore::Vulkan::demo_flush_init_cmd() {
 	setup_cmd = VK_NULL_HANDLE;
 }
 
-namespace {
-	float depthStencil;
-	float depthIncrement;
-}
-
 extern VkSemaphore presentCompleteSemaphore;
 
 void kinc_g5_command_list_init(kinc_g5_command_list_t *list) {
@@ -171,9 +166,6 @@ void kinc_g5_command_list_init(kinc_g5_command_list_t *list) {
 	assert(!err);
 
 	list->impl._indexCount = 0;
-
-	depthStencil = 1.0;
-	depthIncrement = -0.01f;
 
 	// begin();
 }
@@ -210,7 +202,7 @@ void kinc_g5_command_list_begin(kinc_g5_command_list_t *list) {
 	clear_values[0].color.float32[1] = 0.0f;
 	clear_values[0].color.float32[2] = 0.0f;
 	clear_values[0].color.float32[3] = 1.0f;
-	clear_values[1].depthStencil.depth = depthStencil;
+	clear_values[1].depthStencil.depth = 1.0;
 	clear_values[1].depthStencil.stencil = 0;
 
 	VkRenderPassBeginInfo rp_begin = {};
@@ -310,32 +302,11 @@ void kinc_g5_command_list_end(kinc_g5_command_list_t *list) {
 	present.pSwapchains = &swapchain;
 	present.pImageIndices = &current_buffer;
 
-	// TBD/TODO: SHOULD THE "present" PARAMETER BE "const" IN THE HEADER?
 	err = fpQueuePresentKHR(queue, &present);
-	/*if (err == VK_ERROR_OUT_OF_DATE_KHR) {
-	    // demo->swapchain is out of date (e.g. the window was resized) and
-	    // must be recreated:
-	    // demo_resize(demo);
-	    error("VK_ERROR_OUT_OF_DATE_KHR");
-	}
-	else if (err == VK_SUBOPTIMAL_KHR) {
-	    // demo->swapchain is not as optimal as it could be, but the platform's
-	    // presentation engine will still present the image correctly.
-	}
-	else {
-	    assert(!err);
-	}*/
-	assert(!err);
-
 	err = vkQueueWaitIdle(queue);
 	assert(err == VK_SUCCESS);
 
 	vkDestroySemaphore(device, presentCompleteSemaphore, NULL);
-
-	if (depthStencil > 0.99f) depthIncrement = -0.001f;
-	if (depthStencil < 0.8f) depthIncrement = 0.001f;
-
-	depthStencil += depthIncrement;
 
 	vkResetCommandBuffer(list->impl._buffer, 0);
 
@@ -511,7 +482,7 @@ namespace {
 		clear_values[0].color.float32[1] = 0.0f;
 		clear_values[0].color.float32[2] = 0.0f;
 		clear_values[0].color.float32[3] = 1.0f;
-		clear_values[1].depthStencil.depth = depthStencil;
+		clear_values[1].depthStencil.depth = 1.0;
 		clear_values[1].depthStencil.stencil = 0;
 
 		VkRenderPassBeginInfo rp_begin = {};
@@ -544,7 +515,7 @@ void kinc_g5_command_list_set_render_targets(kinc_g5_command_list_t *list, struc
 	clear_values[0].color.float32[1] = 0.0f;
 	clear_values[0].color.float32[2] = 0.0f;
 	clear_values[0].color.float32[3] = 1.0f;
-	clear_values[1].depthStencil.depth = depthStencil;
+	clear_values[1].depthStencil.depth = 1.0;
 	clear_values[1].depthStencil.stencil = 0;
 
 	VkRenderPassBeginInfo rp_begin = {};

--- a/Backends/Graphics5/Vulkan/Sources/Kore/CommandList5Impl.cpp
+++ b/Backends/Graphics5/Vulkan/Sources/Kore/CommandList5Impl.cpp
@@ -370,9 +370,27 @@ void kinc_g5_command_list_draw_indexed_vertices_from_to_from(kinc_g5_command_lis
 	vkCmdDrawIndexed(list->impl._buffer, count, 1, start, vertex_offset, 0);
 }
 
-void kinc_g5_command_list_viewport(kinc_g5_command_list_t *list, int x, int y, int width, int height) {}
+void kinc_g5_command_list_viewport(kinc_g5_command_list_t *list, int x, int y, int width, int height) {
+	VkViewport viewport;
+	memset(&viewport, 0, sizeof(viewport));
+	viewport.x = x;
+	viewport.y = y + height;
+	viewport.width = width;
+	viewport.height = -height;
+	viewport.minDepth = (float)0.0f;
+	viewport.maxDepth = (float)1.0f;
+	vkCmdSetViewport(list->impl._buffer, 0, 1, &viewport);
+}
 
-void kinc_g5_command_list_scissor(kinc_g5_command_list_t *list, int x, int y, int width, int height) {}
+void kinc_g5_command_list_scissor(kinc_g5_command_list_t *list, int x, int y, int width, int height) {
+	VkRect2D scissor;
+	memset(&scissor, 0, sizeof(scissor));
+	scissor.extent.width = width;
+	scissor.extent.height = height;
+	scissor.offset.x = x;
+	scissor.offset.y = y;
+	vkCmdSetScissor(list->impl._buffer, 0, 1, &scissor);
+}
 
 void kinc_g5_command_list_disable_scissor(kinc_g5_command_list_t *list) {}
 

--- a/Backends/Graphics5/Vulkan/Sources/Kore/CommandList5Impl.cpp
+++ b/Backends/Graphics5/Vulkan/Sources/Kore/CommandList5Impl.cpp
@@ -591,15 +591,18 @@ void kinc_g5_command_list_set_render_targets(kinc_g5_command_list_t *list, struc
 			attachments[i].finalLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
 			attachments[i].flags = 0;
 		}
-		attachments[count].format = VK_FORMAT_D16_UNORM;
-		attachments[count].samples = VK_SAMPLE_COUNT_1_BIT;
-		attachments[count].loadOp = VK_ATTACHMENT_LOAD_OP_LOAD;
-		attachments[count].storeOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
-		attachments[count].stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
-		attachments[count].stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
-		attachments[count].initialLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
-		attachments[count].finalLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
-		attachments[count].flags = 0;
+
+		if (targets[0]->impl.depthBufferBits > 0) {
+			attachments[count].format = VK_FORMAT_D16_UNORM;
+			attachments[count].samples = VK_SAMPLE_COUNT_1_BIT;
+			attachments[count].loadOp = VK_ATTACHMENT_LOAD_OP_LOAD;
+			attachments[count].storeOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+			attachments[count].stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+			attachments[count].stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+			attachments[count].initialLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
+			attachments[count].finalLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
+			attachments[count].flags = 0;
+		}
 
 		VkAttachmentReference color_references[8];
 		for (int i = 0; i < count; ++i) {
@@ -619,14 +622,14 @@ void kinc_g5_command_list_set_render_targets(kinc_g5_command_list_t *list, struc
 		subpass.colorAttachmentCount = count;
 		subpass.pColorAttachments = color_references;
 		subpass.pResolveAttachments = nullptr;
-		subpass.pDepthStencilAttachment = &depth_reference;
+		subpass.pDepthStencilAttachment = targets[0]->impl.depthBufferBits > 0 ? &depth_reference : nullptr;
 		subpass.preserveAttachmentCount = 0;
 		subpass.pPreserveAttachments = nullptr;
 
 		VkRenderPassCreateInfo rp_info = {};
 		rp_info.sType = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO;
 		rp_info.pNext = nullptr;
-		rp_info.attachmentCount = count + 1;
+		rp_info.attachmentCount = targets[0]->impl.depthBufferBits > 0 ? count + 1 : count;
 		rp_info.pAttachments = attachments;
 		rp_info.subpassCount = 1;
 		rp_info.pSubpasses = &subpass;
@@ -640,7 +643,9 @@ void kinc_g5_command_list_set_render_targets(kinc_g5_command_list_t *list, struc
 		for (int i = 0; i < count; ++i) {
 			attachmentsViews[i] = targets[i]->impl.sourceView;
 		}
-		attachmentsViews[count] = targets[0]->impl.depthView;
+		if (targets[0]->impl.depthBufferBits > 0) {
+			attachmentsViews[count] = targets[0]->impl.depthView;
+		}
 
 		VkFramebufferCreateInfo fbufCreateInfo = {};
 		fbufCreateInfo.sType = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO;

--- a/Backends/Graphics5/Vulkan/Sources/Kore/CommandList5Impl.h
+++ b/Backends/Graphics5/Vulkan/Sources/Kore/CommandList5Impl.h
@@ -3,8 +3,6 @@
 #include <vulkan/vulkan.h>
 
 typedef struct {
-	//Kore::Graphics5::PipelineState* _currentPipeline;
 	int _indexCount;
 	VkCommandBuffer _buffer;
-	bool closed;
 } CommandList5Impl;

--- a/Backends/Graphics5/Vulkan/Sources/Kore/ConstantBuffer5Impl.cpp
+++ b/Backends/Graphics5/Vulkan/Sources/Kore/ConstantBuffer5Impl.cpp
@@ -13,8 +13,8 @@ bool memory_type_from_properties(uint32_t typeBits, VkFlags requirements_mask, u
 VkBuffer *Kore::Vulkan::vertexUniformBuffer = nullptr;
 VkBuffer *Kore::Vulkan::fragmentUniformBuffer = nullptr;
 
-bool kinc_g5_transposeMat3 = true;
-bool kinc_g5_transposeMat4 = true;
+bool kinc_g5_transposeMat3 = false;
+bool kinc_g5_transposeMat4 = false;
 
 namespace {
 	void createUniformBuffer(VkBuffer& buf, VkMemoryAllocateInfo& mem_alloc, VkDeviceMemory& mem, VkDescriptorBufferInfo& buffer_info, int size) {

--- a/Backends/Graphics5/Vulkan/Sources/Kore/IndexBuffer5Impl.h
+++ b/Backends/Graphics5/Vulkan/Sources/Kore/IndexBuffer5Impl.h
@@ -15,8 +15,6 @@
 #endif
 
 typedef struct {
-	//void unset();
-
 	int *data;
 	int myCount;
 	unsigned bufferId;
@@ -24,6 +22,4 @@ typedef struct {
 	VkBuffer buf;
 	VkDeviceMemory mem;
 	VkMemoryAllocateInfo mem_alloc;
-
-	//static Graphics5::IndexBuffer* current;
 } IndexBuffer5Impl;

--- a/Backends/Graphics5/Vulkan/Sources/Kore/PipelineState5Impl.cpp
+++ b/Backends/Graphics5/Vulkan/Sources/Kore/PipelineState5Impl.cpp
@@ -305,6 +305,12 @@ void kinc_g5_pipeline_compile(kinc_g5_pipeline_t *pipeline) {
 		case KINC_G4_VERTEX_DATA_FLOAT4X4:
 			stride += 4 * 4 * 4;
 			break;
+		case KINC_G4_VERTEX_DATA_SHORT2_NORM:
+			stride += 2 * 2;
+			break;
+		case KINC_G4_VERTEX_DATA_SHORT4_NORM:
+			stride += 4 * 2;
+			break;
 		}
 	}
 
@@ -373,6 +379,20 @@ void kinc_g5_pipeline_compile(kinc_g5_pipeline_t *pipeline) {
 			vi_attrs[i].format = VK_FORMAT_R32G32B32A32_SFLOAT; // TODO
 			vi_attrs[i].offset = offset;
 			offset += 4 * 4 * 4;
+			break;
+		case KINC_G4_VERTEX_DATA_SHORT2_NORM:
+			vi_attrs[i].binding = 0;
+			vi_attrs[i].location = find_number(pipeline->impl.vertexLocations, element.name);
+			vi_attrs[i].format = VK_FORMAT_R16G16_SFLOAT;
+			vi_attrs[i].offset = offset;
+			offset += 2 * 2;
+			break;
+		case KINC_G4_VERTEX_DATA_SHORT4_NORM:
+			vi_attrs[i].binding = 0;
+			vi_attrs[i].location = find_number(pipeline->impl.vertexLocations, element.name);
+			vi_attrs[i].format = VK_FORMAT_R16G16B16A16_SFLOAT;
+			vi_attrs[i].offset = offset;
+			offset += 4 * 2;
 			break;
 		}
 	}

--- a/Backends/Graphics5/Vulkan/Sources/Kore/PipelineState5Impl.cpp
+++ b/Backends/Graphics5/Vulkan/Sources/Kore/PipelineState5Impl.cpp
@@ -516,15 +516,18 @@ void kinc_g5_pipeline_compile(kinc_g5_pipeline_t *pipeline) {
 		attachments[i].finalLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
 		attachments[i].flags = 0;
 	}
-	attachments[pipeline->colorAttachmentCount].format = VK_FORMAT_D16_UNORM;
-	attachments[pipeline->colorAttachmentCount].samples = VK_SAMPLE_COUNT_1_BIT;
-	attachments[pipeline->colorAttachmentCount].loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
-	attachments[pipeline->colorAttachmentCount].storeOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
-	attachments[pipeline->colorAttachmentCount].stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
-	attachments[pipeline->colorAttachmentCount].stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
-	attachments[pipeline->colorAttachmentCount].initialLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
-	attachments[pipeline->colorAttachmentCount].finalLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
-	attachments[pipeline->colorAttachmentCount].flags = 0;
+
+	if (pipeline->depthAttachmentBits > 0) {
+		attachments[pipeline->colorAttachmentCount].format = VK_FORMAT_D16_UNORM;
+		attachments[pipeline->colorAttachmentCount].samples = VK_SAMPLE_COUNT_1_BIT;
+		attachments[pipeline->colorAttachmentCount].loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
+		attachments[pipeline->colorAttachmentCount].storeOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+		attachments[pipeline->colorAttachmentCount].stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+		attachments[pipeline->colorAttachmentCount].stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+		attachments[pipeline->colorAttachmentCount].initialLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
+		attachments[pipeline->colorAttachmentCount].finalLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
+		attachments[pipeline->colorAttachmentCount].flags = 0;
+	}
 
 	VkAttachmentReference color_references[8];
 	for (int i = 0; i < pipeline->colorAttachmentCount; ++i) {
@@ -544,14 +547,14 @@ void kinc_g5_pipeline_compile(kinc_g5_pipeline_t *pipeline) {
 	subpass.colorAttachmentCount = pipeline->colorAttachmentCount;
 	subpass.pColorAttachments = color_references;
 	subpass.pResolveAttachments = nullptr;
-	subpass.pDepthStencilAttachment = &depth_reference;
+	subpass.pDepthStencilAttachment = pipeline->depthAttachmentBits > 0 ? &depth_reference : nullptr;
 	subpass.preserveAttachmentCount = 0;
 	subpass.pPreserveAttachments = nullptr;
 
 	VkRenderPassCreateInfo rp_info = {};
 	rp_info.sType = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO;
 	rp_info.pNext = nullptr;
-	rp_info.attachmentCount = pipeline->colorAttachmentCount + 1;
+	rp_info.attachmentCount = pipeline->depthAttachmentBits > 0 ? pipeline->colorAttachmentCount + 1 : pipeline->colorAttachmentCount;
 	rp_info.pAttachments = attachments;
 	rp_info.subpassCount = 1;
 	rp_info.pSubpasses = &subpass;

--- a/Backends/Graphics5/Vulkan/Sources/Kore/PipelineState5Impl.cpp
+++ b/Backends/Graphics5/Vulkan/Sources/Kore/PipelineState5Impl.cpp
@@ -180,11 +180,7 @@ namespace {
 }
 
 void kinc_g5_pipeline_init(kinc_g5_pipeline_t *pipeline) {
-	pipeline->vertexShader = nullptr;
-	pipeline->fragmentShader = nullptr;
-	pipeline->geometryShader = nullptr;
-	pipeline->tessellationEvaluationShader = nullptr;
-	pipeline->tessellationControlShader = nullptr;
+	kinc_g5_internal_pipeline_init(pipeline);
 }
 
 void kinc_g5_pipeline_destroy(kinc_g5_pipeline_t *pipeline) {}
@@ -537,10 +533,10 @@ void createDescriptorLayout() {
 	descriptor_pool.poolSizeCount = 8;
 	descriptor_pool.pPoolSizes = typeCounts;
 
-	err = vkCreateDescriptorPool(device, &descriptor_pool, NULL, &desc_pools[0]);
-	err = vkCreateDescriptorPool(device, &descriptor_pool, NULL, &desc_pools[1]);
-	err = vkCreateDescriptorPool(device, &descriptor_pool, NULL, &desc_pools[2]);
-	assert(!err);
+	for (int i = 0; i < 3; ++i) {
+		err = vkCreateDescriptorPool(device, &descriptor_pool, NULL, &desc_pools[i]);
+		assert(!err);
+	}
 }
 
 void Kore::Vulkan::createDescriptorSet(struct PipelineState5Impl_s *pipeline, VkDescriptorSet &desc_set) {

--- a/Backends/Graphics5/Vulkan/Sources/Kore/PipelineState5Impl.cpp
+++ b/Backends/Graphics5/Vulkan/Sources/Kore/PipelineState5Impl.cpp
@@ -383,14 +383,14 @@ void kinc_g5_pipeline_compile(kinc_g5_pipeline_t *pipeline) {
 		case KINC_G4_VERTEX_DATA_SHORT2_NORM:
 			vi_attrs[i].binding = 0;
 			vi_attrs[i].location = find_number(pipeline->impl.vertexLocations, element.name);
-			vi_attrs[i].format = VK_FORMAT_R16G16_SFLOAT;
+			vi_attrs[i].format = VK_FORMAT_R16G16_SNORM;
 			vi_attrs[i].offset = offset;
 			offset += 2 * 2;
 			break;
 		case KINC_G4_VERTEX_DATA_SHORT4_NORM:
 			vi_attrs[i].binding = 0;
 			vi_attrs[i].location = find_number(pipeline->impl.vertexLocations, element.name);
-			vi_attrs[i].format = VK_FORMAT_R16G16B16A16_SFLOAT;
+			vi_attrs[i].format = VK_FORMAT_R16G16B16A16_SNORM;
 			vi_attrs[i].offset = offset;
 			offset += 4 * 2;
 			break;

--- a/Backends/Graphics5/Vulkan/Sources/Kore/PipelineState5Impl.cpp
+++ b/Backends/Graphics5/Vulkan/Sources/Kore/PipelineState5Impl.cpp
@@ -684,8 +684,15 @@ void createDescriptorSet(VkDescriptorSet &desc_set) {
 			tex_desc[i].imageView = vulkanTextures[i]->impl.texture.view;
 		}
 		else if (vulkanRenderTargets[i] != nullptr) {
+			if (vulkanRenderTargets[i]->impl.stage_depth == i) {
+				tex_desc[i].imageView = vulkanRenderTargets[i]->impl.depthView;
+				vulkanRenderTargets[i]->impl.stage_depth = -1;
+				vulkanRenderTargets[i] = nullptr;
+			}
+			else {
+				tex_desc[i].imageView = vulkanRenderTargets[i]->impl.destView;
+			}
 			tex_desc[i].sampler = vulkanRenderTargets[i]->impl.sampler;
-			tex_desc[i].imageView = vulkanRenderTargets[i]->impl.destView;
 		}
 		tex_desc[i].imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
 	}

--- a/Backends/Graphics5/Vulkan/Sources/Kore/PipelineState5Impl.cpp
+++ b/Backends/Graphics5/Vulkan/Sources/Kore/PipelineState5Impl.cpp
@@ -653,7 +653,7 @@ void createDescriptorLayout() {
 	}
 }
 
-void Kore::Vulkan::createDescriptorSet(struct PipelineState5Impl_s *pipeline, VkDescriptorSet &desc_set) {
+void createDescriptorSet(struct PipelineState5Impl_s *pipeline, VkDescriptorSet &desc_set) {
 	VkDescriptorBufferInfo buffer_descs[2];
 
 	VkDescriptorSetAllocateInfo alloc_info = {};
@@ -667,14 +667,14 @@ void Kore::Vulkan::createDescriptorSet(struct PipelineState5Impl_s *pipeline, Vk
 
 	memset(&buffer_descs, 0, sizeof(buffer_descs));
 
-	if (vertexUniformBuffer != nullptr) {
-		buffer_descs[0].buffer = *vertexUniformBuffer;
+	if (Kore::Vulkan::vertexUniformBuffer != nullptr) {
+		buffer_descs[0].buffer = *Kore::Vulkan::vertexUniformBuffer;
 	}
 	buffer_descs[0].offset = 0;
 	buffer_descs[0].range = 256 * sizeof(float);
 
-	if (fragmentUniformBuffer != nullptr) {
-		buffer_descs[1].buffer = *fragmentUniformBuffer;
+	if (Kore::Vulkan::fragmentUniformBuffer != nullptr) {
+		buffer_descs[1].buffer = *Kore::Vulkan::fragmentUniformBuffer;
 	}
 	buffer_descs[1].offset = 0;
 	buffer_descs[1].range = 256 * sizeof(float);
@@ -721,7 +721,7 @@ void Kore::Vulkan::createDescriptorSet(struct PipelineState5Impl_s *pipeline, Vk
 	}
 
 	if (vulkanTextures[0] != nullptr || vulkanRenderTargets[0] != nullptr) {
-		if (vertexUniformBuffer != nullptr && fragmentUniformBuffer != nullptr) {
+		if (Kore::Vulkan::vertexUniformBuffer != nullptr && Kore::Vulkan::fragmentUniformBuffer != nullptr) {
 			vkUpdateDescriptorSets(device, 3, writes, 0, nullptr);
 		}
 		else {
@@ -729,7 +729,7 @@ void Kore::Vulkan::createDescriptorSet(struct PipelineState5Impl_s *pipeline, Vk
 		}
 	}
 	else {
-		if (vertexUniformBuffer != nullptr && fragmentUniformBuffer != nullptr) {
+		if (Kore::Vulkan::vertexUniformBuffer != nullptr && Kore::Vulkan::fragmentUniformBuffer != nullptr) {
 			vkUpdateDescriptorSets(device, 2, writes, 0, nullptr);
 		}
 	}

--- a/Backends/Graphics5/Vulkan/Sources/Kore/PipelineState5Impl.cpp
+++ b/Backends/Graphics5/Vulkan/Sources/Kore/PipelineState5Impl.cpp
@@ -411,7 +411,10 @@ void kinc_g5_pipeline_compile(kinc_g5_pipeline_t *pipeline) {
 	VkPipelineColorBlendAttachmentState att_state[8];
 	memset(att_state, 0, sizeof(att_state));
 	for (int i = 0; i < pipeline->colorAttachmentCount; ++i) {
-		att_state[i].colorWriteMask = 0xf;
+		att_state[i].colorWriteMask = (pipeline->colorWriteMaskRed[i] ? VK_COLOR_COMPONENT_R_BIT  : 0)
+			| (pipeline->colorWriteMaskGreen[i] ? VK_COLOR_COMPONENT_G_BIT  : 0)
+			| (pipeline->colorWriteMaskBlue[i] ? VK_COLOR_COMPONENT_B_BIT  : 0)
+			| (pipeline->colorWriteMaskAlpha[i] ? VK_COLOR_COMPONENT_A_BIT  : 0);
 		att_state[i].blendEnable = VK_FALSE;
 	}
 	cb.attachmentCount = pipeline->colorAttachmentCount;

--- a/Backends/Graphics5/Vulkan/Sources/Kore/PipelineState5Impl.cpp
+++ b/Backends/Graphics5/Vulkan/Sources/Kore/PipelineState5Impl.cpp
@@ -23,8 +23,6 @@ bool memory_type_from_properties(uint32_t typeBits, VkFlags requirements_mask, u
 
 VkDescriptorPool desc_pools[3];
 
-kinc_g5_pipeline_t *currentPipeline = NULL;
-
 static bool has_number(kinc_internal_named_number *named_numbers, const char *name) {
 	for (int i = 0; i < KINC_INTERNAL_NAMED_NUMBER_COUNT; ++i) {
 		if (strcmp(named_numbers[i].name, name) == 0) {
@@ -150,7 +148,7 @@ namespace {
 		}
 	}
 
-	VkShaderModule demo_prepare_shader_module(const void *code, size_t size) {
+	VkShaderModule prepare_shader_module(const void *code, size_t size) {
 		VkShaderModuleCreateInfo moduleCreateInfo;
 		VkShaderModule module;
 		VkResult err;
@@ -167,13 +165,13 @@ namespace {
 		return module;
 	}
 
-	VkShaderModule demo_prepare_vs(VkShaderModule &vert_shader_module, kinc_g5_shader_t *vertexShader) {
-		vert_shader_module = demo_prepare_shader_module(vertexShader->impl.source, vertexShader->impl.length);
+	VkShaderModule prepare_vs(VkShaderModule &vert_shader_module, kinc_g5_shader_t *vertexShader) {
+		vert_shader_module = prepare_shader_module(vertexShader->impl.source, vertexShader->impl.length);
 		return vert_shader_module;
 	}
 
-	VkShaderModule demo_prepare_fs(VkShaderModule &frag_shader_module, kinc_g5_shader_t *fragmentShader) {
-		frag_shader_module = demo_prepare_shader_module(fragmentShader->impl.source, fragmentShader->impl.length);
+	VkShaderModule prepare_fs(VkShaderModule &frag_shader_module, kinc_g5_shader_t *fragmentShader) {
+		frag_shader_module = prepare_shader_module(fragmentShader->impl.source, fragmentShader->impl.length);
 		return frag_shader_module;
 	}
 }
@@ -287,8 +285,6 @@ void kinc_g5_pipeline_compile(kinc_g5_pipeline_t *pipeline) {
 	parseShader(pipeline->vertexShader, pipeline->impl.vertexLocations, pipeline->impl.textureBindings, pipeline->impl.vertexOffsets);
 	parseShader(pipeline->fragmentShader, pipeline->impl.fragmentLocations, pipeline->impl.textureBindings, pipeline->impl.fragmentOffsets);
 
-	//
-
 	VkPipelineLayoutCreateInfo pPipelineLayoutCreateInfo = {};
 	pPipelineLayoutCreateInfo.sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
 	pPipelineLayoutCreateInfo.pNext = NULL;
@@ -297,8 +293,6 @@ void kinc_g5_pipeline_compile(kinc_g5_pipeline_t *pipeline) {
 
 	VkResult err = vkCreatePipelineLayout(device, &pPipelineLayoutCreateInfo, NULL, &pipeline->impl.pipeline_layout);
 	assert(!err);
-
-	//
 
 	VkGraphicsPipelineCreateInfo pipeline_info = {};
 	VkPipelineCacheCreateInfo pipelineCache_info = {};
@@ -502,12 +496,12 @@ void kinc_g5_pipeline_compile(kinc_g5_pipeline_t *pipeline) {
 
 	shaderStages[0].sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
 	shaderStages[0].stage = VK_SHADER_STAGE_VERTEX_BIT;
-	shaderStages[0].module = demo_prepare_vs(pipeline->impl.vert_shader_module, pipeline->vertexShader);
+	shaderStages[0].module = prepare_vs(pipeline->impl.vert_shader_module, pipeline->vertexShader);
 	shaderStages[0].pName = "main";
 
 	shaderStages[1].sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
 	shaderStages[1].stage = VK_SHADER_STAGE_FRAGMENT_BIT;
-	shaderStages[1].module = demo_prepare_fs(pipeline->impl.frag_shader_module, pipeline->fragmentShader);
+	shaderStages[1].module = prepare_fs(pipeline->impl.frag_shader_module, pipeline->fragmentShader);
 	shaderStages[1].pName = "main";
 
 	VkAttachmentDescription attachments[9];
@@ -588,7 +582,6 @@ void kinc_g5_pipeline_compile(kinc_g5_pipeline_t *pipeline) {
 	assert(!err);
 
 	vkDestroyPipelineCache(device, pipeline->impl.pipelineCache, nullptr);
-
 	vkDestroyShaderModule(device, pipeline->impl.frag_shader_module, nullptr);
 	vkDestroyShaderModule(device, pipeline->impl.vert_shader_module, nullptr);
 }

--- a/Backends/Graphics5/Vulkan/Sources/Kore/PipelineState5Impl.cpp
+++ b/Backends/Graphics5/Vulkan/Sources/Kore/PipelineState5Impl.cpp
@@ -653,7 +653,7 @@ void createDescriptorLayout() {
 	}
 }
 
-void createDescriptorSet(struct PipelineState5Impl_s *pipeline, VkDescriptorSet &desc_set) {
+void createDescriptorSet(VkDescriptorSet &desc_set) {
 	VkDescriptorBufferInfo buffer_descs[2];
 
 	VkDescriptorSetAllocateInfo alloc_info = {};

--- a/Backends/Graphics5/Vulkan/Sources/Kore/PipelineState5Impl.cpp
+++ b/Backends/Graphics5/Vulkan/Sources/Kore/PipelineState5Impl.cpp
@@ -178,6 +178,24 @@ namespace {
 	}
 }
 
+static VkFormat convert_format(kinc_g5_render_target_format_t format) {
+	switch (format) {
+	case KINC_G5_RENDER_TARGET_FORMAT_128BIT_FLOAT:
+		return VK_FORMAT_R32G32B32A32_SFLOAT;
+	case KINC_G5_RENDER_TARGET_FORMAT_64BIT_FLOAT:
+		return VK_FORMAT_R16G16B16A16_SFLOAT;
+	case KINC_G5_RENDER_TARGET_FORMAT_32BIT_RED_FLOAT:
+		return VK_FORMAT_R32_SFLOAT;
+	case KINC_G5_RENDER_TARGET_FORMAT_16BIT_RED_FLOAT:
+		return VK_FORMAT_R16_SFLOAT;
+	case KINC_G5_RENDER_TARGET_FORMAT_8BIT_RED:
+		return VK_FORMAT_R8_UNORM;
+	case KINC_G5_RENDER_TARGET_FORMAT_32BIT:
+	default:
+		return VK_FORMAT_B8G8R8A8_UNORM;
+	}
+}
+
 void kinc_g5_pipeline_init(kinc_g5_pipeline_t *pipeline) {
 	kinc_g5_internal_pipeline_init(pipeline);
 }
@@ -460,7 +478,7 @@ void kinc_g5_pipeline_compile(kinc_g5_pipeline_t *pipeline) {
 
 	VkAttachmentDescription attachments[9];
 	for (int i = 0; i < pipeline->colorAttachmentCount; ++i) {
-		attachments[i].format = VK_FORMAT_B8G8R8A8_UNORM;
+		attachments[i].format = convert_format(pipeline->colorAttachment[i]);
 		attachments[i].samples = VK_SAMPLE_COUNT_1_BIT;
 		attachments[i].loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
 		attachments[i].storeOp = VK_ATTACHMENT_STORE_OP_STORE;

--- a/Backends/Graphics5/Vulkan/Sources/Kore/PipelineState5Impl.h
+++ b/Backends/Graphics5/Vulkan/Sources/Kore/PipelineState5Impl.h
@@ -40,10 +40,6 @@ typedef struct PipelineState5Impl_s {
 	kinc_internal_named_number fragmentOffsets[KINC_INTERNAL_NAMED_NUMBER_COUNT];
 
 	VkPipelineLayout pipeline_layout;
-
-	VkDescriptorSetLayout desc_layout;
-
-	//static Graphics5::PipelineState* current;
 } PipelineState5Impl;
 
 typedef struct {

--- a/Backends/Graphics5/Vulkan/Sources/Kore/RenderTarget5Impl.cpp
+++ b/Backends/Graphics5/Vulkan/Sources/Kore/RenderTarget5Impl.cpp
@@ -103,6 +103,8 @@ void kinc_g5_render_target_init(kinc_g5_render_target_t *target, int width, int 
 	target->texHeight = height;
 	target->impl.format = convert_format(format);
 	target->impl.depthBufferBits = depthBufferBits;
+	target->impl.stage = 0;
+	target->impl.stage_depth = -1;
 
 	VkSamplerCreateInfo samplerInfo = {};
 	samplerInfo.sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
@@ -405,11 +407,16 @@ void kinc_g5_render_target_init_cube(kinc_g5_render_target_t *target, int cubeMa
 void kinc_g5_render_target_destroy(kinc_g5_render_target_t *target) {}
 
 void kinc_g5_render_target_use_color_as_texture(kinc_g5_render_target_t *target, kinc_g5_texture_unit_t unit) {
+	target->impl.stage = unit.impl.binding - 2;
 	vulkanRenderTargets[unit.impl.binding - 2] = target;
 	vulkanTextures[unit.impl.binding - 2] = nullptr;
 }
 
-void kinc_g5_render_target_use_depth_as_texture(kinc_g5_render_target_t *target, kinc_g5_texture_unit_t unit) {}
+void kinc_g5_render_target_use_depth_as_texture(kinc_g5_render_target_t *target, kinc_g5_texture_unit_t unit) {
+	target->impl.stage_depth = unit.impl.binding - 2;
+	vulkanRenderTargets[unit.impl.binding - 2] = target;
+	vulkanTextures[unit.impl.binding - 2] = nullptr;
+}
 
 void kinc_g5_render_target_set_depth_stencil_from(kinc_g5_render_target_t *target, kinc_g5_render_target_t *source) {
 	target->impl.depthImage = source->impl.depthImage;

--- a/Backends/Graphics5/Vulkan/Sources/Kore/RenderTarget5Impl.cpp
+++ b/Backends/Graphics5/Vulkan/Sources/Kore/RenderTarget5Impl.cpp
@@ -17,8 +17,8 @@ extern kinc_g5_texture_t *vulkanTextures[8];
 extern kinc_g5_render_target_t *vulkanRenderTargets[8];
 
 bool memory_type_from_properties(uint32_t typeBits, VkFlags requirements_mask, uint32_t* typeIndex);
-void demo_setup_init_cmd();
-void demo_flush_init_cmd();
+void setup_init_cmd();
+void flush_init_cmd();
 
 extern VkCommandPool cmd_pool;
 extern VkQueue queue;
@@ -167,9 +167,9 @@ void kinc_g5_render_target_init(kinc_g5_render_target_t *target, int width, int 
 			err = vkBindImageMemory(device, target->impl.destImage, target->impl.destMemory, 0);
 		    assert(!err);
 
-		    demo_setup_init_cmd();
+		    setup_init_cmd();
 		    setImageLayout(setup_cmd, target->impl.destImage, VK_IMAGE_ASPECT_COLOR_BIT, VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
-		    demo_flush_init_cmd();
+		    flush_init_cmd();
 
 		    VkImageViewCreateInfo view = {};
 		    view.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
@@ -241,9 +241,9 @@ void kinc_g5_render_target_init(kinc_g5_render_target_t *target, int width, int 
 		    err = vkBindImageMemory(device, target->impl.sourceImage, target->impl.sourceMemory, 0);
 		    assert(!err);
 
-		    demo_setup_init_cmd();
+		    setup_init_cmd();
 			setImageLayout(setup_cmd, target->impl.sourceImage, VK_IMAGE_ASPECT_COLOR_BIT, VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
-			demo_flush_init_cmd();
+			flush_init_cmd();
 
 		    colorImageView.image = target->impl.sourceImage;
 			err = vkCreateImageView(device, &colorImageView, nullptr, &target->impl.sourceView);
@@ -309,9 +309,9 @@ void kinc_g5_render_target_init(kinc_g5_render_target_t *target, int width, int 
 			err = vkBindImageMemory(device, target->impl.depthImage, target->impl.depthMemory, 0);
 			assert(!err);
 
-			demo_setup_init_cmd();
+			setup_init_cmd();
 			setImageLayout(setup_cmd, target->impl.depthImage, VK_IMAGE_ASPECT_DEPTH_BIT, VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL);
-			demo_flush_init_cmd();
+			flush_init_cmd();
 
 			/* create image view */
 			err = vkCreateImageView(device, &view, NULL, &target->impl.depthView);

--- a/Backends/Graphics5/Vulkan/Sources/Kore/RenderTarget5Impl.cpp
+++ b/Backends/Graphics5/Vulkan/Sources/Kore/RenderTarget5Impl.cpp
@@ -11,7 +11,6 @@
 #include <assert.h>
 
 extern VkDevice device;
-extern VkRenderPass render_pass;
 extern uint32_t swapchainImageCount;
 extern VkPhysicalDevice gpu;
 extern kinc_g5_texture_t *vulkanTextures[8];

--- a/Backends/Graphics5/Vulkan/Sources/Kore/RenderTarget5Impl.cpp
+++ b/Backends/Graphics5/Vulkan/Sources/Kore/RenderTarget5Impl.cpp
@@ -411,4 +411,9 @@ void kinc_g5_render_target_use_color_as_texture(kinc_g5_render_target_t *target,
 
 void kinc_g5_render_target_use_depth_as_texture(kinc_g5_render_target_t *target, kinc_g5_texture_unit_t unit) {}
 
-void kinc_g5_render_target_set_depth_stencil_from(kinc_g5_render_target_t *target, kinc_g5_render_target_t *source) {}
+void kinc_g5_render_target_set_depth_stencil_from(kinc_g5_render_target_t *target, kinc_g5_render_target_t *source) {
+	target->impl.depthImage = source->impl.depthImage;
+	target->impl.depthMemory = source->impl.depthMemory;
+	target->impl.depthView = source->impl.depthView;
+	target->impl.depthBufferBits = source->impl.depthBufferBits;
+}

--- a/Backends/Graphics5/Vulkan/Sources/Kore/RenderTarget5Impl.cpp
+++ b/Backends/Graphics5/Vulkan/Sources/Kore/RenderTarget5Impl.cpp
@@ -19,7 +19,78 @@ extern kinc_g5_render_target_t *vulkanRenderTargets[8];
 
 bool memory_type_from_properties(uint32_t typeBits, VkFlags requirements_mask, uint32_t* typeIndex);
 
+extern VkCommandPool cmd_pool;
+extern VkQueue queue;
+static VkCommandBuffer setup_cmd;
+
+namespace {
+	void demo_flush_init_cmd() {
+		VkResult err;
+
+		if (setup_cmd == VK_NULL_HANDLE) return;
+
+		err = vkEndCommandBuffer(setup_cmd);
+		assert(!err);
+
+		const VkCommandBuffer cmd_bufs[] = {setup_cmd};
+		VkFence nullFence = {VK_NULL_HANDLE};
+		VkSubmitInfo submit_info = {};
+		submit_info.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
+		submit_info.pNext = NULL;
+		submit_info.waitSemaphoreCount = 0;
+		submit_info.pWaitSemaphores = NULL;
+		submit_info.pWaitDstStageMask = NULL;
+		submit_info.commandBufferCount = 1;
+		submit_info.pCommandBuffers = cmd_bufs;
+		submit_info.signalSemaphoreCount = 0;
+		submit_info.pSignalSemaphores = NULL;
+
+		err = vkQueueSubmit(queue, 1, &submit_info, nullFence);
+		assert(!err);
+
+		err = vkQueueWaitIdle(queue);
+		assert(!err);
+
+		vkFreeCommandBuffers(device, cmd_pool, 1, cmd_bufs);
+		setup_cmd = VK_NULL_HANDLE;
+	}
+
+	void demo_setup_init_cmd() {
+		if (setup_cmd == VK_NULL_HANDLE) {
+			VkCommandBufferAllocateInfo cmd = {};
+			cmd.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
+			cmd.pNext = NULL;
+			cmd.commandPool = cmd_pool;
+			cmd.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
+			cmd.commandBufferCount = 1;
+
+			VkResult err = vkAllocateCommandBuffers(device, &cmd, &setup_cmd);
+			assert(!err);
+
+			VkCommandBufferInheritanceInfo cmd_buf_hinfo = {};
+			cmd_buf_hinfo.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_INHERITANCE_INFO;
+			cmd_buf_hinfo.pNext = NULL;
+			cmd_buf_hinfo.renderPass = VK_NULL_HANDLE;
+			cmd_buf_hinfo.subpass = 0;
+			cmd_buf_hinfo.framebuffer = VK_NULL_HANDLE;
+			cmd_buf_hinfo.occlusionQueryEnable = VK_FALSE;
+			cmd_buf_hinfo.queryFlags = 0;
+			cmd_buf_hinfo.pipelineStatistics = 0;
+
+			VkCommandBufferBeginInfo cmd_buf_info = {};
+			cmd_buf_info.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
+			cmd_buf_info.pNext = NULL;
+			cmd_buf_info.flags = 0;
+			cmd_buf_info.pInheritanceInfo = &cmd_buf_hinfo;
+
+			err = vkBeginCommandBuffer(setup_cmd, &cmd_buf_info);
+			assert(!err);
+		}
+	}
+}
+
 void setImageLayout(VkCommandBuffer _buffer, VkImage image, VkImageAspectFlags aspectMask, VkImageLayout oldImageLayout, VkImageLayout newImageLayout) {
+
 	VkImageMemoryBarrier imageMemoryBarrier = {};
 	imageMemoryBarrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
 	imageMemoryBarrier.pNext = nullptr;
@@ -54,10 +125,10 @@ void setImageLayout(VkCommandBuffer _buffer, VkImage image, VkImageAspectFlags a
 		imageMemoryBarrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
 	}
 
-	VkPipelineStageFlags srcStageFlags = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;
-	VkPipelineStageFlags destStageFlags = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;
+	VkPipelineStageFlags srcStageFlags = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
+	VkPipelineStageFlags dstStageFlags = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
 
-	vkCmdPipelineBarrier(_buffer, srcStageFlags, destStageFlags, 0, 0, nullptr, 0, nullptr, 1, &imageMemoryBarrier);
+	vkCmdPipelineBarrier(_buffer, srcStageFlags, dstStageFlags, 0, 0, nullptr, 0, nullptr, 1, &imageMemoryBarrier);
 }
 
 void kinc_g5_render_target_init(kinc_g5_render_target_t *target, int width, int height, int depthBufferBits, bool antialiasing,
@@ -67,124 +138,6 @@ void kinc_g5_render_target_init(kinc_g5_render_target_t *target, int width, int 
 	target->contextId = contextId;
 	target->texWidth = width;
 	target->texHeight = height;
-	/**{
-	    VkFormatProperties formatProperties;
-	    VkResult err;
-
-	    vkGetPhysicalDeviceFormatProperties(gpu, VK_FORMAT_R8G8B8A8_UNORM, &formatProperties);
-	    assert(formatProperties.optimalTilingFeatures & VK_FORMAT_FEATURE_BLIT_DST_BIT);
-
-	    VkImageCreateInfo imageCreateInfo = {};
-	    imageCreateInfo.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
-	    imageCreateInfo.pNext = NULL;
-	    imageCreateInfo.imageType = VK_IMAGE_TYPE_2D;
-	    imageCreateInfo.format = VK_FORMAT_R8G8B8A8_UNORM;
-	    imageCreateInfo.extent = {(uint32_t)width, (uint32_t)height, 1};
-	    imageCreateInfo.mipLevels = 1;
-	    imageCreateInfo.arrayLayers = 1;
-	    imageCreateInfo.samples = VK_SAMPLE_COUNT_1_BIT;
-	    imageCreateInfo.tiling = VK_IMAGE_TILING_OPTIMAL;
-	    imageCreateInfo.usage = VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
-	    imageCreateInfo.flags = 0;
-	    imageCreateInfo.initialLayout = VK_IMAGE_LAYOUT_PREINITIALIZED;
-
-	    err = vkCreateImage(device, &imageCreateInfo, nullptr, &destImage);
-	    assert(!err);
-
-	    VkMemoryRequirements memoryRequirements;
-	    vkGetImageMemoryRequirements(device, destImage, &memoryRequirements);
-
-	    VkMemoryAllocateInfo allocationInfo = {};
-	    allocationInfo.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
-	    allocationInfo.pNext = nullptr;
-	    allocationInfo.memoryTypeIndex = 0;
-
-	    vkGetImageMemoryRequirements(device, destImage, &memoryRequirements);
-	    allocationInfo.allocationSize = memoryRequirements.size;
-	    bool pass = memory_type_from_properties(memoryRequirements.memoryTypeBits, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, &allocationInfo.memoryTypeIndex);
-	    assert(pass);
-	    err = vkAllocateMemory(device, &allocationInfo, nullptr, &destMemory);
-	    assert(!err);
-	    err = vkBindImageMemory(device, destImage, destMemory, 0);
-	    assert(!err);
-
-	    setImageLayout(destImage, VK_IMAGE_ASPECT_COLOR_BIT, VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
-
-	    VkImageViewCreateInfo view = {};
-	    view.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
-	    view.pNext = nullptr;
-	    view.image = VK_NULL_HANDLE;
-	    view.viewType = VK_IMAGE_VIEW_TYPE_2D;
-	    view.format = VK_FORMAT_R8G8B8A8_UNORM;
-	    view.components = {VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_G, VK_COMPONENT_SWIZZLE_B, VK_COMPONENT_SWIZZLE_A};
-	    view.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
-	    view.image = destImage;
-	    err = vkCreateImageView(device, &view, nullptr, &destView);
-	    assert(!err);
-	}
-
-	{
-	    VkFormatProperties formatProperties;
-	    VkResult err;
-
-	    vkGetPhysicalDeviceFormatProperties(gpu, VK_FORMAT_R8G8B8A8_UNORM, &formatProperties);
-	    assert(formatProperties.optimalTilingFeatures & VK_FORMAT_FEATURE_BLIT_SRC_BIT);
-
-	    VkImageCreateInfo image = {};
-	    image.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
-	    image.pNext = nullptr;
-	    image.imageType = VK_IMAGE_TYPE_2D;
-	    image.format = VK_FORMAT_R8G8B8A8_UNORM;
-	    image.extent.width = width;
-	    image.extent.height = height;
-	    image.extent.depth = 1;
-	    image.mipLevels = 1;
-	    image.arrayLayers = 1;
-	    image.samples = VK_SAMPLE_COUNT_1_BIT;
-	    image.tiling = VK_IMAGE_TILING_OPTIMAL;
-	    image.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
-	    image.flags = 0;
-
-	    VkImageViewCreateInfo colorImageView = {};
-	    colorImageView.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
-	    colorImageView.pNext = nullptr;
-	    colorImageView.viewType = VK_IMAGE_VIEW_TYPE_2D;
-	    colorImageView.format = VK_FORMAT_R8G8B8A8_UNORM;
-	    colorImageView.flags = 0;
-	    colorImageView.subresourceRange = {};
-	    colorImageView.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-	    colorImageView.subresourceRange.baseMipLevel = 0;
-	    colorImageView.subresourceRange.levelCount = 1;
-	    colorImageView.subresourceRange.baseArrayLayer = 0;
-	    colorImageView.subresourceRange.layerCount = 1;
-
-	    err = vkCreateImage(device, &image, nullptr, &sourceImage);
-	    assert(!err);
-
-	    VkMemoryRequirements memoryRequirements;
-	    vkGetImageMemoryRequirements(device, sourceImage, &memoryRequirements);
-
-	    VkMemoryAllocateInfo allocationInfo = {};
-	    allocationInfo.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
-	    allocationInfo.pNext = nullptr;
-	    allocationInfo.memoryTypeIndex = 0;
-
-	    vkGetImageMemoryRequirements(device, sourceImage, &memoryRequirements);
-	    allocationInfo.allocationSize = memoryRequirements.size;
-	    bool pass = memory_type_from_properties(memoryRequirements.memoryTypeBits, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, &allocationInfo.memoryTypeIndex);
-	    assert(pass);
-
-	    err = vkAllocateMemory(device, &allocationInfo, nullptr, &sourceMemory);
-	    assert(!err);
-
-	    err = vkBindImageMemory(device, sourceImage, sourceMemory, 0);
-	    assert(!err);
-	    setImageLayout(sourceImage, VK_IMAGE_ASPECT_COLOR_BIT, VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
-
-	    colorImageView.image = sourceImage;
-	    err = vkCreateImageView(device, &colorImageView, nullptr, &sourceView);
-	    assert(!err);
-	}*/
 
 	VkSamplerCreateInfo samplerInfo = {};
 	samplerInfo.sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
@@ -207,127 +160,285 @@ void kinc_g5_render_target_init(kinc_g5_render_target_t *target, int width, int 
 	VkResult err = vkCreateSampler(device, &samplerInfo, nullptr, &target->impl.sampler);
 	assert(!err);
 
-	/*VkImageCreateInfo imageInfo = {};
-	imageInfo.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
-	imageInfo.pNext = nullptr;
-	imageInfo.imageType = VK_IMAGE_TYPE_2D;
-	imageInfo.format = VK_FORMAT_B8G8R8A8_UNORM;
-	imageInfo.extent = { (uint32_t)width, (uint32_t)height, 1 };
-	imageInfo.mipLevels = 1;
-	imageInfo.arrayLayers = 1;
-	imageInfo.samples = VK_SAMPLE_COUNT_1_BIT;
-	imageInfo.tiling = VK_IMAGE_TILING_OPTIMAL;
-	imageInfo.usage = VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
-	imageInfo.flags = 0;
+	if (contextId >= 0) {
 
-	err = vkCreateImage(device, &imageInfo, NULL, &image);
-	assert(!err);
+		{
+		    VkFormatProperties formatProperties;
+		    VkResult err;
 
-	VkMemoryRequirements memoryRequirements;
-	vkGetImageMemoryRequirements(device, image, &memoryRequirements);
+		    vkGetPhysicalDeviceFormatProperties(gpu, VK_FORMAT_B8G8R8A8_UNORM, &formatProperties);
+		    assert(formatProperties.optimalTilingFeatures & VK_FORMAT_FEATURE_BLIT_DST_BIT);
 
-	VkMemoryAllocateInfo allocationInfo = {};
-	allocationInfo.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
-	allocationInfo.pNext = nullptr;
-	allocationInfo.allocationSize = memoryRequirements.size;
-	allocationInfo.memoryTypeIndex = 0;
+		    VkImageCreateInfo imageCreateInfo = {};
+		    imageCreateInfo.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
+		    imageCreateInfo.pNext = NULL;
+		    imageCreateInfo.imageType = VK_IMAGE_TYPE_2D;
+		    imageCreateInfo.format = VK_FORMAT_B8G8R8A8_UNORM;
+		    imageCreateInfo.extent = {(uint32_t)width, (uint32_t)height, 1};
+		    imageCreateInfo.mipLevels = 1;
+		    imageCreateInfo.arrayLayers = 1;
+		    imageCreateInfo.samples = VK_SAMPLE_COUNT_1_BIT;
+		    imageCreateInfo.tiling = VK_IMAGE_TILING_OPTIMAL;
+		    imageCreateInfo.usage = VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
+		    imageCreateInfo.flags = 0;
+		    imageCreateInfo.initialLayout = VK_IMAGE_LAYOUT_PREINITIALIZED;
 
-	bool pass = memory_type_from_properties(memoryRequirements.memoryTypeBits, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, &allocationInfo.memoryTypeIndex);
-	assert(pass);
+		    err = vkCreateImage(device, &imageCreateInfo, nullptr, &target->impl.destImage);
+		    assert(!err);
 
-	err = vkAllocateMemory(device, &allocationInfo, NULL, &memory);
-	assert(!err);
+		    VkMemoryRequirements memoryRequirements;
+			vkGetImageMemoryRequirements(device, target->impl.destImage, &memoryRequirements);
 
-	err = vkBindImageMemory(device, image, memory, 0);
-	assert(!err);
+		    VkMemoryAllocateInfo allocationInfo = {};
+		    allocationInfo.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+		    allocationInfo.pNext = nullptr;
+		    allocationInfo.memoryTypeIndex = 0;
 
-	VkImageViewCreateInfo viewInfo = {};
-	viewInfo.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
-	viewInfo.pNext = nullptr;
-	viewInfo.image = image;
-	viewInfo.format = VK_FORMAT_B8G8R8A8_UNORM; // is that OK?
-	viewInfo.components.r = VK_COMPONENT_SWIZZLE_R;
-	viewInfo.components.g = VK_COMPONENT_SWIZZLE_G;
-	viewInfo.components.b = VK_COMPONENT_SWIZZLE_B;
-	viewInfo.components.a = VK_COMPONENT_SWIZZLE_A;
-	viewInfo.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-	viewInfo.subresourceRange.baseMipLevel = 0;
-	viewInfo.subresourceRange.levelCount = 1;
-	viewInfo.subresourceRange.baseArrayLayer = 0;
-	viewInfo.subresourceRange.layerCount = 1;
-	viewInfo.viewType = VK_IMAGE_VIEW_TYPE_2D;
-	viewInfo.flags = 0;
+		    vkGetImageMemoryRequirements(device, target->impl.destImage, &memoryRequirements);
+		    allocationInfo.allocationSize = memoryRequirements.size;
+		    bool pass = memory_type_from_properties(memoryRequirements.memoryTypeBits, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, &allocationInfo.memoryTypeIndex);
+		    assert(pass);
+			err = vkAllocateMemory(device, &allocationInfo, nullptr, &target->impl.destMemory);
+		    assert(!err);
+			err = vkBindImageMemory(device, target->impl.destImage, target->impl.destMemory, 0);
+		    assert(!err);
 
-	err = vkCreateImageView(device, &viewInfo, nullptr, &view);
-	assert(!err);*/
+		    demo_setup_init_cmd();
+		    setImageLayout(setup_cmd, target->impl.destImage, VK_IMAGE_ASPECT_COLOR_BIT, VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+		    demo_flush_init_cmd();
 
-	/*VkAttachmentReference colorReference = {};
-	colorReference.attachment = 0;
-	colorReference.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+		    VkImageViewCreateInfo view = {};
+		    view.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
+		    view.pNext = nullptr;
+		    view.image = VK_NULL_HANDLE;
+		    view.viewType = VK_IMAGE_VIEW_TYPE_2D;
+		    view.format = VK_FORMAT_B8G8R8A8_UNORM;
+		    view.components = {VK_COMPONENT_SWIZZLE_R, VK_COMPONENT_SWIZZLE_G, VK_COMPONENT_SWIZZLE_B, VK_COMPONENT_SWIZZLE_A};
+		    view.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+			view.image = target->impl.destImage;
+			err = vkCreateImageView(device, &view, nullptr, &target->impl.destView);
+		    assert(!err);
+		}
 
-	VkSubpassDescription subpass = {};
-	subpass.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
-	subpass.flags = 0;
-	subpass.inputAttachmentCount = 0;
-	subpass.pInputAttachments = nullptr;
-	subpass.colorAttachmentCount = 1;
-	subpass.pColorAttachments = &colorReference;
-	subpass.pResolveAttachments = nullptr;
-	subpass.pDepthStencilAttachment = nullptr;
-	subpass.preserveAttachmentCount = 0;
-	subpass.pPreserveAttachments = nullptr;
+		{
+		    VkFormatProperties formatProperties;
+		    VkResult err;
 
-	VkAttachmentDescription attachment;
-	attachment.format = VK_FORMAT_B8G8R8A8_UNORM;
-	attachment.samples = VK_SAMPLE_COUNT_1_BIT;
-	attachment.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
-	attachment.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
-	attachment.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
-	attachment.stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
-	attachment.initialLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
-	attachment.finalLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+		    vkGetPhysicalDeviceFormatProperties(gpu, VK_FORMAT_B8G8R8A8_UNORM, &formatProperties);
+		    assert(formatProperties.optimalTilingFeatures & VK_FORMAT_FEATURE_BLIT_SRC_BIT);
 
-	VkRenderPassCreateInfo renderPassInfo = {};
-	renderPassInfo.sType = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO;
-	renderPassInfo.pNext = nullptr;
-	renderPassInfo.attachmentCount = 1;
-	renderPassInfo.pAttachments = &attachment;
-	renderPassInfo.subpassCount = 1;
-	renderPassInfo.pSubpasses = &subpass;
-	renderPassInfo.dependencyCount = 0;
-	renderPassInfo.pDependencies = nullptr;
+		    VkImageCreateInfo image = {};
+		    image.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
+		    image.pNext = nullptr;
+		    image.imageType = VK_IMAGE_TYPE_2D;
+		    image.format = VK_FORMAT_B8G8R8A8_UNORM;
+		    image.extent.width = width;
+		    image.extent.height = height;
+		    image.extent.depth = 1;
+		    image.mipLevels = 1;
+		    image.arrayLayers = 1;
+		    image.samples = VK_SAMPLE_COUNT_1_BIT;
+		    image.tiling = VK_IMAGE_TILING_OPTIMAL;
+		    image.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
+		    image.flags = 0;
 
-	err = vkCreateRenderPass(device, &renderPassInfo, nullptr, &renderPass);
-	assert(!err);
+		    VkImageViewCreateInfo colorImageView = {};
+		    colorImageView.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
+		    colorImageView.pNext = nullptr;
+		    colorImageView.viewType = VK_IMAGE_VIEW_TYPE_2D;
+		    colorImageView.format = VK_FORMAT_B8G8R8A8_UNORM;
+		    colorImageView.flags = 0;
+		    colorImageView.subresourceRange = {};
+		    colorImageView.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+		    colorImageView.subresourceRange.baseMipLevel = 0;
+		    colorImageView.subresourceRange.levelCount = 1;
+		    colorImageView.subresourceRange.baseArrayLayer = 0;
+		    colorImageView.subresourceRange.layerCount = 1;
 
-	VkFramebufferCreateInfo fbufCreateInfo = {};
-	fbufCreateInfo.sType = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO;
-	fbufCreateInfo.pNext = nullptr;
-	fbufCreateInfo.renderPass = renderPass;
-	fbufCreateInfo.attachmentCount = 1;
-	fbufCreateInfo.pAttachments = &sourceView;
-	fbufCreateInfo.width = width;
-	fbufCreateInfo.height = height;
-	fbufCreateInfo.layers = 1;
+		    err = vkCreateImage(device, &image, nullptr, &target->impl.sourceImage);
+		    assert(!err);
 
-	err = vkCreateFramebuffer(device, &fbufCreateInfo, nullptr, &framebuffer);
-	assert(!err);
+		    VkMemoryRequirements memoryRequirements;
+			vkGetImageMemoryRequirements(device, target->impl.sourceImage, &memoryRequirements);
 
-	createDescriptorSet(nullptr, this, desc_set);*/
+		    VkMemoryAllocateInfo allocationInfo = {};
+		    allocationInfo.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+		    allocationInfo.pNext = nullptr;
+		    allocationInfo.memoryTypeIndex = 0;
+
+		    vkGetImageMemoryRequirements(device, target->impl.sourceImage, &memoryRequirements);
+		    allocationInfo.allocationSize = memoryRequirements.size;
+		    bool pass = memory_type_from_properties(memoryRequirements.memoryTypeBits, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, &allocationInfo.memoryTypeIndex);
+		    assert(pass);
+
+		    err = vkAllocateMemory(device, &allocationInfo, nullptr, &target->impl.sourceMemory);
+		    assert(!err);
+
+		    err = vkBindImageMemory(device, target->impl.sourceImage, target->impl.sourceMemory, 0);
+		    assert(!err);
+
+		    demo_setup_init_cmd();
+			setImageLayout(setup_cmd, target->impl.sourceImage, VK_IMAGE_ASPECT_COLOR_BIT, VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
+			demo_flush_init_cmd();
+
+		    colorImageView.image = target->impl.sourceImage;
+			err = vkCreateImageView(device, &colorImageView, nullptr, &target->impl.sourceView);
+		    assert(!err);
+		}
+
+		{
+			const VkFormat depth_format = VK_FORMAT_D16_UNORM;
+			VkImageCreateInfo image = {};
+			image.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
+			image.pNext = NULL;
+			image.imageType = VK_IMAGE_TYPE_2D;
+			image.format = depth_format;
+			image.extent.width = width;
+			image.extent.height = height;
+			image.extent.depth = 1;
+			image.mipLevels = 1;
+			image.arrayLayers = 1;
+			image.samples = VK_SAMPLE_COUNT_1_BIT;
+			image.tiling = VK_IMAGE_TILING_OPTIMAL;
+			image.usage = VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT;
+			image.flags = 0;
+
+			/* create image */
+			err = vkCreateImage(device, &image, NULL, &target->impl.depthImage);
+			assert(!err);
+
+			VkMemoryAllocateInfo mem_alloc = {};
+			mem_alloc.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+			mem_alloc.pNext = NULL;
+			mem_alloc.allocationSize = 0;
+			mem_alloc.memoryTypeIndex = 0;
+
+			VkImageViewCreateInfo view = {};
+			view.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
+			view.pNext = NULL;
+			view.image = target->impl.depthImage;
+			view.format = depth_format;
+			view.subresourceRange.aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT;
+			view.subresourceRange.baseMipLevel = 0;
+			view.subresourceRange.levelCount = 1;
+			view.subresourceRange.baseArrayLayer = 0;
+			view.subresourceRange.layerCount = 1;
+			view.flags = 0;
+			view.viewType = VK_IMAGE_VIEW_TYPE_2D;
+
+			VkMemoryRequirements mem_reqs = {};
+			bool pass;
+
+			/* get memory requirements for this object */
+			vkGetImageMemoryRequirements(device, target->impl.depthImage, &mem_reqs);
+
+			/* select memory size and type */
+			mem_alloc.allocationSize = mem_reqs.size;
+			pass = memory_type_from_properties(mem_reqs.memoryTypeBits, 0, /* No requirements */ &mem_alloc.memoryTypeIndex);
+			assert(pass);
+
+			/* allocate memory */
+			err = vkAllocateMemory(device, &mem_alloc, NULL, &target->impl.depthMemory);
+			assert(!err);
+
+			/* bind memory */
+			err = vkBindImageMemory(device, target->impl.depthImage, target->impl.depthMemory, 0);
+			assert(!err);
+
+			demo_setup_init_cmd();
+			setImageLayout(setup_cmd, target->impl.depthImage, VK_IMAGE_ASPECT_DEPTH_BIT, VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL);
+			demo_flush_init_cmd();
+
+			/* create image view */
+			err = vkCreateImageView(device, &view, NULL, &target->impl.depthView);
+			assert(!err);
+		}
+
+		{
+			VkAttachmentDescription attachments[2];
+			attachments[0].format = VK_FORMAT_B8G8R8A8_UNORM;
+			attachments[0].samples = VK_SAMPLE_COUNT_1_BIT;
+			attachments[0].loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
+			attachments[0].storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+			attachments[0].stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+			attachments[0].stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+			attachments[0].initialLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+			attachments[0].finalLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+			attachments[0].flags = 0;
+
+			attachments[1].format = VK_FORMAT_D16_UNORM;
+			attachments[1].samples = VK_SAMPLE_COUNT_1_BIT;
+			attachments[1].loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
+			attachments[1].storeOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+			attachments[1].stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+			attachments[1].stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+			attachments[1].initialLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
+			attachments[1].finalLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
+			attachments[1].flags = 0;
+
+			VkAttachmentReference color_reference = {};
+			color_reference.attachment = 0;
+			color_reference.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+			VkAttachmentReference depth_reference = {};
+			depth_reference.attachment = 1;
+			depth_reference.layout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
+
+			VkSubpassDescription subpass = {};
+			subpass.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
+			subpass.flags = 0;
+			subpass.inputAttachmentCount = 0;
+			subpass.pInputAttachments = nullptr;
+			subpass.colorAttachmentCount = 1;
+			subpass.pColorAttachments = &color_reference;
+			subpass.pResolveAttachments = nullptr;
+			subpass.pDepthStencilAttachment = &depth_reference;
+			subpass.preserveAttachmentCount = 0;
+			subpass.pPreserveAttachments = nullptr;
+
+			VkRenderPassCreateInfo rp_info = {};
+			rp_info.sType = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO;
+			rp_info.pNext = nullptr;
+			rp_info.attachmentCount = 2;
+			rp_info.pAttachments = attachments;
+			rp_info.subpassCount = 1;
+			rp_info.pSubpasses = &subpass;
+			rp_info.dependencyCount = 0;
+			rp_info.pDependencies = nullptr;
+
+			err = vkCreateRenderPass(device, &rp_info, NULL, &target->impl.renderPass);
+			assert(!err);
+		}
+
+		VkImageView attachments[2];
+		attachments[0] = target->impl.sourceView;
+		attachments[1] = target->impl.depthView;
+
+		VkFramebufferCreateInfo fbufCreateInfo = {};
+		fbufCreateInfo.sType = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO;
+		fbufCreateInfo.pNext = nullptr;
+		fbufCreateInfo.renderPass = target->impl.renderPass;
+		fbufCreateInfo.attachmentCount = 2;
+		fbufCreateInfo.pAttachments = attachments;
+		fbufCreateInfo.width = width;
+		fbufCreateInfo.height = height;
+		fbufCreateInfo.layers = 1;
+
+		err = vkCreateFramebuffer(device, &fbufCreateInfo, nullptr, &target->impl.framebuffer);
+		assert(!err);
+	}
 }
 
 void kinc_g5_render_target_init_cube(kinc_g5_render_target_t *target, int cubeMapSize, int depthBufferBits, bool antialiasing,
                                      kinc_g5_render_target_format_t format, int stencilBufferBits, int contextId) {}
 
 void kinc_g5_render_target_destroy(kinc_g5_render_target_t *target) {}
-	 
+
 void kinc_g5_render_target_use_color_as_texture(kinc_g5_render_target_t *target, kinc_g5_texture_unit_t unit) {
 	vulkanRenderTargets[unit.impl.binding - 2] = target;
 	vulkanTextures[unit.impl.binding - 2] = nullptr;
-	//** if (Program5Impl::current != nullptr)
-	//**	vkCmdBindDescriptorSets(draw_cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, Program5Impl::current->pipeline_layout, 0, 1, &desc_set, 0, nullptr);
 }
 
- void kinc_g5_render_target_use_depth_as_texture(kinc_g5_render_target_t *target, kinc_g5_texture_unit_t unit) {}
+void kinc_g5_render_target_use_depth_as_texture(kinc_g5_render_target_t *target, kinc_g5_texture_unit_t unit) {}
 
 void kinc_g5_render_target_set_depth_stencil_from(kinc_g5_render_target_t *target, kinc_g5_render_target_t *source) {}

--- a/Backends/Graphics5/Vulkan/Sources/Kore/RenderTarget5Impl.h
+++ b/Backends/Graphics5/Vulkan/Sources/Kore/RenderTarget5Impl.h
@@ -26,6 +26,7 @@ typedef struct {
 	VkImage depthImage;
 	VkDeviceMemory depthMemory;
 	VkImageView depthView;
+	int depthBufferBits;
 
 	VkFramebuffer framebuffer;
 	VkSampler sampler;

--- a/Backends/Graphics5/Vulkan/Sources/Kore/RenderTarget5Impl.h
+++ b/Backends/Graphics5/Vulkan/Sources/Kore/RenderTarget5Impl.h
@@ -33,4 +33,7 @@ typedef struct {
 	VkRenderPass renderPass;
 
 	VkFormat format;
+
+	int stage;
+	int stage_depth;
 } RenderTarget5Impl;

--- a/Backends/Graphics5/Vulkan/Sources/Kore/RenderTarget5Impl.h
+++ b/Backends/Graphics5/Vulkan/Sources/Kore/RenderTarget5Impl.h
@@ -30,4 +30,6 @@ typedef struct {
 	VkFramebuffer framebuffer;
 	VkSampler sampler;
 	VkRenderPass renderPass;
+
+	VkFormat format;
 } RenderTarget5Impl;

--- a/Backends/Graphics5/Vulkan/Sources/Kore/RenderTarget5Impl.h
+++ b/Backends/Graphics5/Vulkan/Sources/Kore/RenderTarget5Impl.h
@@ -23,8 +23,11 @@ typedef struct {
 	VkDeviceMemory sourceMemory;
 	VkImageView sourceView;
 
+	VkImage depthImage;
+	VkDeviceMemory depthMemory;
+	VkImageView depthView;
+
 	VkFramebuffer framebuffer;
-	VkDescriptorSet desc_set;
 	VkSampler sampler;
 	VkRenderPass renderPass;
 } RenderTarget5Impl;

--- a/Backends/Graphics5/Vulkan/Sources/Kore/Texture5Impl.cpp
+++ b/Backends/Graphics5/Vulkan/Sources/Kore/Texture5Impl.cpp
@@ -114,12 +114,10 @@ namespace {
 			image_memory_barrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT | VK_ACCESS_INPUT_ATTACHMENT_READ_BIT;
 		}
 
-		VkImageMemoryBarrier* pmemory_barrier = &image_memory_barrier;
+		VkPipelineStageFlags srcStageMask = VK_PIPELINE_STAGE_HOST_BIT;
+		VkPipelineStageFlags dstStageMask = VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
 
-		VkPipelineStageFlags src_stages = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;
-		VkPipelineStageFlags dest_stages = VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT;
-
-		vkCmdPipelineBarrier(setup_cmd, src_stages, dest_stages, 0, 0, NULL, 0, NULL, 1, pmemory_barrier);
+		vkCmdPipelineBarrier(setup_cmd, srcStageMask, dstStageMask, 0, 0, NULL, 0, NULL, 1, &image_memory_barrier);
 	}
 
 	void demo_prepare_texture_image(uint8_t *tex_colors, uint32_t tex_width, uint32_t tex_height, texture_object* tex_obj, VkImageTiling tiling,
@@ -225,6 +223,8 @@ void kinc_g5_texture_init_from_image(kinc_g5_texture_t *texture, kinc_image_t *i
 		// Device can texture using linear textures
 		demo_prepare_texture_image((uint8_t*)image->data, (uint32_t)image->width, (uint32_t)image->height, &texture->impl.texture, VK_IMAGE_TILING_LINEAR, VK_IMAGE_USAGE_SAMPLED_BIT,
 		                           VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT, texture->impl.deviceSize);
+
+		demo_flush_init_cmd();
 	}
 	else if (props.optimalTilingFeatures & VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT) {
 		// Must use staging buffer to copy linear texture to optimized
@@ -297,8 +297,6 @@ void kinc_g5_texture_init_from_image(kinc_g5_texture_t *texture, kinc_image_t *i
 	view.image = texture->impl.texture.image;
 	err = vkCreateImageView(device, &view, NULL, &texture->impl.texture.view);
 	assert(!err);
-
-	Kore::Vulkan::createDescriptorSet(nullptr, texture, nullptr, texture->impl.desc_set); // TODO
 }
 
 void kinc_g5_texture_init(kinc_g5_texture_t* texture, int width, int height, kinc_image_format_t format) {

--- a/Backends/Graphics5/Vulkan/Sources/Kore/Texture5Impl.cpp
+++ b/Backends/Graphics5/Vulkan/Sources/Kore/Texture5Impl.cpp
@@ -230,9 +230,32 @@ static VkFormat convert_format(kinc_image_format_t format) {
 	}
 }
 
+static int format_byte_size(kinc_image_format_t format) {
+	switch (format) {
+	case KINC_IMAGE_FORMAT_RGBA128:
+		return 16;
+	case KINC_IMAGE_FORMAT_RGBA64:
+		return 8;
+	case KINC_IMAGE_FORMAT_RGB24:
+		return 4;
+	case KINC_IMAGE_FORMAT_A32:
+		return 4;
+	case KINC_IMAGE_FORMAT_A16:
+		return 2;
+	case KINC_IMAGE_FORMAT_GREY8:
+		return 1;
+	case KINC_IMAGE_FORMAT_BGRA32:
+	case KINC_IMAGE_FORMAT_RGBA32:
+		return 4;
+	default:
+		return 4;
+	}
+}
+
 void kinc_g5_texture_init_from_image(kinc_g5_texture_t *texture, kinc_image_t *image) {
 	texture->texWidth = image->width;
 	texture->texHeight = image->height;
+	texture->impl.stride = format_byte_size(image->format) * texture->texWidth;
 
 	const VkFormat tex_format = convert_format(image->format);
 	VkFormatProperties props;
@@ -323,6 +346,7 @@ void kinc_g5_texture_init_from_image(kinc_g5_texture_t *texture, kinc_image_t *i
 void kinc_g5_texture_init(kinc_g5_texture_t* texture, int width, int height, kinc_image_format_t format) {
 	texture->texWidth = width;
 	texture->texHeight = height;
+	texture->impl.stride = format_byte_size(format) * texture->texWidth;
 
 	const VkFormat tex_format = convert_format(format);
 	VkFormatProperties props;
@@ -387,7 +411,7 @@ void kinc_g5_texture_destroy(kinc_g5_texture_t *texture) {}
 void kinc_g5_internal_texture_set(kinc_g5_texture_t *texture, int unit) {}
 
 int kinc_g5_texture_stride(kinc_g5_texture_t *texture) {
-	return texture->texWidth * 4;
+	return texture->impl.stride;
 }
 
 uint8_t *kinc_g5_texture_lock(kinc_g5_texture_t *texture) {

--- a/Backends/Graphics5/Vulkan/Sources/Kore/Texture5Impl.h
+++ b/Backends/Graphics5/Vulkan/Sources/Kore/Texture5Impl.h
@@ -36,4 +36,5 @@ typedef struct {
 	VkDeviceSize deviceSize;
 
 	uint8_t *conversionBuffer;
+	int stride;
 } Texture5Impl;

--- a/Backends/Graphics5/Vulkan/Sources/Kore/Texture5Impl.h
+++ b/Backends/Graphics5/Vulkan/Sources/Kore/Texture5Impl.h
@@ -35,7 +35,5 @@ typedef struct {
 	struct texture_object texture;
 	VkDeviceSize deviceSize;
 
-	VkDescriptorSet desc_set;
-
 	uint8_t *conversionBuffer;
 } Texture5Impl;

--- a/Backends/Graphics5/Vulkan/Sources/Kore/VertexBuffer5Impl.cpp
+++ b/Backends/Graphics5/Vulkan/Sources/Kore/VertexBuffer5Impl.cpp
@@ -88,8 +88,6 @@ void kinc_g5_vertex_buffer_init(kinc_g5_vertex_buffer_t *buffer, int vertexCount
 
 	err = vkBindBufferMemory(device, buffer->impl.vertices.buf, buffer->impl.vertices.mem, 0);
 	assert(!err);
-
-	// createVertexInfo(structure, vertices.info);
 }
 
 static void unset(kinc_g5_vertex_buffer_t *buffer) {
@@ -126,10 +124,6 @@ static int setVertexAttributes(int offset) {
 
 int kinc_g5_internal_vertex_buffer_set(kinc_g5_vertex_buffer_t *buffer, int offset) {
 	int offsetoffset = setVertexAttributes(offset);
-	//if (currentIndexBuffer != NULL) {
-	//	IndexBuffer::current->_set();
-	//}
-
 	return offsetoffset;
 }
 

--- a/Backends/Graphics5/Vulkan/Sources/Kore/VertexBuffer5Impl.cpp
+++ b/Backends/Graphics5/Vulkan/Sources/Kore/VertexBuffer5Impl.cpp
@@ -44,6 +44,12 @@ void kinc_g5_vertex_buffer_init(kinc_g5_vertex_buffer_t *buffer, int vertexCount
 		case KINC_G4_VERTEX_DATA_FLOAT4X4:
 			buffer->impl.myStride += 4 * 4 * 4;
 			break;
+		case KINC_G4_VERTEX_DATA_SHORT2_NORM:
+			buffer->impl.myStride += 2 * 2;
+			break;
+		case KINC_G4_VERTEX_DATA_SHORT4_NORM:
+			buffer->impl.myStride += 4 * 2;
+			break;
 		}
 	}
 	buffer->impl.structure = *structure;

--- a/Backends/Graphics5/Vulkan/Sources/Kore/VertexBuffer5Impl.h
+++ b/Backends/Graphics5/Vulkan/Sources/Kore/VertexBuffer5Impl.h
@@ -22,7 +22,6 @@ struct Vertices {
 };
 
 typedef struct {
-//void unset();
 	float* data;
 	int myCount;
 	int myStride;
@@ -30,7 +29,5 @@ typedef struct {
 	kinc_g5_vertex_structure_t structure;
 	VkMemoryAllocateInfo mem_alloc;
 	int instanceDataStepRate;
-	//int setVertexAttributes(int offset);
 	struct Vertices vertices;
-	//static Graphics5::VertexBuffer* current;
 } VertexBuffer5Impl;

--- a/Backends/Graphics5/Vulkan/Sources/Kore/Vulkan.cpp
+++ b/Backends/Graphics5/Vulkan/Sources/Kore/Vulkan.cpp
@@ -64,13 +64,13 @@ VkDescriptorSet desc_set;
 VkPhysicalDevice gpu;
 VkCommandPool cmd_pool;
 VkQueue queue;
-bool use_staging_buffer;
-VkDescriptorPool desc_pool;
+bool use_staging_buffer = false;
 uint32_t swapchainImageCount;
 VkFramebuffer *framebuffers;
 PFN_vkQueuePresentKHR fpQueuePresentKHR;
 PFN_vkAcquireNextImageKHR fpAcquireNextImageKHR;
 VkSemaphore presentCompleteSemaphore;
+void createDescriptorLayout();
 
 #ifndef NDEBUG
 #define VALIDATE
@@ -932,6 +932,8 @@ void kinc_g5_init(int window, int depthBufferBits, int stencilBufferBits, bool v
 
 	Kore::Vulkan::demo_flush_init_cmd();
 
+	createDescriptorLayout();
+
 	began = false;
 	kinc_g5_begin(nullptr, 0);
 }
@@ -987,8 +989,6 @@ void kinc_g5_end(int window) {
 void kinc_g5_set_texture(kinc_g5_texture_unit_t unit, kinc_g5_texture_t *texture) {
 	vulkanTextures[unit.impl.binding - 2] = texture;
 	vulkanRenderTargets[unit.impl.binding - 2] = nullptr;
-	//** if (PipelineState5Impl::current != nullptr)
-	//**	vkCmdBindDescriptorSets(draw_cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, PipelineState5Impl::current->pipeline_layout, 0, 1, &texture->desc_set, 0, NULL);
 }
 
 void kinc_g5_set_image_texture(kinc_g5_texture_unit_t unit, kinc_g5_texture_t *texture) {}
@@ -1011,56 +1011,8 @@ int kinc_g5_max_bound_textures(void) {
 	return props.limits.maxPerStageDescriptorSamplers;
 }
 
-/*void Graphics5::restoreRenderTarget() {
-    if (onBackBuffer) return;
-
-    endPass();
-
-    currentRenderTarget = nullptr;
-    onBackBuffer = true;
-
-    VkClearValue clear_values[2];
-    memset(clear_values, 0, sizeof(VkClearValue) * 2);
-    clear_values[0].color.float32[0] = 0.0f;
-    clear_values[0].color.float32[1] = 0.0f;
-    clear_values[0].color.float32[2] = 0.0f;
-    clear_values[0].color.float32[3] = 1.0f;
-    clear_values[1].depthStencil.depth = depthStencil;
-    clear_values[1].depthStencil.stencil = 0;
-
-    VkRenderPassBeginInfo rp_begin = {};
-    rp_begin.sType = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO;
-    rp_begin.pNext = nullptr;
-    rp_begin.renderPass = render_pass;
-    rp_begin.framebuffer = framebuffers[current_buffer];
-    rp_begin.renderArea.offset.x = 0;
-    rp_begin.renderArea.offset.y = 0;
-    rp_begin.renderArea.extent.width = renderTargetWidth;
-    rp_begin.renderArea.extent.height = renderTargetHeight;
-    rp_begin.clearValueCount = 2;
-    rp_begin.pClearValues = clear_values;
-
-    vkCmdBeginRenderPass(draw_cmd, &rp_begin, VK_SUBPASS_CONTENTS_INLINE);
-
-    VkViewport viewport;
-    memset(&viewport, 0, sizeof(viewport));
-    viewport.width = (float)renderTargetWidth;
-    viewport.height = (float)renderTargetHeight;
-    viewport.minDepth = (float)0.0f;
-    viewport.maxDepth = (float)1.0f;
-    vkCmdSetViewport(draw_cmd, 0, 1, &viewport);
-
-    VkRect2D scissor;
-    memset(&scissor, 0, sizeof(scissor));
-    scissor.extent.width = renderTargetWidth;
-    scissor.extent.height = renderTargetHeight;
-    scissor.offset.x = 0;
-    scissor.offset.y = 0;
-    vkCmdSetScissor(draw_cmd, 0, 1, &scissor);
-}*/
-
 bool kinc_g5_render_targets_inverted_y() {
-	return true;
+	return false;
 }
 
 bool kinc_g5_non_pow2_textures_qupported() {

--- a/Backends/Graphics5/Vulkan/Sources/Kore/Vulkan.cpp
+++ b/Backends/Graphics5/Vulkan/Sources/Kore/Vulkan.cpp
@@ -514,7 +514,8 @@ void create_swapchain() {
 }
 
 void kinc_g5_init(int window, int depthBufferBits, int stencilBufferBits, bool vsync) {
-	depthBits = depthBufferBits;
+	// depthBits = depthBufferBits;
+	depthBits = 0;
 	stencilBits = stencilBufferBits;
 	uint32_t instance_extension_count = 0;
 	uint32_t instance_layer_count = 0;

--- a/Backends/Graphics5/Vulkan/Sources/Kore/Vulkan.cpp
+++ b/Backends/Graphics5/Vulkan/Sources/Kore/Vulkan.cpp
@@ -80,6 +80,7 @@ VkSwapchainKHR swapchain;
 uint32_t current_buffer;
 int depthBits;
 int stencilBits;
+bool vsynced;
 
 kinc_g5_texture_t *vulkanTextures[8] = {nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr};
 kinc_g5_render_target_t *vulkanRenderTargets[8] = {nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr};
@@ -261,7 +262,7 @@ void create_swapchain() {
 		renderTargetHeight = surfCapabilities.currentExtent.height;
 	}
 
-	VkPresentModeKHR swapchainPresentMode = VK_PRESENT_MODE_FIFO_KHR;
+	VkPresentModeKHR swapchainPresentMode = vsynced ? VK_PRESENT_MODE_FIFO_KHR : VK_PRESENT_MODE_MAILBOX_KHR;
 
 	// Determine the number of VkImage's to use in the swap chain (we desire to
 	// own only 1 image at a time, besides the images being displayed and
@@ -517,6 +518,7 @@ void kinc_g5_init(int window, int depthBufferBits, int stencilBufferBits, bool v
 	// depthBits = depthBufferBits;
 	depthBits = 0;
 	stencilBits = stencilBufferBits;
+	vsynced = vsync;
 	uint32_t instance_extension_count = 0;
 	uint32_t instance_layer_count = 0;
 #ifdef VALIDATE

--- a/Backends/Graphics5/Vulkan/Sources/Kore/Vulkan.cpp
+++ b/Backends/Graphics5/Vulkan/Sources/Kore/Vulkan.cpp
@@ -430,7 +430,7 @@ void create_swapchain() {
 	VkAttachmentDescription attachments[2];
 	attachments[0].format = format;
 	attachments[0].samples = VK_SAMPLE_COUNT_1_BIT;
-	attachments[0].loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
+	attachments[0].loadOp = VK_ATTACHMENT_LOAD_OP_LOAD;
 	attachments[0].storeOp = VK_ATTACHMENT_STORE_OP_STORE;
 	attachments[0].stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
 	attachments[0].stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
@@ -440,7 +440,7 @@ void create_swapchain() {
 
 	attachments[1].format = depth_format;
 	attachments[1].samples = VK_SAMPLE_COUNT_1_BIT;
-	attachments[1].loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
+	attachments[1].loadOp = VK_ATTACHMENT_LOAD_OP_LOAD;
 	attachments[1].storeOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
 	attachments[1].stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
 	attachments[1].stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
@@ -926,8 +926,6 @@ void kinc_g5_init(int window, int depthBufferBits, int stencilBufferBits, bool v
 	assert(!err);
 
 	create_swapchain();
-
-	demo_flush_init_cmd();
 
 	createDescriptorLayout();
 

--- a/Backends/Graphics5/Vulkan/Sources/Kore/Vulkan.cpp
+++ b/Backends/Graphics5/Vulkan/Sources/Kore/Vulkan.cpp
@@ -521,11 +521,11 @@ void kinc_g5_init(int window, int depthBufferBits, int stencilBufferBits, bool v
 	// demo->enabled_layer_count = 0;
 
 #ifdef VALIDATE
-	char *instance_validation_layers[] = {"VK_LAYER_LUNARG_standard_validation"};
+	char *instance_validation_layers[] = {"VK_LAYER_KHRONOS_validation"};
 #endif
 
 #ifdef VALIDATE
-	device_validation_layers[0] = "VK_LAYER_LUNARG_standard_validation";
+	device_validation_layers[0] = "VK_LAYER_KHRONOS_validation";
 	device_validation_layer_count = 1;
 #endif
 

--- a/Backends/Graphics5/Vulkan/Sources/Kore/Vulkan.cpp
+++ b/Backends/Graphics5/Vulkan/Sources/Kore/Vulkan.cpp
@@ -68,8 +68,7 @@ PFN_vkQueuePresentKHR fpQueuePresentKHR;
 PFN_vkAcquireNextImageKHR fpAcquireNextImageKHR;
 VkSemaphore presentCompleteSemaphore;
 void createDescriptorLayout();
-void demo_flush_init_cmd();
-void demo_set_image_layout(VkImage image, VkImageAspectFlags aspectMask, VkImageLayout old_image_layout, VkImageLayout new_image_layout);
+void set_image_layout(VkImage image, VkImageAspectFlags aspectMask, VkImageLayout old_image_layout, VkImageLayout new_image_layout);
 
 #ifndef NDEBUG
 #define VALIDATE
@@ -137,7 +136,7 @@ namespace {
 	bool quit;
 	uint32_t queue_count;
 
-	VkBool32 demo_check_layers(uint32_t check_count, char **check_names, uint32_t layer_count, VkLayerProperties *layers) {
+	VkBool32 check_layers(uint32_t check_count, char **check_names, uint32_t layer_count, VkLayerProperties *layers) {
 		for (uint32_t i = 0; i < check_count; ++i) {
 			VkBool32 found = 0;
 			for (uint32_t j = 0; j < layer_count; ++j) {
@@ -346,7 +345,7 @@ void create_swapchain() {
 		// VK_IMAGE_LAYOUT_PRESENT_SRC_KHR
 		// layout and will change to COLOR_ATTACHMENT_OPTIMAL, so init the image
 		// to that state
-		demo_set_image_layout(Kore::Vulkan::buffers[i].image, VK_IMAGE_ASPECT_COLOR_BIT, VK_IMAGE_LAYOUT_UNDEFINED,
+		set_image_layout(Kore::Vulkan::buffers[i].image, VK_IMAGE_ASPECT_COLOR_BIT, VK_IMAGE_LAYOUT_UNDEFINED,
 		                      VK_IMAGE_LAYOUT_PRESENT_SRC_KHR);
 
 		color_attachment_view.image = Kore::Vulkan::buffers[i].image;
@@ -419,7 +418,7 @@ void create_swapchain() {
 	err = vkBindImageMemory(device, Kore::Vulkan::depth.image, Kore::Vulkan::depth.mem, 0);
 	assert(!err);
 
-	demo_set_image_layout(Kore::Vulkan::depth.image, VK_IMAGE_ASPECT_DEPTH_BIT, VK_IMAGE_LAYOUT_UNDEFINED,
+	set_image_layout(Kore::Vulkan::depth.image, VK_IMAGE_ASPECT_DEPTH_BIT, VK_IMAGE_LAYOUT_UNDEFINED,
 	                      VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL);
 
 	/* create image view */
@@ -514,8 +513,6 @@ void kinc_g5_init(int window, int depthBufferBits, int stencilBufferBits, bool v
 #ifdef VALIDATE
 	uint32_t device_validation_layer_count = 0;
 #endif
-	// demo->enabled_extension_count = 0;
-	// demo->enabled_layer_count = 0;
 
 #ifdef VALIDATE
 	char *instance_validation_layers[] = {"VK_LAYER_KHRONOS_validation"};
@@ -536,7 +533,7 @@ void kinc_g5_init(int window, int depthBufferBits, int stencilBufferBits, bool v
 		assert(!err);
 
 #ifdef VALIDATE
-		validation_found = demo_check_layers(ARRAY_SIZE(instance_validation_layers), instance_validation_layers, instance_layer_count, instance_layers);
+		validation_found = check_layers(ARRAY_SIZE(instance_validation_layers), instance_validation_layers, instance_layer_count, instance_layers);
 		enabled_layer_count = ARRAY_SIZE(instance_validation_layers);
 #endif
 		free(instance_layers);
@@ -690,7 +687,7 @@ void kinc_g5_init(int window, int depthBufferBits, int stencilBufferBits, bool v
 		assert(!err);
 
 #ifdef VALIDATE
-		validation_found = demo_check_layers(device_validation_layer_count, device_validation_layers, device_layer_count, device_layers);
+		validation_found = check_layers(device_validation_layer_count, device_validation_layers, device_layer_count, device_layers);
 		enabled_layer_count = device_validation_layer_count;
 #endif
 

--- a/Backends/Graphics5/Vulkan/Sources/Kore/Vulkan.cpp
+++ b/Backends/Graphics5/Vulkan/Sources/Kore/Vulkan.cpp
@@ -719,6 +719,10 @@ void kinc_g5_init(int window, int depthBufferBits, int stencilBufferBits, bool v
 				swapchainExtFound = 1;
 				extension_names[enabled_extension_count++] = VK_KHR_SWAPCHAIN_EXTENSION_NAME;
 			}
+			if (!strcmp(VK_KHR_MAINTENANCE1_EXTENSION_NAME, device_extensions[i].extensionName)) {
+				// Allows negative viewport height to flip viewport
+				extension_names[enabled_extension_count++] = VK_KHR_MAINTENANCE1_EXTENSION_NAME;
+			}
 			assert(enabled_extension_count < 64);
 		}
 

--- a/Backends/Graphics5/Vulkan/Sources/Kore/Vulkan.h
+++ b/Backends/Graphics5/Vulkan/Sources/Kore/Vulkan.h
@@ -31,6 +31,6 @@ namespace Kore {
 
 		void demo_set_image_layout(VkImage image, VkImageAspectFlags aspectMask, VkImageLayout old_image_layout, VkImageLayout new_image_layout);
 		void demo_flush_init_cmd();
-		void createDescriptorSet(struct PipelineState5Impl_s *pipeline, kinc_g5_texture_t *texture, kinc_g5_render_target_t *renderTarget, VkDescriptorSet &desc_set);
+		void createDescriptorSet(struct PipelineState5Impl_s *pipeline, VkDescriptorSet &desc_set);
 	}
 }

--- a/Backends/Graphics5/Vulkan/Sources/Kore/Vulkan.h
+++ b/Backends/Graphics5/Vulkan/Sources/Kore/Vulkan.h
@@ -5,8 +5,6 @@
 #include <kinc/graphics5/texture.h>
 #include <kinc/math/matrix.h>
 
-struct PipelineState5Impl_s;
-
 namespace Kore {
 	namespace Vulkan {
 		struct SwapchainBuffers {
@@ -28,9 +26,5 @@ namespace Kore {
 		// buffer hack
 		extern VkBuffer* vertexUniformBuffer;
 		extern VkBuffer* fragmentUniformBuffer;
-
-		void demo_set_image_layout(VkImage image, VkImageAspectFlags aspectMask, VkImageLayout old_image_layout, VkImageLayout new_image_layout);
-		void demo_flush_init_cmd();
-		void createDescriptorSet(struct PipelineState5Impl_s *pipeline, VkDescriptorSet &desc_set);
 	}
 }


### PR DESCRIPTION
With this patch, the following examples are all working for me:
https://github.com/Kha-Samples/BlocksFromHeaven
https://github.com/Kha-Samples/Texture
https://github.com/luboslenco/kha3d_examples
https://github.com/luboslenco/kha_mrt
https://github.com/armory3d/zui/tree/master/examples/Elements
https://github.com/armory3d/zui/tree/master/examples/Nodes

Only tested on Windows for now. Approaching the reign of G5. 🔨 

(related: https://github.com/Kode/krafix/pull/67, https://github.com/Kode/krafix/pull/68)