### PR TITLE
Fix the window close callback.

### DIFF
--- a/Backends/System/Android/Sources/kinc/backend/window.c.h
+++ b/Backends/System/Android/Sources/kinc/backend/window.c.h
@@ -68,6 +68,8 @@ void kinc_internal_call_resize_callback(int window_index, int width, int height)
 
 void kinc_window_set_ppi_changed_callback(int window_index, void (*callback)(int ppi, void *data), void *data) {}
 
+void kinc_window_set_close_callback(int window, bool (*callback)(void *), void *data) {}
+
 kinc_window_mode_t kinc_window_get_mode(int window_index) {
 	return KINC_WINDOW_MODE_FULLSCREEN;
 }

--- a/Backends/System/HTML5/Sources/kinc/backend/window.c.h
+++ b/Backends/System/HTML5/Sources/kinc/backend/window.c.h
@@ -74,6 +74,8 @@ void kinc_window_set_resize_callback(int window_index, void (*callback)(int x, i
 
 void kinc_window_set_ppi_changed_callback(int window_index, void (*callback)(int ppi, void *data), void *data) {}
 
+void kinc_window_set_close_callback(int window, bool (*callback)(void *), void *data) {}
+
 kinc_window_mode_t kinc_window_get_mode(int window_index) {
 	return kinc_internal_window_mode;
 }

--- a/Backends/System/Windows/Sources/kinc/backend/system.c.h
+++ b/Backends/System/Windows/Sources/kinc/backend/system.c.h
@@ -332,7 +332,7 @@ LRESULT WINAPI KoreWindowsMessageProcedure(HWND hWnd, UINT msg, WPARAM wParam, L
 				return 0;
 			}
 		}
-		break;
+		return 0;
 	case WM_ERASEBKGND:
 		return 1;
 	case WM_ACTIVATE:

--- a/Backends/System/WindowsApp/Sources/kinc/backend/window.c
+++ b/Backends/System/WindowsApp/Sources/kinc/backend/window.c
@@ -51,3 +51,5 @@ void kinc_window_set_title(int window_index, const char *title) {}
 void kinc_window_set_resize_callback(int window_index, void (*callback)(int x, int y, void *data), void *data) {}
 
 void kinc_window_set_ppi_changed_callback(int window_index, void (*callback)(int ppi, void *data), void *data) {}
+
+void kinc_window_set_close_callback(int window, bool (*callback)(void *), void *data) {}

--- a/Backends/System/iOS/Sources/kinc/backend/window.c.h
+++ b/Backends/System/iOS/Sources/kinc/backend/window.c.h
@@ -51,6 +51,8 @@ void kinc_window_set_resize_callback(int window, void (*callback)(int x, int y, 
 
 void kinc_window_set_ppi_changed_callback(int window, void (*callback)(int ppi, void *data), void *data) {}
 
+void kinc_window_set_close_callback(int window, bool (*callback)(void *), void *data) {}
+
 kinc_window_mode_t kinc_window_get_mode(int window) {
 	return KINC_WINDOW_MODE_FULLSCREEN;
 }

--- a/Backends/System/macOS/Sources/kinc/backend/system.m.h
+++ b/Backends/System/macOS/Sources/kinc/backend/system.m.h
@@ -156,6 +156,11 @@ void kinc_window_change_window_mode(int window_index, kinc_window_mode_t mode) {
 	}
 }
 
+void kinc_window_set_close_callback(int window, bool (*callback)(void *), void *data) {
+	windows[window].closeCallback = callback;
+	windows[window].closeCallbackData = data;
+}
+
 static void addMenubar() {
 	NSString *appName = [[NSProcessInfo processInfo] processName];
 
@@ -276,6 +281,17 @@ int main(int argc, char **argv) {
 @end
 
 @implementation KincAppDelegate
+- (BOOL)windowShouldClose:(NSWindow *)sender {
+	if (windows[0].closeCallback != NULL) {
+		if (windows[0].closeCallback(windows[0].closeCallbackData)) {
+			return YES;
+		}
+		else {
+			return NO;
+		}
+	}
+	return YES;
+}
 
 - (void)windowWillClose:(NSNotification *)notification {
 	kinc_stop();

--- a/Backends/System/macOS/Sources/kinc/backend/windowdata.h
+++ b/Backends/System/macOS/Sources/kinc/backend/windowdata.h
@@ -8,6 +8,8 @@ struct WindowData {
 	bool fullscreen;
 	void (*resizeCallback)(int width, int height, void *data);
 	void *resizeCallbackData;
+	bool (*closeCallback)(void *data);
+	void *closeCallbackData;
 };
 
 NSWindow *kinc_get_mac_window_handle(int window_index);


### PR DESCRIPTION
Fix the callback for windows, as pointed out in https://github.com/armory3d/armorpaint/issues/1328#issuecomment-1066042671
Add an untested implementation for macOS.
And add empty implementations for the other backends.