### PR TITLE
[wayland] Make sure the xdg_surface is configured.

### DIFF
--- a/Backends/System/Linux/Sources/kinc/backend/wayland/wayland.h
+++ b/Backends/System/Linux/Sources/kinc/backend/wayland/wayland.h
@@ -226,6 +226,8 @@ struct kinc_wl_window {
 	struct xdg_toplevel *toplevel;
 	struct zxdg_toplevel_decoration_v1 *xdg_decoration;
 
+	bool configured;
+
 	struct {
 		bool server_side;
 		enum kinc_wl_decoration_focus focus;

--- a/Backends/System/Linux/Sources/kinc/backend/wayland/window.c.h
+++ b/Backends/System/Linux/Sources/kinc/backend/wayland/window.c.h
@@ -9,6 +9,7 @@
 #include <string.h>
 #include <sys/mman.h>
 #include <unistd.h>
+#include <wayland-client-core.h>
 
 #ifdef KINC_EGL
 #include <EGL/egl.h>
@@ -17,6 +18,8 @@
 
 static void xdg_surface_handle_configure(void *data, struct xdg_surface *surface, uint32_t serial) {
 	xdg_surface_ack_configure(surface, serial);
+	struct kinc_wl_window *window = data;
+	window->configured = true;
 }
 
 void kinc_internal_resize(int, int, int);
@@ -359,6 +362,11 @@ int kinc_wayland_window_create(kinc_window_options_t *win, kinc_framebuffer_opti
 	wl_surface_commit(window->surface);
 	kinc_wayland_window_change_mode(window_index, win->mode);
 	wl_ctx.num_windows++;
+
+	while(!window->configured) {
+		wl_display_roundtrip(wl_ctx.display);
+	}
+
 	return window_index;
 }
 


### PR DESCRIPTION
This makes sway and other more spec-compliant compositors happy.