### PR TITLE
Enable NEON on aarch64

### DIFF
--- a/Sources/kinc/simd/float32x4.h
+++ b/Sources/kinc/simd/float32x4.h
@@ -71,7 +71,7 @@ static inline kinc_float32x4_t kinc_float32x4_sqrt(kinc_float32x4_t t) {
 	return _mm_sqrt_ps(t);
 }
 
-#elif defined(KORE_IOS) || defined(KORE_SWITCH) || (defined(KORE_MACOS) && __arm64) || ((defined(KORE_LINUX) || defined(KORE_ANDROID)) && defined(__aarch64__))
+#elif defined(KORE_IOS) || defined(KORE_SWITCH) || defined(__aarch64__)) || defined(KORE_NEON)
 
 #include <arm_neon.h>
 
@@ -98,7 +98,7 @@ static inline kinc_float32x4_t kinc_float32x4_add(kinc_float32x4_t a, kinc_float
 }
 
 static inline kinc_float32x4_t kinc_float32x4_div(kinc_float32x4_t a, kinc_float32x4_t b) {
-#if defined(ARM64) || defined(KORE_SWITCH) || defined(__arm64) || defined(__aarch64__)
+#if defined(KORE_SWITCH) || defined(__aarch64__)
 	return vdivq_f32(a, b);
 #else
 	float32x4_t inv = vrecpeq_f32(b);
@@ -129,7 +129,7 @@ static inline kinc_float32x4_t kinc_float32x4_sub(kinc_float32x4_t a, kinc_float
 }
 
 static inline kinc_float32x4_t kinc_float32x4_sqrt(kinc_float32x4_t t) {
-#if defined(ARM64) || defined(KORE_SWITCH) || defined(__arm64) || defined(__aarch64__)
+#if defined(KORE_SWITCH) || defined(__aarch64__)
 	return vsqrtq_f32(t);
 #else
 	return vmulq_f32(t, vrsqrteq_f32(t));

--- a/Sources/kinc/simd/float32x4.h
+++ b/Sources/kinc/simd/float32x4.h
@@ -16,15 +16,15 @@ extern "C" {
 
 typedef __m128 kinc_float32x4_t;
 
-inline kinc_float32x4_t kinc_float32x4_load(float a, float b, float c, float d) {
+static inline kinc_float32x4_t kinc_float32x4_load(float a, float b, float c, float d) {
 	return _mm_set_ps(d, c, b, a);
 }
 
-inline kinc_float32x4_t kinc_float32x4_load_all(float t) {
+static inline kinc_float32x4_t kinc_float32x4_load_all(float t) {
 	return _mm_set_ps1(t);
 }
 
-inline float kinc_float32x4_get(kinc_float32x4_t t, int index) {
+static inline float kinc_float32x4_get(kinc_float32x4_t t, int index) {
 	union {
 		__m128 value;
 		float elements[4];
@@ -33,72 +33,72 @@ inline float kinc_float32x4_get(kinc_float32x4_t t, int index) {
 	return converter.elements[index];
 }
 
-inline kinc_float32x4_t kinc_float32x4_abs(kinc_float32x4_t t) {
+static inline kinc_float32x4_t kinc_float32x4_abs(kinc_float32x4_t t) {
 	__m128 mask = _mm_set_ps1(-0.f);
 	return _mm_andnot_ps(mask, t);
 }
 
-inline kinc_float32x4_t kinc_float32x4_add(kinc_float32x4_t a, kinc_float32x4_t b) {
+static inline kinc_float32x4_t kinc_float32x4_add(kinc_float32x4_t a, kinc_float32x4_t b) {
 	return _mm_add_ps(a, b);
 }
 
-inline kinc_float32x4_t kinc_float32x4_div(kinc_float32x4_t a, kinc_float32x4_t b) {
+static inline kinc_float32x4_t kinc_float32x4_div(kinc_float32x4_t a, kinc_float32x4_t b) {
 	return _mm_div_ps(a, b);
 }
 
-inline kinc_float32x4_t kinc_float32x4_mul(kinc_float32x4_t a, kinc_float32x4_t b) {
+static inline kinc_float32x4_t kinc_float32x4_mul(kinc_float32x4_t a, kinc_float32x4_t b) {
 	return _mm_mul_ps(a, b);
 }
 
-inline kinc_float32x4_t kinc_float32x4_neg(kinc_float32x4_t t) {
+static inline kinc_float32x4_t kinc_float32x4_neg(kinc_float32x4_t t) {
 	__m128 negative = _mm_set_ps1(-1.0f);
 	return _mm_mul_ps(t, negative);
 }
 
-inline kinc_float32x4_t kinc_float32x4_reciprocal_approximation(kinc_float32x4_t t) {
+static inline kinc_float32x4_t kinc_float32x4_reciprocal_approximation(kinc_float32x4_t t) {
 	return _mm_rcp_ps(t);
 }
 
-inline kinc_float32x4_t kinc_float32x4_reciprocal_sqrt_approximation(kinc_float32x4_t t) {
+static inline kinc_float32x4_t kinc_float32x4_reciprocal_sqrt_approximation(kinc_float32x4_t t) {
 	return _mm_rsqrt_ps(t);
 }
 
-inline kinc_float32x4_t kinc_float32x4_sub(kinc_float32x4_t a, kinc_float32x4_t b) {
+static inline kinc_float32x4_t kinc_float32x4_sub(kinc_float32x4_t a, kinc_float32x4_t b) {
 	return _mm_sub_ps(a, b);
 }
 
-inline kinc_float32x4_t kinc_float32x4_sqrt(kinc_float32x4_t t) {
+static inline kinc_float32x4_t kinc_float32x4_sqrt(kinc_float32x4_t t) {
 	return _mm_sqrt_ps(t);
 }
 
-#elif defined(KORE_IOS) || defined(KORE_SWITCH) || (defined(KORE_MACOS) && __arm64)
+#elif defined(KORE_IOS) || defined(KORE_SWITCH) || (defined(KORE_MACOS) && __arm64) || ((defined(KORE_LINUX) || defined(KORE_ANDROID)) && defined(__aarch64__))
 
 #include <arm_neon.h>
 
 typedef float32x4_t kinc_float32x4_t;
 
-inline kinc_float32x4_t kinc_float32x4_load(float a, float b, float c, float d) {
-	return {a, b, c, d};
+static inline kinc_float32x4_t kinc_float32x4_load(float a, float b, float c, float d) {
+	return (kinc_float32x4_t){a, b, c, d};
 }
 
-inline kinc_float32x4_t kinc_float32x4_load_all(float t) {
-	return {t, t, t, t};
+static inline kinc_float32x4_t kinc_float32x4_load_all(float t) {
+	return (kinc_float32x4_t){t, t, t, t};
 }
 
-inline float kinc_float32x4_get(kinc_float32x4_t t, int index) {
+static inline float kinc_float32x4_get(kinc_float32x4_t t, int index) {
 	return t[index];
 }
 
-inline kinc_float32x4_t kinc_float32x4_abs(kinc_float32x4_t t) {
+static inline kinc_float32x4_t kinc_float32x4_abs(kinc_float32x4_t t) {
 	return vabsq_f32(t);
 }
 
-inline kinc_float32x4_t kinc_float32x4_add(kinc_float32x4_t a, kinc_float32x4_t b) {
+static inline kinc_float32x4_t kinc_float32x4_add(kinc_float32x4_t a, kinc_float32x4_t b) {
 	return vaddq_f32(a, b);
 }
 
-inline kinc_float32x4_t kinc_float32x4_div(kinc_float32x4_t a, kinc_float32x4_t b) {
-#if defined(ARM64) || defined(KORE_SWITCH) || __arm64
+static inline kinc_float32x4_t kinc_float32x4_div(kinc_float32x4_t a, kinc_float32x4_t b) {
+#if defined(ARM64) || defined(KORE_SWITCH) || defined(__arm64) || defined(__aarch64__)
 	return vdivq_f32(a, b);
 #else
 	float32x4_t inv = vrecpeq_f32(b);
@@ -108,28 +108,28 @@ inline kinc_float32x4_t kinc_float32x4_div(kinc_float32x4_t a, kinc_float32x4_t 
 #endif
 }
 
-inline kinc_float32x4_t kinc_float32x4_mul(kinc_float32x4_t a, kinc_float32x4_t b) {
+static inline kinc_float32x4_t kinc_float32x4_mul(kinc_float32x4_t a, kinc_float32x4_t b) {
 	return vmulq_f32(a, b);
 }
 
-inline kinc_float32x4_t kinc_float32x4_neg(kinc_float32x4_t t) {
+static inline kinc_float32x4_t kinc_float32x4_neg(kinc_float32x4_t t) {
 	return vnegq_f32(t);
 }
 
-inline kinc_float32x4_t kinc_float32x4_reciprocal_approximation(kinc_float32x4_t t) {
+static inline kinc_float32x4_t kinc_float32x4_reciprocal_approximation(kinc_float32x4_t t) {
 	return vrecpeq_f32(t);
 }
 
-inline kinc_float32x4_t kinc_float32x4_reciprocal_sqrt_approximation(kinc_float32x4_t t) {
+static inline kinc_float32x4_t kinc_float32x4_reciprocal_sqrt_approximation(kinc_float32x4_t t) {
 	return vrsqrteq_f32(t);
 }
 
-inline kinc_float32x4_t kinc_float32x4_sub(kinc_float32x4_t a, kinc_float32x4_t b) {
+static inline kinc_float32x4_t kinc_float32x4_sub(kinc_float32x4_t a, kinc_float32x4_t b) {
 	return vsubq_f32(a, b);
 }
 
-inline kinc_float32x4_t kinc_float32x4_sqrt(kinc_float32x4_t t) {
-#if defined(ARM64) || defined(KORE_SWITCH) || __arm64
+static inline kinc_float32x4_t kinc_float32x4_sqrt(kinc_float32x4_t t) {
+#if defined(ARM64) || defined(KORE_SWITCH) || defined(__arm64) || defined(__aarch64__)
 	return vsqrtq_f32(t);
 #else
 	return vmulq_f32(t, vrsqrteq_f32(t));
@@ -144,7 +144,7 @@ typedef struct kinc_float32x4 {
 	float values[4];
 } kinc_float32x4_t;
 
-inline kinc_float32x4_t kinc_float32x4_load(float a, float b, float c, float d) {
+static inline kinc_float32x4_t kinc_float32x4_load(float a, float b, float c, float d) {
 	kinc_float32x4_t value;
 	value.values[0] = a;
 	value.values[1] = b;
@@ -153,7 +153,7 @@ inline kinc_float32x4_t kinc_float32x4_load(float a, float b, float c, float d) 
 	return value;
 }
 
-inline kinc_float32x4_t kinc_float32x4_load_all(float t) {
+static inline kinc_float32x4_t kinc_float32x4_load_all(float t) {
 	kinc_float32x4_t value;
 	value.values[0] = t;
 	value.values[1] = t;
@@ -162,11 +162,11 @@ inline kinc_float32x4_t kinc_float32x4_load_all(float t) {
 	return value;
 }
 
-inline float kinc_float32x4_get(kinc_float32x4_t t, int index) {
+static inline float kinc_float32x4_get(kinc_float32x4_t t, int index) {
 	return t.values[index];
 }
 
-inline kinc_float32x4_t kinc_float32x4_abs(kinc_float32x4_t t) {
+static inline kinc_float32x4_t kinc_float32x4_abs(kinc_float32x4_t t) {
 	kinc_float32x4_t value;
 	value.values[0] = kinc_abs(t.values[0]);
 	value.values[1] = kinc_abs(t.values[1]);
@@ -175,7 +175,7 @@ inline kinc_float32x4_t kinc_float32x4_abs(kinc_float32x4_t t) {
 	return value;
 }
 
-inline kinc_float32x4_t kinc_float32x4_add(kinc_float32x4_t a, kinc_float32x4_t b) {
+static inline kinc_float32x4_t kinc_float32x4_add(kinc_float32x4_t a, kinc_float32x4_t b) {
 	kinc_float32x4_t value;
 	value.values[0] = a.values[0] + b.values[0];
 	value.values[1] = a.values[1] + b.values[1];
@@ -184,7 +184,7 @@ inline kinc_float32x4_t kinc_float32x4_add(kinc_float32x4_t a, kinc_float32x4_t 
 	return value;
 }
 
-inline kinc_float32x4_t kinc_float32x4_div(kinc_float32x4_t a, kinc_float32x4_t b) {
+static inline kinc_float32x4_t kinc_float32x4_div(kinc_float32x4_t a, kinc_float32x4_t b) {
 	kinc_float32x4_t value;
 	value.values[0] = a.values[0] / b.values[0];
 	value.values[1] = a.values[1] / b.values[1];
@@ -193,7 +193,7 @@ inline kinc_float32x4_t kinc_float32x4_div(kinc_float32x4_t a, kinc_float32x4_t 
 	return value;
 }
 
-inline kinc_float32x4_t kinc_float32x4_mul(kinc_float32x4_t a, kinc_float32x4_t b) {
+static inline kinc_float32x4_t kinc_float32x4_mul(kinc_float32x4_t a, kinc_float32x4_t b) {
 	kinc_float32x4_t value;
 	value.values[0] = a.values[0] * b.values[0];
 	value.values[1] = a.values[1] * b.values[1];
@@ -202,7 +202,7 @@ inline kinc_float32x4_t kinc_float32x4_mul(kinc_float32x4_t a, kinc_float32x4_t 
 	return value;
 }
 
-inline kinc_float32x4_t kinc_float32x4_neg(kinc_float32x4_t t) {
+static inline kinc_float32x4_t kinc_float32x4_neg(kinc_float32x4_t t) {
 	kinc_float32x4_t value;
 	value.values[0] = -t.values[0];
 	value.values[1] = -t.values[1];
@@ -211,7 +211,7 @@ inline kinc_float32x4_t kinc_float32x4_neg(kinc_float32x4_t t) {
 	return value;
 }
 
-inline kinc_float32x4_t kinc_float32x4_reciprocal_approximation(kinc_float32x4_t t) {
+static inline kinc_float32x4_t kinc_float32x4_reciprocal_approximation(kinc_float32x4_t t) {
 	kinc_float32x4_t value;
 	value.values[0] = 0;
 	value.values[1] = 0;
@@ -220,7 +220,7 @@ inline kinc_float32x4_t kinc_float32x4_reciprocal_approximation(kinc_float32x4_t
 	return value;
 }
 
-inline kinc_float32x4_t kinc_float32x4_reciprocal_sqrt_approximation(kinc_float32x4_t t) {
+static inline kinc_float32x4_t kinc_float32x4_reciprocal_sqrt_approximation(kinc_float32x4_t t) {
 	kinc_float32x4_t value;
 	value.values[0] = 0;
 	value.values[1] = 0;
@@ -229,7 +229,7 @@ inline kinc_float32x4_t kinc_float32x4_reciprocal_sqrt_approximation(kinc_float3
 	return value;
 }
 
-inline kinc_float32x4_t kinc_float32x4_sub(kinc_float32x4_t a, kinc_float32x4_t b) {
+static inline kinc_float32x4_t kinc_float32x4_sub(kinc_float32x4_t a, kinc_float32x4_t b) {
 	kinc_float32x4_t value;
 	value.values[0] = a.values[0] - b.values[0];
 	value.values[1] = a.values[1] - b.values[1];
@@ -238,7 +238,7 @@ inline kinc_float32x4_t kinc_float32x4_sub(kinc_float32x4_t a, kinc_float32x4_t 
 	return value;
 }
 
-inline kinc_float32x4_t kinc_float32x4_sqrt(kinc_float32x4_t t) {
+static inline kinc_float32x4_t kinc_float32x4_sqrt(kinc_float32x4_t t) {
 	kinc_float32x4_t value;
 	value.values[0] = kinc_sqrt(t.values[0]);
 	value.values[1] = kinc_sqrt(t.values[1]);


### PR DESCRIPTION
This enables NEON on all Android and Linux devices that support it.
All ARMv8 CPUs support the extension, so this should be safe.

Also makes all functions `static inline` instead of `inline` because
GCC doesn't like only `inline`.

Also fixes a compile error by using compound literals as return value.