### PR TITLE
Fix KINC_APPLE_SOC define for macOS

### DIFF
--- a/Backends/Graphics5/Metal/Sources/kinc/backend/graphics5/graphics.h
+++ b/Backends/Graphics5/Metal/Sources/kinc/backend/graphics5/graphics.h
@@ -5,6 +5,6 @@
 #include <kinc/backend/graphics5/texture.h>
 #include <kinc/backend/graphics5/vertexbuffer.h>
 
-#if defined(KORE_IOS) || defined(__arm__)
+#if defined(KORE_IOS) || defined(__arm64__)
 #define KINC_APPLE_SOC
 #endif


### PR DESCRIPTION
Apparently `__arm__` is 32-bit only.