### PR TITLE
use custom code when KINC_VIDEO_GSTREAMER is defined

### DIFF
--- a/Backends/System/Linux/Sources/kinc/backend/video.c.h
+++ b/Backends/System/Linux/Sources/kinc/backend/video.c.h
@@ -1,10 +1,11 @@
 #include <kinc/video.h>
 
+#if !defined(KINC_VIDEO_GSTREAMER)
 void kinc_video_init(kinc_video_t *video, const char *filename) {}
 
 void kinc_video_destroy(kinc_video_t *video) {}
 
-void kinc_video_play(kinc_video_t *video) {}
+void kinc_video_play(kinc_video_t *video, bool loop) {}
 
 void kinc_video_pause(kinc_video_t *video) {}
 
@@ -53,3 +54,4 @@ float kinc_internal_video_sound_stream_next_sample(kinc_internal_video_sound_str
 bool kinc_internal_video_sound_stream_ended(kinc_internal_video_sound_stream_t *stream) {
 	return true;
 }
+#endif

--- a/Backends/System/Linux/Sources/kinc/backend/video.h
+++ b/Backends/System/Linux/Sources/kinc/backend/video.h
@@ -4,6 +4,9 @@
 extern "C" {
 #endif
 
+#if defined(KINC_VIDEO_GSTREAMER)
+#include <kinc/backend/video_gstreamer.h>
+#else
 typedef struct {
 	int nothing;
 } kinc_video_impl_t;
@@ -21,6 +24,7 @@ void kinc_internal_video_sound_stream_insert_data(kinc_internal_video_sound_stre
 float kinc_internal_video_sound_stream_next_sample(kinc_internal_video_sound_stream_t *stream);
 
 bool kinc_internal_video_sound_stream_ended(kinc_internal_video_sound_stream_t *stream);
+#endif
 
 #ifdef __cplusplus
 }

--- a/Sources/kinc/video.h
+++ b/Sources/kinc/video.h
@@ -37,7 +37,7 @@ KINC_FUNC void kinc_video_destroy(kinc_video_t *video);
 /// <summary>
 /// Starts playing a video.
 /// </summary>
-KINC_FUNC void kinc_video_play(kinc_video_t *video);
+KINC_FUNC void kinc_video_play(kinc_video_t *video, bool loop);
 
 /// <summary>
 /// Pauses a video.


### PR DESCRIPTION
Not sure how to best handle this, but here are my current changes to handle video support for linux native.

Actual implementation: https://github.com/sh-dave/kinc-video-gstreamer

Changes in kinc:

When KINC_VIDEO_GSTREAMER is defined, it will basically ignore the impl video types and stub implementation in kinc and include that from a file from my library instead.

I thought about just renaming the GSTREAMER to something like CUSTOM to make it slightly more generic, but dunno if that makes things better.

Any opinions?