### PR TITLE
Added sample rate change support for Mac OS

### DIFF
--- a/Sources/Kore/Audio2/Audio.cpp
+++ b/Sources/Kore/Audio2/Audio.cpp
@@ -41,7 +41,7 @@ namespace {
 		}
 	}
 
-#ifdef KORE_IOS
+#if defined(KORE_IOS) || defined(KORE_MACOS)
 	void sample_rate_changed() {
 		Audio2::samplesPerSecond = kinc_a2_samples_per_second;
 	}
@@ -56,7 +56,7 @@ void Audio2::init() {
 	buffer.data = new u8[buffer.dataSize];
 	Audio2::samplesPerSecond = kinc_a2_samples_per_second;
 	kinc_a2_set_callback(audio);
-#ifdef KORE_IOS
+#if defined(KORE_IOS) || defined(KORE_MACOS)
 	kinc_a2_set_sample_rate_callback(sample_rate_changed);
 #endif
 }


### PR DESCRIPTION
I am not 100% sure this is the most elegant way to handle this, but it works. I tried looking at AudioObjectAddPropertyListener  (https://developer.apple.com/documentation/coreaudio/1422472-audioobjectaddpropertylistener?language=objc) but it requires more code. I imagine calling AudioObjectGetPropertyData isn't that heavy of a call, but it might be worth revisiting at some point?