### PR TITLE
Allow spaces in path on windows for get_dlc

### DIFF
--- a/get_dlc.bat
+++ b/get_dlc.bat
@@ -1,1 +1,3 @@
-@git -C %~dp0 submodule update --init Tools/windows_x64
+@pushd "%~dp0"
+@git submodule update --init Tools/windows_x64
+@popd

--- a/get_dlc_dangerously.bat
+++ b/get_dlc_dangerously.bat
@@ -1,1 +1,3 @@
-@git -C %~dp0 submodule update --init --remote Tools/windows_x64
+@pushd "%~dp0"
+@git submodule update --init --remote Tools/windows_x64
+@popd


### PR DESCRIPTION
This fixes the "fatal: cannot change to path" error when running get_dlc if there is a space in the path on windows.