### PR TITLE
x11-backend: prevent keyup-/keydown-events on repeated keystroke

### DIFF
--- a/Backends/System/Linux/Sources/kinc/backend/x11/x11.h
+++ b/Backends/System/Linux/Sources/kinc/backend/x11/x11.h
@@ -112,6 +112,7 @@ struct kinc_x11_procs {
 	int (*XPending)(Display *display);
 	int (*XFlush)(Display *display);
 	int (*XNextEvent)(Display *display, XEvent *event_return);
+	int (*XPeekEvent)(Display *display, XEvent *event_return);
 	int (*XRefreshKeyboardMapping)(XMappingEvent *event_map);
 	int (*XwcLookupString)(XIC, XKeyPressedEvent *, wchar_t *, int, KeySym *, int *);
 	int (*XFilterEvent)(XEvent *, Window);


### PR DESCRIPTION
As discussed in discord(2022-07-10 14:33):
Repeated keystrokes In the x11-backend have the effect of sending x11 KeyRelease/KeyPress-Events which leads to unwanted kinc-callback-calls to KeyUp/Down. 

In order to prevent this you can peek for the next event (in the KeyRelease-event) to check if it is a KeyPress-Event with the exact same keycode. If yes, it is a repeated keystroke which should not fire kinc's KeyUp/Down events but should fire the KeyPress-Event. 
For this I set a flag "preventNextKeyDownEvent" to stop processing the next KeyDownEvent after KeyPress-Handling. 