### PR TITLE
Pass null instead of creating empty pipeline cache for Vulkan

### DIFF
--- a/Backends/Graphics5/Vulkan/Sources/kinc/backend/graphics5/pipeline.c.h
+++ b/Backends/Graphics5/Vulkan/Sources/kinc/backend/graphics5/pipeline.c.h
@@ -362,7 +362,6 @@ void kinc_g5_pipeline_compile(kinc_g5_pipeline_t *pipeline) {
 	assert(!err);
 
 	VkGraphicsPipelineCreateInfo pipeline_info = {0};
-	VkPipelineCacheCreateInfo pipelineCache_info = {0};
 
 	VkPipelineInputAssemblyStateCreateInfo ia = {0};
 	VkPipelineRasterizationStateCreateInfo rs = {0};
@@ -636,15 +635,9 @@ void kinc_g5_pipeline_compile(kinc_g5_pipeline_t *pipeline) {
 	pipeline_info.renderPass = render_pass;
 	pipeline_info.pDynamicState = &dynamicState;
 
-	memset(&pipelineCache_info, 0, sizeof(pipelineCache_info));
-	pipelineCache_info.sType = VK_STRUCTURE_TYPE_PIPELINE_CACHE_CREATE_INFO;
-
-	err = vkCreatePipelineCache(device, &pipelineCache_info, NULL, &pipeline->impl.pipelineCache);
-	assert(!err);
-	err = vkCreateGraphicsPipelines(device, pipeline->impl.pipelineCache, 1, &pipeline_info, NULL, &pipeline->impl.pipeline);
+	err = vkCreateGraphicsPipelines(device, VK_NULL_HANDLE, 1, &pipeline_info, NULL, &pipeline->impl.pipeline);
 	assert(!err);
 
-	vkDestroyPipelineCache(device, pipeline->impl.pipelineCache, NULL);
 	vkDestroyShaderModule(device, pipeline->impl.frag_shader_module, NULL);
 	vkDestroyShaderModule(device, pipeline->impl.vert_shader_module, NULL);
 }

--- a/Backends/Graphics5/Vulkan/Sources/kinc/backend/graphics5/pipeline.h
+++ b/Backends/Graphics5/Vulkan/Sources/kinc/backend/graphics5/pipeline.h
@@ -17,7 +17,6 @@ typedef struct PipelineState5Impl_s {
 	int textureCount;
 
 	VkPipeline pipeline;
-	VkPipelineCache pipelineCache;
 	VkShaderModule vert_shader_module;
 	VkShaderModule frag_shader_module;
 


### PR DESCRIPTION
I am getting a random crash at `vkCreatePipelineCache` after updating linux nvidia drivers to 495.44. Not sure if driver bug (works ok on windows) but we only create an empty cache, according to docs it is valid to pass `VK_NULL_HANDLE` in that case.

https://www.khronos.org/registry/vulkan/specs/1.2-extensions/man/html/vkCreateGraphicsPipelines.html#_parameters