### PR TITLE
IOS: Fix wrong identifier in KINC_ATOMIC_DECREMENT

### DIFF
--- a/Backends/System/POSIX/Sources/kinc/backend/atomic.h
+++ b/Backends/System/POSIX/Sources/kinc/backend/atomic.h
@@ -10,7 +10,7 @@
 
 #define KINC_ATOMIC_INCREMENT(pointer) (OSAtomicIncrement32Barrier(pointer) - 1)
 
-#define KINC_ATOMIC_DECREMENT(pointer) (OSAtomicDecrement32Barrier(ioWhere) + 1)
+#define KINC_ATOMIC_DECREMENT(pointer) (OSAtomicDecrement32Barrier(pointer) + 1)
 
 #define KINC_ATOMIC_EXCHANGE_32(pointer, value) (__sync_swap(pointer, value))
 


### PR DESCRIPTION
Not sure where the `ioWhere` came from, but I believe it makes more sense to pass in the `pointer`