### PR TITLE
Handle utf8 paths for filewriter correctly on Windows

### DIFF
--- a/Sources/kinc/io/filewriter.c
+++ b/Sources/kinc/io/filewriter.c
@@ -11,6 +11,11 @@
 #include <stdio.h>
 #include <string.h>
 
+#if defined(KORE_WINDOWS)
+#define NOMINMAX
+#include <Windows.h>
+#endif
+
 #if defined(KORE_PS4) || defined(KORE_SWITCH)
 #define MOUNT_SAVES
 bool mountSaveData(bool);
@@ -29,7 +34,14 @@ bool kinc_file_writer_open(kinc_file_writer_t *writer, const char *filepath) {
 	char path[1001];
 	strcpy(path, kinc_internal_save_path());
 	strcat(path, filepath);
+
+#ifdef KORE_WINDOWS
+	wchar_t wpath[MAX_PATH];
+	MultiByteToWideChar(CP_UTF8, 0, path, -1, wpath, MAX_PATH);
+	writer->file = _wfopen(wpath, L"wb");
+#else
 	writer->file = fopen(path, "wb");
+#endif
 	if (writer->file == NULL) {
 		kinc_log(KINC_LOG_LEVEL_WARNING, "Could not open file %s.", filepath);
 		return false;


### PR DESCRIPTION
Kinc could not open utf8 paths correctly for file writing on windows. 