### PR TITLE
Fix recent regressions

### DIFF
--- a/Backends/Graphics5/Direct3D12/Sources/kinc/backend/graphics5/commandlist.cpp
+++ b/Backends/Graphics5/Direct3D12/Sources/kinc/backend/graphics5/commandlist.cpp
@@ -84,9 +84,8 @@ namespace {
 		commandAllocator->Reset();
 		list->impl._commandList->Reset(commandAllocator, nullptr);
 		if (currentRenderTarget != nullptr) {
-			D3D12_CPU_DESCRIPTOR_HANDLE heapStart = currentRenderTarget->impl.depthStencilDescriptorHeap->GetCPUDescriptorHandleForHeapStart();
-			list->impl._commandList->OMSetRenderTargets(currentRenderTargetCount, &targetDescriptors[0], false,
-			                                            currentRenderTarget->impl.depthStencilDescriptorHeap != nullptr ? &heapStart : nullptr);
+			D3D12_CPU_DESCRIPTOR_HANDLE *heapStart = currentRenderTarget->impl.depthStencilDescriptorHeap != nullptr ? &currentRenderTarget->impl.depthStencilDescriptorHeap->GetCPUDescriptorHandleForHeapStart() : nullptr;
+			list->impl._commandList->OMSetRenderTargets(currentRenderTargetCount, &targetDescriptors[0], false, heapStart);
 			list->impl._commandList->RSSetViewports(1, (D3D12_VIEWPORT *)&currentRenderTarget->impl.viewport);
 			list->impl._commandList->RSSetScissorRects(1, (D3D12_RECT *)&currentRenderTarget->impl.scissor);
 		}

--- a/Backends/Graphics5/Direct3D12/Sources/kinc/backend/graphics5/constantbuffer.cpp
+++ b/Backends/Graphics5/Direct3D12/Sources/kinc/backend/graphics5/constantbuffer.cpp
@@ -5,8 +5,8 @@
 #include <kinc/backend/SystemMicrosoft.h>
 #include <kinc/backend/graphics5/Direct3D12.h>
 
-bool kinc_g5_transposeMat3 = true;
-bool kinc_g5_transposeMat4 = true;
+bool kinc_g5_transposeMat3 = false;
+bool kinc_g5_transposeMat4 = false;
 
 void kinc_g5_constant_buffer_init(kinc_g5_constant_buffer_t *buffer, int size) {
 	buffer->impl.mySize = size;

--- a/Backends/Graphics5/Metal/Sources/kinc/backend/graphics5/constantbuffer.mm
+++ b/Backends/Graphics5/Metal/Sources/kinc/backend/graphics5/constantbuffer.mm
@@ -6,8 +6,8 @@
 
 id getMetalDevice();
 
-bool kinc_g5_transposeMat3 = false;
-bool kinc_g5_transposeMat4 = false;
+bool kinc_g5_transposeMat3 = true;
+bool kinc_g5_transposeMat4 = true;
 
 void kinc_g5_constant_buffer_init(kinc_g5_constant_buffer_t *buffer, int size) {
 	buffer->impl.mySize = size;
@@ -29,7 +29,7 @@ void kinc_g5_constant_buffer_lock(kinc_g5_constant_buffer_t *buffer, int start, 
 }
 
 void kinc_g5_constant_buffer_unlock(kinc_g5_constant_buffer_t *buffer) {
-	
+
 	buffer->data = nullptr;
 }
 

--- a/Backends/Graphics5/Vulkan/Sources/kinc/backend/graphics5/constantbuffer.cpp
+++ b/Backends/Graphics5/Vulkan/Sources/kinc/backend/graphics5/constantbuffer.cpp
@@ -13,8 +13,8 @@ bool memory_type_from_properties(uint32_t typeBits, VkFlags requirements_mask, u
 VkBuffer *Kore::Vulkan::vertexUniformBuffer = nullptr;
 VkBuffer *Kore::Vulkan::fragmentUniformBuffer = nullptr;
 
-bool kinc_g5_transposeMat3 = false;
-bool kinc_g5_transposeMat4 = false;
+bool kinc_g5_transposeMat3 = true;
+bool kinc_g5_transposeMat4 = true;
 
 namespace {
 	void createUniformBuffer(VkBuffer& buf, VkMemoryAllocateInfo& mem_alloc, VkDeviceMemory& mem, VkDescriptorBufferInfo& buffer_info, int size) {


### PR DESCRIPTION
- Prevents crash after https://github.com/Kode/Kinc/commit/8ff48cfafcef89c080edcf78d8d211e9c0c57c3b when `currentRenderTarget->impl.depthStencilDescriptorHeap` was null in  `D3D12_CPU_DESCRIPTOR_HANDLE heapStart = currentRenderTarget->impl.depthStencilDescriptorHeap->GetCPUDescriptorHandleForHeapStart();`.

- Fixes matrix layout for G5 after https://github.com/Kode/Kinc/commit/a8879841059a3005930676b241ee4cd38438567a.