### PR TITLE
Fix resize on Windows

### DIFF
--- a/Backends/System/Windows/Sources/Kore/System.cpp
+++ b/Backends/System/Windows/Sources/Kore/System.cpp
@@ -52,6 +52,7 @@
 
 extern "C" __declspec(dllexport) unsigned long NvOptimusEnablement = 0x00000001;
 extern "C" __declspec(dllexport) int AmdPowerXpressRequestHighPerformance = 1;
+extern "C" void kinc_internal_resize(int window, int width, int height);
 
 typedef BOOL(WINAPI *GetPointerInfoType)(UINT32 pointerId, POINTER_INFO *pointerInfo);
 static GetPointerInfoType MyGetPointerInfo = NULL;
@@ -290,6 +291,7 @@ extern "C" LRESULT WINAPI KoreWindowsMessageProcedure(HWND hWnd, UINT msg, WPARA
 		if (window >= 0) {
 			int width = LOWORD(lParam);
 			int height = HIWORD(lParam);
+			kinc_internal_resize(window, width, height);
 			kinc_internal_call_resize_callback(window, width, height);
 		}
 		break;


### PR DESCRIPTION
The call to `kinc_internal_resize` got removed at https://github.com/Kode/Kinc/commit/db12fc40670e176c92b6f6366ef0178c4d239222#diff-7b9d51fedb2577ba193d408dae677b2d.