### PR TITLE
Handle Metal running on Apple silicon

### DIFF
--- a/Backends/Graphics5/Metal/Sources/kinc/backend/graphics5/commandlist.mm
+++ b/Backends/Graphics5/Metal/Sources/kinc/backend/graphics5/commandlist.mm
@@ -168,7 +168,7 @@ void kinc_g5_command_list_get_render_target_pixels(kinc_g5_command_list_t *list,
 		descriptor.arrayLength = 1;
 		descriptor.mipmapLevelCount = 1;
 		descriptor.usage = MTLTextureUsageUnknown;
-#ifdef KORE_IOS
+#ifdef __ARM_ARCH_ISA_A64
 		descriptor.resourceOptions = MTLResourceStorageModeShared;
 #else
 		descriptor.resourceOptions = MTLResourceStorageModeManaged;
@@ -181,7 +181,7 @@ void kinc_g5_command_list_get_render_target_pixels(kinc_g5_command_list_t *list,
 	id<MTLCommandBuffer> commandBuffer = [commandQueue commandBuffer];
 	id<MTLBlitCommandEncoder> commandEncoder = [commandBuffer blitCommandEncoder];
 	[commandEncoder copyFromTexture:render_target->impl._tex sourceSlice:0 sourceLevel:0 sourceOrigin:MTLOriginMake(0, 0, 0) sourceSize:MTLSizeMake(render_target->texWidth, render_target->texHeight, 1) toTexture:render_target->impl._texReadback destinationSlice:0 destinationLevel:0 destinationOrigin:MTLOriginMake(0, 0, 0)];
-#ifndef KORE_IOS
+#ifndef __ARM_ARCH_ISA_A64
 	[commandEncoder synchronizeResource:render_target->impl._texReadback];
 #endif
 	[commandEncoder endEncoding];
@@ -232,7 +232,7 @@ void kinc_g5_command_list_set_fragment_constant_buffer(kinc_g5_command_list_t *l
 }
 
 void kinc_g5_command_list_render_target_to_texture_barrier(kinc_g5_command_list_t *list, struct kinc_g5_render_target *renderTarget) {
-#ifndef KORE_IOS
+#ifndef __ARM_ARCH_ISA_A64
 	id<MTLRenderCommandEncoder> encoder = getMetalEncoder();
 	[encoder textureBarrier];
 #endif

--- a/Backends/Graphics5/Metal/Sources/kinc/backend/graphics5/indexbuffer.mm
+++ b/Backends/Graphics5/Metal/Sources/kinc/backend/graphics5/indexbuffer.mm
@@ -19,7 +19,7 @@ void kinc_g5_index_buffer_init(kinc_g5_index_buffer_t *buffer, int indexCount, b
 	buffer->impl.gpuMemory = gpuMemory;
 	id<MTLDevice> device = getMetalDevice();
 	MTLResourceOptions options = MTLCPUCacheModeWriteCombined;
-#ifdef KORE_IOS
+#ifdef __ARM_ARCH_ISA_A64
 	options |= MTLResourceStorageModeShared;
 #else
 	if (gpuMemory) {
@@ -43,7 +43,7 @@ int *kinc_g5_index_buffer_lock(kinc_g5_index_buffer_t *buf) {
 }
 
 void kinc_g5_index_buffer_unlock(kinc_g5_index_buffer_t *buf) {
-#ifndef KORE_IOS
+#ifndef __ARM_ARCH_ISA_A64
 	if (buf->impl.gpuMemory) {
 		id<MTLBuffer> buffer = buf->impl.mtlBuffer;
 		NSRange range;

--- a/Backends/Graphics5/Metal/Sources/kinc/backend/graphics5/vertexbuffer.mm
+++ b/Backends/Graphics5/Metal/Sources/kinc/backend/graphics5/vertexbuffer.mm
@@ -57,7 +57,7 @@ void kinc_g5_vertex_buffer_init(kinc_g5_vertex_buffer_t *buffer, int count, kinc
 
 	id<MTLDevice> device = getMetalDevice();
 	MTLResourceOptions options = MTLCPUCacheModeWriteCombined;
-#ifdef KORE_IOS
+#ifdef __ARM_ARCH_ISA_A64
 	options |= MTLResourceStorageModeShared;
 #else
 	if (gpuMemory) {
@@ -92,7 +92,7 @@ float *kinc_g5_vertex_buffer_lock(kinc_g5_vertex_buffer_t *buf, int start, int c
 }
 
 void kinc_g5_vertex_buffer_unlock_all(kinc_g5_vertex_buffer_t *buf) {
-#ifndef KORE_IOS
+#ifndef __ARM_ARCH_ISA_A64
 	if (buf->impl.gpuMemory) {
 		id<MTLBuffer> buffer = buf->impl.mtlBuffer;
 		NSRange range;
@@ -104,7 +104,7 @@ void kinc_g5_vertex_buffer_unlock_all(kinc_g5_vertex_buffer_t *buf) {
 }
 
 void kinc_g5_vertex_buffer_unlock(kinc_g5_vertex_buffer_t *buf, int count) {
-#ifndef KORE_IOS
+#ifndef __ARM_ARCH_ISA_A64
 	if (buf->impl.gpuMemory) {
 		id<MTLBuffer> buffer = buf->impl.mtlBuffer;
 		NSRange range;


### PR DESCRIPTION
Gets rid of the exception thrown at https://github.com/Kode/Kinc/blob/master/Backends/Graphics5/Metal/Sources/kinc/backend/graphics5/commandlist.mm#L237.