### PR TITLE
Fix compilation on FreeBSD

### DIFF
--- a/Backends/System/Linux/Sources/kinc/backend/sound.cpp
+++ b/Backends/System/Linux/Sources/kinc/backend/sound.cpp
@@ -57,7 +57,10 @@ namespace {
 			case EINTR:
 			case EPIPE:
 			case ESPIPE:
-			case ESTRPIPE: {
+			#if !defined(__FreeBSD__)
+			case ESTRPIPE:
+			#endif
+			{
 				int recovered = snd_pcm_recover(playback_handle, errorCode, 1);
 
 				if (recovered != 0) {
@@ -105,7 +108,7 @@ namespace {
 			return nullptr;
 		}
 
-		uint rate = 44100;
+		unsigned int rate = 44100;
 		int dir = 0;
 		if ((err = snd_pcm_hw_params_set_rate_near(playback_handle, hw_params, &rate, &dir)) < 0) {
 			fprintf(stderr, "cannot set sample rate (%s)\n", snd_strerror(err));

--- a/Sources/kinc/audio1/stb_vorbis.c
+++ b/Sources/kinc/audio1/stb_vorbis.c
@@ -598,6 +598,13 @@ enum STBVorbisError
    #endif
 #endif
 
+#ifdef __FreeBSD__
+   #ifdef alloca
+   #undef alloca
+   #endif
+   #define alloca allocm
+#endif
+
 #if STB_VORBIS_MAX_CHANNELS > 256
 #error "Value of STB_VORBIS_MAX_CHANNELS outside of allowed range"
 #endif

--- a/kincfile.js
+++ b/kincfile.js
@@ -327,7 +327,7 @@ else if (platform === Platform.HTML5) {
 		throw new Error('Graphics API ' + graphics + ' is not available for HTML5.');
 	}
 }
-else if (platform === Platform.Linux) {
+else if (platform === Platform.Linux || platform === Platform.FreeBSD) {
 	project.addDefine('KORE_LINUX');
 	addBackend('System/Linux');
 	addBackend('System/POSIX');


### PR DESCRIPTION
sound.cpp:
- Under FreeBSD ESTRPIPE is defined identical to ESPIPE, thus ifdef
- uint -> unsigned int

stb_vorbis.c:
- Redefine alloca as allocm

kincfile.js:
- Treat FreeBSD like Linux