### PR TITLE
[android-native] Added *KeyPress* events to some keys.

### DIFF
--- a/Backends/System/Android/Sources/Kore/System.cpp
+++ b/Backends/System/Android/Sources/Kore/System.cpp
@@ -239,55 +239,69 @@ namespace {
 				case AKEYCODE_STAR:
 				case AKEYCODE_NUMPAD_MULTIPLY:
 					kinc_internal_keyboard_trigger_key_down(KINC_KEY_MULTIPLY);
+					kinc_internal_keyboard_trigger_key_press('*');
 					return 1;
-				// case AKEYCODE_POUND:
-				//	Kore::Keyboard::the()->_keydown((Kore::KeyCode)'&', '&');
-				//	return 1;
+				case AKEYCODE_POUND:
+					kinc_internal_keyboard_trigger_key_down(KINC_KEY_HASH);
+					kinc_internal_keyboard_trigger_key_press('#');
+					return 1;
 				case AKEYCODE_COMMA:
 				case AKEYCODE_NUMPAD_COMMA:
 					kinc_internal_keyboard_trigger_key_down(KINC_KEY_COMMA);
+					kinc_internal_keyboard_trigger_key_press(',');
 					return 1;
 				case AKEYCODE_PERIOD:
 				case AKEYCODE_NUMPAD_DOT:
 					kinc_internal_keyboard_trigger_key_down(KINC_KEY_PERIOD);
+					kinc_internal_keyboard_trigger_key_press('.');
 					return 1;
 				case AKEYCODE_SPACE:
 					kinc_internal_keyboard_trigger_key_down(KINC_KEY_SPACE);
+					kinc_internal_keyboard_trigger_key_press(' ');
 					return 1;
 				case AKEYCODE_MINUS:
 				case AKEYCODE_NUMPAD_SUBTRACT:
 					kinc_internal_keyboard_trigger_key_down(KINC_KEY_HYPHEN_MINUS);
+					kinc_internal_keyboard_trigger_key_press('-');
 					return 1;
 				case AKEYCODE_EQUALS:
 				case AKEYCODE_NUMPAD_EQUALS:
 					kinc_internal_keyboard_trigger_key_down(KINC_KEY_EQUALS);
+					kinc_internal_keyboard_trigger_key_press('=');
 					return 1;
 				case AKEYCODE_LEFT_BRACKET:
 				case AKEYCODE_NUMPAD_LEFT_PAREN:
 					kinc_internal_keyboard_trigger_key_down(KINC_KEY_OPEN_BRACKET);
+					kinc_internal_keyboard_trigger_key_press('{');
 					return 1;
 				case AKEYCODE_RIGHT_BRACKET:
 				case AKEYCODE_NUMPAD_RIGHT_PAREN:
 					kinc_internal_keyboard_trigger_key_down(KINC_KEY_CLOSE_BRACKET);
+					kinc_internal_keyboard_trigger_key_press('}');
 					return 1;
 				case AKEYCODE_BACKSLASH:
 					kinc_internal_keyboard_trigger_key_down(KINC_KEY_BACK_SLASH);
+					kinc_internal_keyboard_trigger_key_press('\\');
 					return 1;
 				case AKEYCODE_SEMICOLON:
 					kinc_internal_keyboard_trigger_key_down(KINC_KEY_SEMICOLON);
+					kinc_internal_keyboard_trigger_key_press(';');
 					return 1;
 				// case AKEYCODE_APOSTROPHE:
 				//	return 1;
 				case AKEYCODE_SLASH:
 				case AKEYCODE_NUMPAD_DIVIDE:
 					kinc_internal_keyboard_trigger_key_down(KINC_KEY_SLASH);
+					kinc_internal_keyboard_trigger_key_press('/');
 					return 1;
 				case AKEYCODE_AT:
 					kinc_internal_keyboard_trigger_key_down(KINC_KEY_AT);
+					kinc_internal_keyboard_trigger_key_press('@');
 					return 1;
 				case AKEYCODE_PLUS:
 				case AKEYCODE_NUMPAD_ADD:
 					kinc_internal_keyboard_trigger_key_down(KINC_KEY_PLUS);
+					kinc_internal_keyboard_trigger_key_press('+');
 					return 1;
 				// (DK) Amazon FireTV remote/controller mappings
 				// (DK) TODO handle multiple pads (up to 4 possible)


### PR DESCRIPTION
There is still work to do to support keyboard input in Android, but this should improve the situation a little bit just by adding missing `kinc_internal_keyboard_trigger_key_press` to some keys (*\*#,.-={}\;/@+* and *space*).

@RobDangerous maybe too little improvement, but I wanted to commit this anyway, mainly to see if there is some problem or something I didn't understand properly — tested with a Kha app, now correctly getting those chars both with a physical (only on-screen keyboard) and an emulated device (with both on-screen and physical keyboard).