### PR TITLE
Metal is limited to 16 samplers

### DIFF
--- a/Backends/Graphics5/Metal/Sources/Kore/RenderTarget5Impl.mm
+++ b/Backends/Graphics5/Metal/Sources/Kore/RenderTarget5Impl.mm
@@ -150,11 +150,11 @@ void kinc_g5_set_render_target_descriptor(kinc_g5_render_target_t *renderTarget,
 void kinc_g5_render_target_use_color_as_texture(kinc_g5_render_target_t *target, kinc_g5_texture_unit_t unit) {
 	id<MTLRenderCommandEncoder> encoder = getMetalEncoder();
 	if (unit.impl.vertex) {
-		[encoder setVertexSamplerState:target->impl._sampler atIndex:unit.impl.index];
+		if (unit.impl.index < 16) [encoder setVertexSamplerState:target->impl._sampler atIndex:unit.impl.index];
 		[encoder setVertexTexture:target->impl._tex atIndex:unit.impl.index];
 	}
 	else {
-		[encoder setFragmentSamplerState:target->impl._sampler atIndex:unit.impl.index];
+		if (unit.impl.index < 16) [encoder setFragmentSamplerState:target->impl._sampler atIndex:unit.impl.index];
 		[encoder setFragmentTexture:target->impl._tex atIndex:unit.impl.index];
 	}
 }
@@ -162,11 +162,11 @@ void kinc_g5_render_target_use_color_as_texture(kinc_g5_render_target_t *target,
 void kinc_g5_render_target_use_depth_as_texture(kinc_g5_render_target_t *target, kinc_g5_texture_unit_t unit) {
 	id<MTLRenderCommandEncoder> encoder = getMetalEncoder();
 	if (unit.impl.vertex) {
-		[encoder setVertexSamplerState:target->impl._sampler atIndex:unit.impl.index];
+		if (unit.impl.index < 16) [encoder setVertexSamplerState:target->impl._sampler atIndex:unit.impl.index];
 		[encoder setVertexTexture:target->impl._depthTex atIndex:unit.impl.index];
 	}
 	else {
-		[encoder setFragmentSamplerState:target->impl._sampler atIndex:unit.impl.index];
+		if (unit.impl.index < 16) [encoder setFragmentSamplerState:target->impl._sampler atIndex:unit.impl.index];
 		[encoder setFragmentTexture:target->impl._depthTex atIndex:unit.impl.index];
 	}
 }

--- a/Backends/Graphics5/Metal/Sources/Kore/Texture5Impl.mm
+++ b/Backends/Graphics5/Metal/Sources/Kore/Texture5Impl.mm
@@ -164,7 +164,7 @@ void kinc_g5_internal_set_texture_descriptor(kinc_g5_texture_t *texture, kinc_g5
 
 void kinc_g5_internal_texture_set(kinc_g5_texture_t *texture, int unit) {
 	id<MTLRenderCommandEncoder> encoder = getMetalEncoder();
-	[encoder setFragmentSamplerState:texture->impl._sampler atIndex:unit];
+	if (unit < 16) [encoder setFragmentSamplerState:texture->impl._sampler atIndex:unit];
 	[encoder setFragmentTexture:texture->impl._tex atIndex:unit];
 }
 


### PR DESCRIPTION
Prevents a crash when setting a texture at slot 16 or higher.