### PR TITLE
Added support for basic multi-touch on Windows

### DIFF
--- a/Backends/System/Windows/Sources/kinc/backend/system.cpp
+++ b/Backends/System/Windows/Sources/kinc/backend/system.cpp
@@ -17,6 +17,7 @@
 #include <kinc/input/keyboard.h>
 #include <kinc/input/mouse.h>
 #include <kinc/input/pen.h>
+#include <kinc/input/surface.h>
 #include <kinc/log.h>
 #include <kinc/system.h>
 #include <kinc/threads/thread.h>
@@ -60,10 +61,53 @@ static GetPointerPenInfoType MyGetPointerPenInfo = NULL;
 typedef BOOL(WINAPI *EnableNonClientDpiScalingType)(HWND hwnd);
 static EnableNonClientDpiScalingType MyEnableNonClientDpiScaling = NULL;
 
+#define MAX_TOUCH_POINTS 10
+
+struct touchpoint {
+	int sysID;
+	int x;
+	int y;
+};
+
+static touchpoint touchPoints[MAX_TOUCH_POINTS];
 static int mouseX, mouseY;
 static bool keyPressed[256];
 int keyTranslated[256]; // http://msdn.microsoft.com/en-us/library/windows/desktop/dd375731(v=vs.85).aspx
 int cursor = 0;
+
+static int GetTouchIndex(int dwID) {	
+	for (int i=0; i < MAX_TOUCH_POINTS; i++) {
+		if (touchPoints[i].sysID == dwID) {
+			return i;
+		}
+	}
+	return -1;
+}
+
+static int GetAddTouchIndex(int dwID) {	
+	for (int i=0; i < MAX_TOUCH_POINTS; i++) {
+		if (touchPoints[i].sysID == dwID) {
+			return i;
+		}
+	}
+	for (int i=0; i < MAX_TOUCH_POINTS; i++) {
+		if (touchPoints[i].sysID == -1) {
+				touchPoints[i].sysID = dwID;
+				return i;
+		}
+	}	
+	return -1;
+}
+
+static void ReleaseTouchIndex(int dwID) {
+	for (int i=0; i < MAX_TOUCH_POINTS; i++) {
+		if (touchPoints[i].sysID == dwID) {
+			touchPoints[i].sysID = -1;
+			touchPoints[i].x = -1;
+			touchPoints[i].y = -1;
+		}
+	}
+}
 
 static void initKeyTranslation() {
 	for (int i = 0; i < 256; ++i) keyTranslated[i] = KINC_KEY_UNKNOWN;
@@ -310,6 +354,7 @@ extern "C" LRESULT WINAPI KoreWindowsMessageProcedure(HWND hWnd, UINT msg, WPARA
 			kinc_internal_background_callback();
 			altDown = false;
 		}
+		RegisterTouchWindow(hWnd, 0);
 		break;
 	case WM_MOUSELEAVE:
 		windowId = kinc_windows_window_index_from_hwnd(hWnd);
@@ -455,6 +500,62 @@ extern "C" LRESULT WINAPI KoreWindowsMessageProcedure(HWND hWnd, UINT msg, WPARA
 			ScreenToClient(hWnd, &pointerInfo.ptPixelLocation);
 			kinc_internal_pen_trigger_move(kinc_windows_window_index_from_hwnd(hWnd), pointerInfo.ptPixelLocation.x, pointerInfo.ptPixelLocation.y,
 			                               float(penInfo.pressure) / 1024.0f);
+		}
+		break;
+	case WM_TOUCH:
+		{
+			BOOL bHandled = FALSE;
+			UINT cInputs = LOWORD(wParam);
+			PTOUCHINPUT pInputs = new TOUCHINPUT[cInputs];
+			POINT ptInput;
+			int tindex;
+			if (pInputs) {
+				if (GetTouchInputInfo((HTOUCHINPUT)lParam, cInputs, pInputs, sizeof(TOUCHINPUT))) {
+					for (int i=0; i < static_cast<int>(cInputs); i++) {
+						TOUCHINPUT ti = pInputs[i];
+						if (ti.dwID != 0) {
+							ptInput.x = TOUCH_COORD_TO_PIXEL(ti.x);
+							ptInput.y = TOUCH_COORD_TO_PIXEL(ti.y);
+							ScreenToClient(hWnd, &ptInput);
+
+							if (ti.dwFlags & TOUCHEVENTF_UP) {
+								tindex = GetTouchIndex(ti.dwID);
+								ReleaseTouchIndex(ti.dwID);
+								kinc_internal_surface_trigger_touch_end(tindex,ptInput.x,ptInput.y);												
+							}
+							else {
+								bool touchExisits = GetTouchIndex(ti.dwID)!=-1;
+								tindex = GetAddTouchIndex(ti.dwID);
+								if (tindex>=0) {
+									if (touchExisits) {
+										if (touchPoints[tindex].x != ptInput.x || touchPoints[tindex].y != ptInput.y) {
+											touchPoints[tindex].x = ptInput.x;
+											touchPoints[tindex].y = ptInput.y;
+											kinc_internal_surface_trigger_move(tindex,ptInput.x,ptInput.y);												
+										}
+									}
+									else {
+										touchPoints[tindex].x = ptInput.x;
+										touchPoints[tindex].y = ptInput.y;
+										kinc_internal_surface_trigger_touch_start(tindex,ptInput.x,ptInput.y);												
+									}
+								}
+							}
+						}
+						bHandled = TRUE;
+
+						if (!CloseTouchInputHandle((HTOUCHINPUT)lParam)) {
+						}
+					}
+				}
+				delete [] pInputs;
+			}
+   			if (bHandled)
+        		CloseTouchInputHandle((HTOUCHINPUT)lParam);
+			else
+				DefWindowProc(hWnd, WM_TOUCH, wParam, lParam);
+		
+			InvalidateRect(hWnd, NULL, FALSE);
 		}
 		break;
 	case WM_KEYDOWN:
@@ -1230,6 +1331,12 @@ int kinc_init(const char *name, int width, int height, kinc_window_options_t *wi
 	MyEnableNonClientDpiScaling = (EnableNonClientDpiScalingType)GetProcAddress(user32, "EnableNonClientDpiScaling");
 	initKeyTranslation();
 	for (int i = 0; i < 256; ++i) keyPressed[i] = false;
+
+	for (int i=0; i < MAX_TOUCH_POINTS; i++) {
+		touchPoints[i].sysID = -1;
+		touchPoints[i].x = -1;
+		touchPoints[i].y = -1;
+   	}
 
 	kinc_display_init();
 


### PR DESCRIPTION
This adds basic support for multi-touch on Windows. Using point touch, not gestures - to work nicely with existing `kinc_internal_surface_trigger_touch_start` , `kinc_internal_surface_trigger_move` and  `kinc_internal_surface_trigger_touch_end` methods.