### PR TITLE
[D3D12] Fix texture stride computation for unaligned data

### DIFF
--- a/Backends/Graphics5/Direct3D12/Sources/kinc/backend/graphics5/texture.c.h
+++ b/Backends/Graphics5/Direct3D12/Sources/kinc/backend/graphics5/texture.c.h
@@ -254,10 +254,7 @@ void kinc_g5_texture_init_from_image(kinc_g5_texture_t *texture, kinc_image_t *i
 		}
 	}
 
-	texture->impl.stride = (int)ceilf(uploadBufferSize / (float)image->height);
-	if (texture->impl.stride < d3d12_textureAlignment()) {
-		texture->impl.stride = d3d12_textureAlignment();
-	}
+	texture->impl.stride = (int)ceilf(uploadBufferSize / (float)(image->height * d3d12_textureAlignment())) * d3d12_textureAlignment();
 
 	BYTE *pixel;
 	texture->impl.uploadImage->Map(0, NULL, (void **)&pixel);
@@ -364,10 +361,7 @@ void create_texture(struct kinc_g5_texture *texture, int width, int height, kinc
 		}
 	}
 
-	texture->impl.stride = (int)ceilf(uploadBufferSize / (float)height);
-	if (texture->impl.stride < d3d12_textureAlignment()) {
-		texture->impl.stride = d3d12_textureAlignment();
-	}
+	texture->impl.stride = (int)ceilf(uploadBufferSize / (float)(height * d3d12_textureAlignment())) * d3d12_textureAlignment();
 
 	D3D12_DESCRIPTOR_HEAP_DESC descriptorHeapDesc = {0};
 	descriptorHeapDesc.NumDescriptors = 1;


### PR DESCRIPTION
Stride computation is incorrect in some situations. Here is an example, for size 281×23:

![image](https://user-images.githubusercontent.com/245089/192698716-4ed51561-2c19-4c01-9f8e-af778f914610.png) ![image](https://user-images.githubusercontent.com/245089/192698744-550e21b4-9d51-4743-aeac-f4dcc9eb759d.png)

This change now gives the same result as the `rowPitch` computation in `kinc_g5_command_list_get_render_target_pixels()`. Maybe the code could be harmonised.