### PR TITLE
Fix myStride not being initialized to 0 for vertex buffers in Metal

### DIFF
--- a/Backends/Graphics5/Metal/Sources/kinc/backend/graphics5/rendertarget.m.h
+++ b/Backends/Graphics5/Metal/Sources/kinc/backend/graphics5/rendertarget.m.h
@@ -28,6 +28,8 @@ static MTLPixelFormat convert_format(kinc_g5_render_target_format_t format) {
 
 void kinc_g5_render_target_init(kinc_g5_render_target_t *target, int width, int height, int depthBufferBits, bool antialiasing,
                                 kinc_g5_render_target_format_t format, int stencilBufferBits, int contextId) {
+	memset(target, 0, sizeof(kinc_g5_render_target_t));
+
 	target->texWidth = width;
 	target->texHeight = height;
 

--- a/Backends/Graphics5/Metal/Sources/kinc/backend/graphics5/vertexbuffer.m.h
+++ b/Backends/Graphics5/Metal/Sources/kinc/backend/graphics5/vertexbuffer.m.h
@@ -18,6 +18,7 @@ static void vertex_buffer_unset(kinc_g5_vertex_buffer_t *buffer) {
 }
 
 void kinc_g5_vertex_buffer_init(kinc_g5_vertex_buffer_t *buffer, int count, kinc_g5_vertex_structure_t *structure, bool gpuMemory, int instanceDataStepRate) {
+	memset(&buffer->impl, 0, sizeof(buffer->impl));
 	buffer->impl.myCount = count;
 	buffer->impl.gpuMemory = gpuMemory;
 	for (int i = 0; i < structure->size; ++i) {


### PR DESCRIPTION
Somehow this got removed.