### PR TITLE
[Vulkan] Fix crash when posix_memalign fails.

### DIFF
--- a/Backends/Graphics5/Vulkan/Sources/kinc/backend/graphics5/Vulkan.c.h
+++ b/Backends/Graphics5/Vulkan/Sources/kinc/backend/graphics5/Vulkan.c.h
@@ -609,6 +609,7 @@ void kinc_g5_internal_init() {
 #ifdef VALIDATE
 		vk_ctx.validation_found = find_layer(instance_layers, instance_layer_count, "VK_LAYER_KHRONOS_validation");
 		if (vk_ctx.validation_found) {
+			kinc_log(KINC_LOG_LEVEL_INFO, "Running with Vulkan validation layers enabled.");
 			wanted_instance_layers[wanted_instance_layer_count++] = "VK_LAYER_KHRONOS_validation";
 		}
 #endif
@@ -657,12 +658,16 @@ void kinc_g5_internal_init() {
 	info.pNext = NULL;
 	info.pApplicationInfo = &app;
 #ifdef VALIDATE
-	info.enabledLayerCount = wanted_instance_layer_count;
-	info.ppEnabledLayerNames = (const char *const *)wanted_instance_layers;
-#else
-	info.enabledLayerCount = 0;
-	info.ppEnabledLayerNames = NULL;
+	if (vk_ctx.validation_found) {
+		info.enabledLayerCount = wanted_instance_layer_count;
+		info.ppEnabledLayerNames = (const char *const *)wanted_instance_layers;
+	}
+	else
 #endif
+	{
+		info.enabledLayerCount = 0;
+		info.ppEnabledLayerNames = NULL;
+	}
 	info.enabledExtensionCount = wanted_instance_extension_count;
 	info.ppEnabledExtensionNames = (const char *const *)wanted_instance_extensions;
 

--- a/Backends/Graphics5/Vulkan/Sources/kinc/backend/graphics5/Vulkan.c.h
+++ b/Backends/Graphics5/Vulkan/Sources/kinc/backend/graphics5/Vulkan.c.h
@@ -97,7 +97,9 @@ static VKAPI_ATTR void *VKAPI_CALL myalloc(void *pUserData, size_t size, size_t 
 	return _aligned_malloc(size, alignment);
 #else
 	void *ptr;
-	posix_memalign(&ptr, alignment, size);
+	if(posix_memalign(&ptr, alignment, size) != 0) {
+		return NULL;
+	}
 	return ptr;
 #endif
 }

--- a/Tests/MultiWindow/kfile.js
+++ b/Tests/MultiWindow/kfile.js
@@ -3,7 +3,6 @@ const project = new Project('MultiWindow');
 await project.addProject('../../');
 
 project.addFile('Sources/**');
-project.addDefine("VALIDATE");
 project.setDebugDir('Deployment');
 
 project.flatten();


### PR DESCRIPTION
Not sure why this suddenly started messing up, I suspect a mesa3d update.
Returning null as the specification wants us to seems to fix it.

Also only request validation layers when they were actually found.