### PR TITLE
Consistently provide struct tags in non-internal/non-impl typedefs.

### DIFF
--- a/Sources/kinc/audio1/audio.h
+++ b/Sources/kinc/audio1/audio.h
@@ -18,7 +18,7 @@ extern "C" {
 
 struct kinc_internal_video_sound_stream;
 
-typedef struct {
+typedef struct kinc_a1_channel {
 	kinc_a1_sound_t *sound;
 	float position;
 	bool loop;
@@ -26,12 +26,12 @@ typedef struct {
 	float pitch;
 } kinc_a1_channel_t;
 
-typedef struct {
+typedef struct kinc_a1_stream_channel {
 	kinc_a1_sound_stream_t *stream;
 	int position;
 } kinc_a1_stream_channel_t;
 
-typedef struct {
+typedef struct kinc_internal_video_channel {
 	struct kinc_internal_video_sound_stream *stream;
 	int position;
 } kinc_internal_video_channel_t;

--- a/Sources/kinc/audio1/sound.h
+++ b/Sources/kinc/audio1/sound.h
@@ -14,7 +14,7 @@
 extern "C" {
 #endif
 
-typedef struct {
+typedef struct kinc_a1_sound {
 	kinc_a2_buffer_format_t format;
 	int16_t *left;
 	int16_t *right;

--- a/Sources/kinc/audio1/soundstream.h
+++ b/Sources/kinc/audio1/soundstream.h
@@ -15,7 +15,7 @@ extern "C" {
 
 struct stb_vorbis;
 
-typedef struct {
+typedef struct kinc_a1_sound_stream {
 	struct stb_vorbis *vorbis;
 	int chans;
 	int rate;

--- a/Sources/kinc/audio2/audio.h
+++ b/Sources/kinc/audio2/audio.h
@@ -12,13 +12,13 @@
 extern "C" {
 #endif
 
-typedef struct {
+typedef struct kinc_a2_buffer_format {
 	int channels;
 	int samples_per_second;
 	int bits_per_sample;
 } kinc_a2_buffer_format_t;
 
-typedef struct {
+typedef struct kinc_a2_buffer {
 	kinc_a2_buffer_format_t format;
 	uint8_t *data;
 	int data_size;

--- a/Sources/kinc/display.h
+++ b/Sources/kinc/display.h
@@ -12,7 +12,7 @@
 extern "C" {
 #endif
 
-typedef struct {
+typedef struct kinc_display_mode {
 	int x;
 	int y;
 	int width;

--- a/Sources/kinc/io/filereader.h
+++ b/Sources/kinc/io/filereader.h
@@ -28,7 +28,7 @@ typedef struct __sFILE FILE;
 #define KINC_FILE_TYPE_SAVE 1
 
 #ifdef KORE_ANDROID
-typedef struct {
+typedef struct kinc_file_reader {
 	int pos;
 	int size;
 	FILE *file;

--- a/Sources/kinc/io/filewriter.h
+++ b/Sources/kinc/io/filewriter.h
@@ -8,7 +8,7 @@
 extern "C" {
 #endif
 
-typedef struct {
+typedef struct kinc_file_writer {
 	void *file;
 	const char *filename;
 	bool mounted;

--- a/Sources/kinc/math/quaternion.h
+++ b/Sources/kinc/math/quaternion.h
@@ -10,7 +10,7 @@
 extern "C" {
 #endif
 
-typedef struct {
+typedef struct kinc_quaternion {
 	float x;
 	float y;
 	float z;

--- a/Sources/kinc/math/vector.h
+++ b/Sources/kinc/math/vector.h
@@ -10,18 +10,18 @@
 extern "C" {
 #endif
 
-typedef struct {
+typedef struct kinc_vector2 {
 	float x;
 	float y;
 } kinc_vector2_t;
 
-typedef struct {
+typedef struct kinc_vector3 {
 	float x;
 	float y;
 	float z;
 } kinc_vector3_t;
 
-typedef struct {
+typedef struct kinc_vector4 {
 	float x;
 	float y;
 	float z;

--- a/Sources/kinc/network/socket.h
+++ b/Sources/kinc/network/socket.h
@@ -24,7 +24,7 @@ typedef _W64 unsigned int UINT_PTR, *PUINT_PTR;
 typedef UINT_PTR SOCKET;
 #endif
 
-typedef struct {
+typedef struct kinc_socket {
 #ifdef KORE_MICROSOFT
 	SOCKET handle;
 #else

--- a/Sources/kinc/simd/float32x4.h
+++ b/Sources/kinc/simd/float32x4.h
@@ -140,7 +140,7 @@ inline kinc_float32x4_t kinc_float32x4_sqrt(kinc_float32x4_t t) {
 
 #include <kinc/math/core.h>
 
-typedef struct {
+typedef struct kinc_float32x4 {
 	float values[4];
 } kinc_float32x4_t;
 

--- a/Sources/kinc/threads/event.h
+++ b/Sources/kinc/threads/event.h
@@ -14,7 +14,7 @@
 extern "C" {
 #endif
 
-typedef struct {
+typedef struct kinc_event {
 	kinc_event_impl_t impl;
 } kinc_event_t;
 

--- a/Sources/kinc/threads/fiber.h
+++ b/Sources/kinc/threads/fiber.h
@@ -12,7 +12,7 @@
 extern "C" {
 #endif
 
-typedef struct {
+typedef struct kinc_fiber {
 	kinc_fiber_impl_t impl;
 } kinc_fiber_t;
 

--- a/Sources/kinc/threads/mutex.h
+++ b/Sources/kinc/threads/mutex.h
@@ -14,7 +14,7 @@
 extern "C" {
 #endif
 
-typedef struct {
+typedef struct kinc_mutex {
 	kinc_mutex_impl_t impl;
 } kinc_mutex_t;
 
@@ -50,7 +50,7 @@ KINC_FUNC bool kinc_mutex_try_to_lock(kinc_mutex_t *mutex);
 /// <param name="mutex">The mutex to unlock</param>
 KINC_FUNC void kinc_mutex_unlock(kinc_mutex_t *mutex);
 
-typedef struct {
+typedef struct kinc_uber_mutex {
 	kinc_uber_mutex_impl_t impl;
 } kinc_uber_mutex_t;
 

--- a/Sources/kinc/threads/semaphore.h
+++ b/Sources/kinc/threads/semaphore.h
@@ -14,7 +14,7 @@
 extern "C" {
 #endif
 
-typedef struct {
+typedef struct kinc_semaphore {
 	kinc_semaphore_impl_t impl;
 } kinc_semaphore_t;
 

--- a/Sources/kinc/threads/thread.h
+++ b/Sources/kinc/threads/thread.h
@@ -12,7 +12,7 @@
 extern "C" {
 #endif
 
-typedef struct {
+typedef struct kinc_thread {
 	kinc_thread_impl_t impl;
 } kinc_thread_t;
 

--- a/Sources/kinc/threads/threadlocal.h
+++ b/Sources/kinc/threads/threadlocal.h
@@ -12,7 +12,7 @@
 extern "C" {
 #endif
 
-typedef struct {
+typedef struct kinc_thread_local {
 	kinc_thread_local_impl_t impl;
 } kinc_thread_local_t;
 

--- a/Sources/kinc/video.h
+++ b/Sources/kinc/video.h
@@ -14,7 +14,7 @@
 extern "C" {
 #endif
 
-typedef struct {
+typedef struct kinc_video {
 	kinc_video_impl_t impl;
 } kinc_video_t;
 


### PR DESCRIPTION
While Kinc includes struct tags in many of its typedefs, it also had many typedef'd anonymous structs. This PR adds struct tags to typedef'd anonymous structs on the API side of Kinc. This is useful for some language FFIs.

The tags follow the form of the majority already provided in Kinc, modeled after the typedef name, sans the `_t` on the end.