### PR TITLE
Minor improvements to the download and make tools

### DIFF
--- a/Tools/platform.sh
+++ b/Tools/platform.sh
@@ -1,0 +1,23 @@
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+	MACHINE_TYPE=`uname -m`
+	if [[ "$MACHINE_TYPE" == "armv"* ]]; then
+		KINC_PLATFORM=linux_arm
+	elif [[ "$MACHINE_TYPE" == "aarch64"* ]]; then
+		KINC_PLATFORM=linux_arm64
+	elif [[ "$MACHINE_TYPE" == "x86_64"* ]]; then
+		KINC_PLATFORM=linux_x64
+	else
+		echo "Unknown Linux machine '$MACHINE_TYPE', please edit Tools/platform.sh"
+		exit 1
+	fi
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+	KINC_PLATFORM=macos
+elif [[ "$OSTYPE" == "FreeBSD"* ]]; then
+	KINC_PLATFORM=freebsd_x64
+elif [[ "$OSTYPE" == "msys"* || "$OSTYPE" == "cygwin"* ]]; then
+	KINC_PLATFORM=windows_x64
+	KINC_EXE_SUFFIX=.exe
+else
+	echo "Unknown platform '$OSTYPE', please edit Tools/platform.sh"
+	exit 1
+fi

--- a/get_dlc
+++ b/get_dlc
@@ -1,15 +1,4 @@
 #!/usr/bin/env bash
-if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-	MACHINE_TYPE=`uname -m`
-	if [[ "$MACHINE_TYPE" == "armv"* ]]; then
-		git -C `dirname "$0"` submodule update --init Tools/linux_arm
-	elif [[ "$MACHINE_TYPE" == "aarch64"* ]]; then
-		git -C `dirname "$0"` submodule update --init Tools/linux_arm64
-	else
-		git -C `dirname "$0"` submodule update --init Tools/linux_x64
-	fi
-elif [[ "$OSTYPE" == "darwin"* ]]; then
-	git -C `dirname "$0"` submodule update --init Tools/macos
-elif [[ "$OSTYPE" == "FreeBSD"* ]]; then
-	git -C `dirname "$0"` submodule update --init Tools/freebsd_x64
-fi
+
+. `dirname "$0"`/Tools/platform.sh
+git -C `dirname "$0"` submodule update --init "Tools/$KINC_PLATFORM"

--- a/get_dlc_dangerously
+++ b/get_dlc_dangerously
@@ -1,15 +1,4 @@
 #!/usr/bin/env bash
-if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-	MACHINE_TYPE=`uname -m`
-	if [[ "$MACHINE_TYPE" == "armv"* ]]; then
-		git -C `dirname "$0"` submodule update --init --remote Tools/linux_arm
-	elif [[ "$MACHINE_TYPE" == "aarch64"* ]]; then
-		git -C `dirname "$0"` submodule update --init --remote Tools/linux_arm64
-	else
-		git -C `dirname "$0"` submodule update --init --remote Tools/linux_x64
-	fi
-elif [[ "$OSTYPE" == "darwin"* ]]; then
-	git -C `dirname "$0"` submodule update --init --remote Tools/macos
-elif [[ "$OSTYPE" == "FreeBSD"* ]]; then
-	git -C `dirname "$0"` submodule update --init --remote Tools/freebsd_x64
-fi
+
+. `dirname "$0"`/Tools/platform.sh
+git -C `dirname "$0"` submodule update --init --remote "Tools/$KINC_PLATFORM"

--- a/make
+++ b/make
@@ -1,21 +1,11 @@
 #!/usr/bin/env bash
-if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-	MACHINE_TYPE=`uname -m`
-	if [[ "$MACHINE_TYPE" == "armv"* ]]; then
-		MAKE=`dirname "$0"`/Tools/linux_arm/kmake
-	elif [[ "$MACHINE_TYPE" == "aarch64"* ]]; then
-		MAKE=`dirname "$0"`/Tools/linux_arm64/kmake
-	else
-		MAKE=`dirname "$0"`/Tools/linux_x64/kmake
-	fi
-elif [[ "$OSTYPE" == "darwin"* ]]; then
-	MAKE=`dirname "$0"`/Tools/macos/kmake
-elif [[ "$OSTYPE" == "FreeBSD"* ]]; then
-	MAKE=`dirname "$0"`/Tools/freebsd_x64/kmake
-fi
+
+. `dirname "$0"`/Tools/platform.sh
+MAKE="`dirname "$0"`/Tools/$KINC_PLATFORM/kmake$KINC_EXE_SUFFIX"
 
 if [ -f "$MAKE" ]; then
-	$MAKE "$@"
+	exec $MAKE "$@"
 else 
 	echo "kmake was not found, please run the get_dlc script."
+	exit 1
 fi


### PR DESCRIPTION
Platform discovery logic is now centralised in a single file, making all scripts a lot shorter, and the shell scripts can be run under MSYS2 or Cygwin.

All scripts also exit with a more meaningful error if the current platform is unknown, and the `make` script exits with a non-zero exit code if any error occurs.