### PR TITLE
[Direct3D 12] Use wrap texture address mode as default

### DIFF
--- a/Backends/Graphics5/Direct3D12/Sources/kinc/backend/graphics5/texture.c.h
+++ b/Backends/Graphics5/Direct3D12/Sources/kinc/backend/graphics5/texture.c.h
@@ -145,9 +145,9 @@ static void createSampler(bool bilinear, D3D12_FILTER filter) {
 	D3D12_SAMPLER_DESC samplerDesc;
 	ZeroMemory(&samplerDesc, sizeof(D3D12_SAMPLER_DESC));
 	samplerDesc.Filter = filter;
-	samplerDesc.AddressU = D3D12_TEXTURE_ADDRESS_MODE_CLAMP;
-	samplerDesc.AddressV = D3D12_TEXTURE_ADDRESS_MODE_CLAMP;
-	samplerDesc.AddressW = D3D12_TEXTURE_ADDRESS_MODE_CLAMP;
+	samplerDesc.AddressU = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
+	samplerDesc.AddressV = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
+	samplerDesc.AddressW = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
 	samplerDesc.MinLOD = 0;
 	samplerDesc.MaxLOD = D3D12_FLOAT32_MAX;
 	samplerDesc.MipLODBias = 0.0f;


### PR DESCRIPTION
Matches other backends.