### PR TITLE
[android-native] Added support for more keys.

### DIFF
--- a/Backends/System/Android/Sources/Kore/System.cpp
+++ b/Backends/System/Android/Sources/Kore/System.cpp
@@ -28,7 +28,6 @@ namespace {
     const ASensor *accelerometerSensor = nullptr;
     const ASensor *gyroSensor = nullptr;
     ASensorEventQueue *sensorEventQueue = nullptr;
-    bool shift = false;
     // int screenRotation = 0;
 
     ndk_helper::GLContext *glContext = nullptr;
@@ -158,10 +157,82 @@ namespace {
 			int32_t code = AKeyEvent_getKeyCode(event);
 
 			if (AKeyEvent_getAction(event) == AKEY_EVENT_ACTION_DOWN) {
+				int shift = AKeyEvent_getMetaState(event) & AMETA_SHIFT_ON;
+				if (shift) {
+					switch (code) {
+					case AKEYCODE_1:
+						kinc_internal_keyboard_trigger_key_down(KINC_KEY_EXCLAMATION);
+						kinc_internal_keyboard_trigger_key_press('!');
+						return 1;
+					case AKEYCODE_4:
+						kinc_internal_keyboard_trigger_key_down(KINC_KEY_DOLLAR);
+						kinc_internal_keyboard_trigger_key_press('$');
+						return 1;
+					case AKEYCODE_5:
+						kinc_internal_keyboard_trigger_key_down(KINC_KEY_PERCENT);
+						kinc_internal_keyboard_trigger_key_press('%');
+						return 1;
+					case AKEYCODE_6:
+						kinc_internal_keyboard_trigger_key_down(KINC_KEY_CIRCUMFLEX);
+						kinc_internal_keyboard_trigger_key_press('^');
+						return 1;
+					case AKEYCODE_7:
+						kinc_internal_keyboard_trigger_key_down(KINC_KEY_AMPERSAND);
+						kinc_internal_keyboard_trigger_key_press('&');
+						return 1;
+					case AKEYCODE_9:
+						kinc_internal_keyboard_trigger_key_down(KINC_KEY_OPEN_PAREN);
+						kinc_internal_keyboard_trigger_key_press('(');
+						return 1;
+					case AKEYCODE_0:
+						kinc_internal_keyboard_trigger_key_down(KINC_KEY_CLOSE_PAREN);
+						kinc_internal_keyboard_trigger_key_press(')');
+						return 1;
+					case AKEYCODE_COMMA:
+						kinc_internal_keyboard_trigger_key_down(KINC_KEY_LESS_THAN);
+						kinc_internal_keyboard_trigger_key_press('<');
+						return 1;
+					case AKEYCODE_PERIOD:
+						kinc_internal_keyboard_trigger_key_down(KINC_KEY_GREATER_THAN);
+						kinc_internal_keyboard_trigger_key_press('>');
+						return 1;
+					case AKEYCODE_MINUS:
+						kinc_internal_keyboard_trigger_key_down(KINC_KEY_UNDERSCORE);
+						kinc_internal_keyboard_trigger_key_press('_');
+						return 1;
+					case AKEYCODE_SLASH:
+						kinc_internal_keyboard_trigger_key_down(KINC_KEY_QUESTIONMARK);
+						kinc_internal_keyboard_trigger_key_press('?');
+						return 1;
+					case AKEYCODE_BACKSLASH:
+						kinc_internal_keyboard_trigger_key_down(KINC_KEY_PIPE);
+						kinc_internal_keyboard_trigger_key_press('|');
+						return 1;
+					case AKEYCODE_LEFT_BRACKET:
+						kinc_internal_keyboard_trigger_key_down(KINC_KEY_OPEN_CURLY_BRACKET);
+						kinc_internal_keyboard_trigger_key_press('{');
+						return 1;
+					case AKEYCODE_RIGHT_BRACKET:
+						kinc_internal_keyboard_trigger_key_down(KINC_KEY_CLOSE_CURLY_BRACKET);
+						kinc_internal_keyboard_trigger_key_press('}');
+						return 1;
+					case AKEYCODE_SEMICOLON:
+						kinc_internal_keyboard_trigger_key_down(KINC_KEY_COLON);
+						kinc_internal_keyboard_trigger_key_press(':');
+						return 1;
+					case AKEYCODE_APOSTROPHE:
+						kinc_internal_keyboard_trigger_key_down(KINC_KEY_DOUBLE_QUOTE);
+						kinc_internal_keyboard_trigger_key_press('"');
+						return 1;
+					case AKEYCODE_GRAVE:
+						kinc_internal_keyboard_trigger_key_down(KINC_KEY_TILDE);
+						kinc_internal_keyboard_trigger_key_press('~');
+						return 1;
+					}
+				}
 				switch (code) {
 				case AKEYCODE_SHIFT_LEFT:
 				case AKEYCODE_SHIFT_RIGHT:
-					shift = true;
 					kinc_internal_keyboard_trigger_key_down(KINC_KEY_SHIFT);
 					return 1;
 				case AKEYCODE_DEL:
@@ -272,12 +343,12 @@ namespace {
 				case AKEYCODE_LEFT_BRACKET:
 				case AKEYCODE_NUMPAD_LEFT_PAREN:
 					kinc_internal_keyboard_trigger_key_down(KINC_KEY_OPEN_BRACKET);
-					kinc_internal_keyboard_trigger_key_press('{');
+					kinc_internal_keyboard_trigger_key_press('[');
 					return 1;
 				case AKEYCODE_RIGHT_BRACKET:
 				case AKEYCODE_NUMPAD_RIGHT_PAREN:
 					kinc_internal_keyboard_trigger_key_down(KINC_KEY_CLOSE_BRACKET);
-					kinc_internal_keyboard_trigger_key_press('}');
+					kinc_internal_keyboard_trigger_key_press(']');
 					return 1;
 				case AKEYCODE_BACKSLASH:
 					kinc_internal_keyboard_trigger_key_down(KINC_KEY_BACK_SLASH);
@@ -287,8 +358,14 @@ namespace {
 					kinc_internal_keyboard_trigger_key_down(KINC_KEY_SEMICOLON);
 					kinc_internal_keyboard_trigger_key_press(';');
 					return 1;
-				// case AKEYCODE_APOSTROPHE:
-				//	return 1;
+				case AKEYCODE_APOSTROPHE:
+					kinc_internal_keyboard_trigger_key_down(KINC_KEY_QUOTE);
+					kinc_internal_keyboard_trigger_key_press('\'');
+					return 1;
+				case AKEYCODE_GRAVE:
+					kinc_internal_keyboard_trigger_key_down(KINC_KEY_BACK_QUOTE);
+					kinc_internal_keyboard_trigger_key_press('`');
+					return 1;
 				case AKEYCODE_SLASH:
 				case AKEYCODE_NUMPAD_DIVIDE:
 					kinc_internal_keyboard_trigger_key_down(KINC_KEY_SLASH);
@@ -337,10 +414,65 @@ namespace {
 				}
 			}
 			else if (AKeyEvent_getAction(event) == AKEY_EVENT_ACTION_UP) {
+				int shift = AKeyEvent_getMetaState(event) & AMETA_SHIFT_ON;
+				if (shift) {
+					switch (code) {
+					case AKEYCODE_1:
+						kinc_internal_keyboard_trigger_key_up(KINC_KEY_EXCLAMATION);
+						return 1;
+					case AKEYCODE_4:
+						kinc_internal_keyboard_trigger_key_up(KINC_KEY_DOLLAR);
+						return 1;
+					case AKEYCODE_5:
+						kinc_internal_keyboard_trigger_key_up(KINC_KEY_PERCENT);
+						return 1;
+					case AKEYCODE_6:
+						kinc_internal_keyboard_trigger_key_up(KINC_KEY_CIRCUMFLEX);
+						return 1;
+					case AKEYCODE_7:
+						kinc_internal_keyboard_trigger_key_up(KINC_KEY_AMPERSAND);
+						return 1;
+					case AKEYCODE_9:
+						kinc_internal_keyboard_trigger_key_up(KINC_KEY_OPEN_PAREN);
+						return 1;
+					case AKEYCODE_0:
+						kinc_internal_keyboard_trigger_key_up(KINC_KEY_CLOSE_PAREN);
+						return 1;
+					case AKEYCODE_COMMA:
+						kinc_internal_keyboard_trigger_key_up(KINC_KEY_LESS_THAN);
+						return 1;
+					case AKEYCODE_PERIOD:
+						kinc_internal_keyboard_trigger_key_up(KINC_KEY_GREATER_THAN);
+						return 1;
+					case AKEYCODE_MINUS:
+						kinc_internal_keyboard_trigger_key_up(KINC_KEY_UNDERSCORE);
+						return 1;
+					case AKEYCODE_SLASH:
+						kinc_internal_keyboard_trigger_key_up(KINC_KEY_QUESTIONMARK);
+						return 1;
+					case AKEYCODE_BACKSLASH:
+						kinc_internal_keyboard_trigger_key_up(KINC_KEY_PIPE);
+						return 1;
+					case AKEYCODE_LEFT_BRACKET:
+						kinc_internal_keyboard_trigger_key_up(KINC_KEY_OPEN_CURLY_BRACKET);
+						return 1;
+					case AKEYCODE_RIGHT_BRACKET:
+						kinc_internal_keyboard_trigger_key_up(KINC_KEY_CLOSE_CURLY_BRACKET);
+						return 1;
+					case AKEYCODE_SEMICOLON:
+						kinc_internal_keyboard_trigger_key_up(KINC_KEY_COLON);
+						return 1;
+					case AKEYCODE_APOSTROPHE:
+						kinc_internal_keyboard_trigger_key_up(KINC_KEY_DOUBLE_QUOTE);
+						return 1;
+					case AKEYCODE_GRAVE:
+						kinc_internal_keyboard_trigger_key_up(KINC_KEY_TILDE);
+						return 1;
+					}
+				}
 				switch (code) {
 				case AKEYCODE_SHIFT_LEFT:
 				case AKEYCODE_SHIFT_RIGHT:
-					shift = false;
 					kinc_internal_keyboard_trigger_key_up(KINC_KEY_SHIFT);
 					return 1;
 				case AKEYCODE_DEL:
@@ -418,9 +550,9 @@ namespace {
 				case AKEYCODE_NUMPAD_MULTIPLY:
 					kinc_internal_keyboard_trigger_key_up(KINC_KEY_MULTIPLY);
 					return 1;
-				// case AKEYCODE_POUND:
-				//	Kore::Keyboard::the()->_keyup((Kore::KeyCode)'&', '&');
-				//	return 1;
+				case AKEYCODE_POUND:
+				  kinc_internal_keyboard_trigger_key_up(KINC_KEY_HASH);
+					return 1;
 				case AKEYCODE_COMMA:
 				case AKEYCODE_NUMPAD_COMMA:
 					kinc_internal_keyboard_trigger_key_up(KINC_KEY_COMMA);
@@ -454,9 +586,12 @@ namespace {
 				case AKEYCODE_SEMICOLON:
 					kinc_internal_keyboard_trigger_key_up(KINC_KEY_SEMICOLON);
 					return 1;
-				// case AKEYCODE_APOSTROPHE:
-				//	Kore::Keyboard::the()->_keyup((Kore::KeyCode)'\'', '\'');
-				//	return 1;
+				case AKEYCODE_APOSTROPHE:
+					kinc_internal_keyboard_trigger_key_up(KINC_KEY_QUOTE);
+					return 1;
+				case AKEYCODE_GRAVE:
+					kinc_internal_keyboard_trigger_key_up(KINC_KEY_BACK_QUOTE);
+					return 1;
 				case AKEYCODE_SLASH:
 				case AKEYCODE_NUMPAD_DIVIDE:
 					kinc_internal_keyboard_trigger_key_up(KINC_KEY_SLASH);


### PR DESCRIPTION
- Added support for *quote* and *back quote* (*regular* keys in Android
  but still missing).

- Added *keyUp* for *hash* key — I've added only *keyDown* and *keyPress*
  in commit 1b097af.

- Fixed wrong *keyPress* chars (were `{}` instead of `[]`) for *non-shift*
  Android left/right brackets — I've added them wrongly in 1b097af.

- Added support for *implicit shift* keys: upper case chars
  and `!$%^&()<>_?|{}:"~` — by the way, upper case chars
  wheren't working with *soft keyboard* because when you
  press e.g. *shift and A* Android sends *shift down*,
  *shift up*, *A down* and *A up* (but the last two will have
  a shift modifier flag).

There are still two problems I can see:

- Unicode.
- Something weird with backspace in both physical and software keyboard, moreover behaving in different ways — physical: key autorepeats forever; software: key only triggered sometimes, and it also cancels the *forever* autorepeat state of physical backspace previously pressed... maybe related to #383, but also, **some of this could be related to how I use Kha**... so I need to investigate more.

Also, there could be problems related to device configurations and... things — so testing would be appreciated for developers interested in Kha/Kore → Android.