### PR TITLE
KINC_G4_VERTEX_DATA_COLOR changed from uint to unorm.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /build
 /Tests/Empty/build
+*.o

--- a/Backends/Graphics4/Direct3D11/Sources/Kore/PipelineStateImpl.cpp
+++ b/Backends/Graphics4/Direct3D11/Sources/Kore/PipelineStateImpl.cpp
@@ -515,7 +515,7 @@ void kinc_g4_pipeline_compile(kinc_g4_pipeline *state) {
 				setVertexDesc(vertexDesc[i],
 				              getAttributeLocation(state->vertex_shader->impl.attributes, state->input_layout[stream]->elements[index].name, used), index,
 				              stream, state->input_layout[stream]->instanced);
-				vertexDesc[i].Format = DXGI_FORMAT_R8G8B8A8_UINT;
+				vertexDesc[i].Format = DXGI_FORMAT_R8G8B8A8_UNORM;
 				++i;
 				break;
 			case KINC_G4_VERTEX_DATA_FLOAT4X4:

--- a/Backends/Graphics4/OpenGL/Sources/Kore/TextureImpl.c
+++ b/Backends/Graphics4/OpenGL/Sources/Kore/TextureImpl.c
@@ -118,7 +118,7 @@ static int convertInternalFormat(kinc_image_format_t format) {
 // #ifdef GL_BGRA
 		// return GL_BGRA;
 // #else
-		return GL_RGBA8;
+		return GL_RGBA;
 // #endif
 #endif
 	case KINC_IMAGE_FORMAT_RGB24:


### PR DESCRIPTION
that transfroms color bytes to float in 0.0 to 1.0 range ready for shaders.
graphic 2 is not affected as it uses floats for color.