### PR TITLE
Make the webgpu backend compile again.

### DIFF
--- a/Backends/Graphics5/WebGPU/Sources/kinc/backend/graphics5/WebGPU.c
+++ b/Backends/Graphics5/WebGPU/Sources/kinc/backend/graphics5/WebGPU.c
@@ -41,7 +41,7 @@ void kinc_g5_init(int window, int depthBufferBits, int stencilBufferBits, bool v
 
 	WGPUSwapChainDescriptor scDesc;
 	memset(&scDesc, 0, sizeof(scDesc));
-	scDesc.usage = WGPUTextureUsage_OutputAttachment;
+	scDesc.usage = WGPUTextureUsage_RenderAttachment;
 	scDesc.format = WGPUTextureFormat_BGRA8Unorm;
 	scDesc.width = kinc_width();
 	scDesc.height = kinc_height();

--- a/Backends/Graphics5/WebGPU/Sources/kinc/backend/graphics5/constantbuffer.h
+++ b/Backends/Graphics5/WebGPU/Sources/kinc/backend/graphics5/constantbuffer.h
@@ -1,11 +1,13 @@
 #pragma once
 
+#include <webgpu/webgpu.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 typedef struct {
-
+    WGPUBuffer buffer;
 } ConstantBuffer5Impl;
 
 #ifdef __cplusplus

--- a/Backends/Graphics5/WebGPU/Sources/kinc/backend/graphics5/pipeline.h
+++ b/Backends/Graphics5/WebGPU/Sources/kinc/backend/graphics5/pipeline.h
@@ -11,7 +11,7 @@ typedef struct {
 } PipelineState5Impl;
 
 typedef struct {
-	int a;
+	WGPUComputePipeline pipeline;
 } ComputePipelineState5Impl;
 
 typedef struct {

--- a/Backends/Graphics5/WebGPU/Sources/kinc/backend/graphics5/rendertarget.h
+++ b/Backends/Graphics5/WebGPU/Sources/kinc/backend/graphics5/rendertarget.h
@@ -1,11 +1,13 @@
 #pragma once
 
+#include <webgpu/webgpu.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 typedef struct {
-
+    WGPUTexture texture;
 } RenderTarget5Impl;
 
 #ifdef __cplusplus

--- a/Backends/Graphics5/WebGPU/Sources/kinc/backend/graphics5/texture.h
+++ b/Backends/Graphics5/WebGPU/Sources/kinc/backend/graphics5/texture.h
@@ -1,13 +1,17 @@
 #pragma once
 
+#include <webgpu/webgpu.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 typedef struct {
+    int unused;
 } TextureUnit5Impl;
 
 typedef struct {
+    WGPUTexture texture;
 } Texture5Impl;
 
 #ifdef __cplusplus


### PR DESCRIPTION
Also locks the emscripten version for wgpu CI, so that it doesn't break every time the headers are updated.
