### PR TITLE
Instruct clang-format to avoid single-line `if` and `for` statements

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -10,8 +10,8 @@ AllowAllParametersOfDeclarationOnNextLine: true
 AllowShortBlocksOnASingleLine: false
 AllowShortCaseLabelsOnASingleLine: false
 AllowShortFunctionsOnASingleLine: Empty
-AllowShortIfStatementsOnASingleLine: true
-AllowShortLoopsOnASingleLine: true
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
 AlwaysBreakAfterDefinitionReturnType: None
 AlwaysBreakAfterReturnType: None
 AlwaysBreakBeforeMultilineStrings: false


### PR DESCRIPTION
The previous settings would cause Visual Studio to reformat short `if` statements in a single line, which made it more difficult to set breakpoints in the code.