### PR TITLE
Fix D3D12

### DIFF
--- a/Backends/Graphics5/Direct3D12/Sources/kinc/backend/graphics5/pipeline.c.h
+++ b/Backends/Graphics5/Direct3D12/Sources/kinc/backend/graphics5/pipeline.c.h
@@ -151,6 +151,10 @@ kinc_g5_constant_location_t kinc_g5_pipeline_get_constant_location(struct kinc_g
 
 kinc_g5_texture_unit_t kinc_g5_pipeline_get_texture_unit(kinc_g5_pipeline_t *pipe, const char *name) {
 	kinc_g5_texture_unit_t unit;
+	for (int i = 0; i < KINC_G5_SHADER_TYPE_COUNT; ++i) {
+		unit.stages[i] = -1;
+	}
+
 	ShaderTexture vertexTexture = findTexture(pipe->vertexShader, name);
 	if (vertexTexture.texture != -1) {
 		unit.stages[KINC_G5_SHADER_TYPE_VERTEX] = vertexTexture.texture;

--- a/Backends/Graphics5/Direct3D12/Sources/kinc/backend/graphics5/texture.c.h
+++ b/Backends/Graphics5/Direct3D12/Sources/kinc/backend/graphics5/texture.c.h
@@ -103,7 +103,7 @@ void kinc_g5_internal_set_textures(ID3D12GraphicsCommandList *commandList) {
 		samplerGpu.ptr += heapIndex * samplerStep;
 
 		for (int i = 0; i < textureCount; ++i) {
-			if (currentRenderTargets[i] != NULL || currentTextures[i] != NULL && current_samplers[i] != NULL) {
+			if ((currentRenderTargets[i] != NULL || currentTextures[i] != NULL) && current_samplers[i] != NULL) {
 				ID3D12DescriptorHeap *samplerDescriptorHeap = current_samplers[i]->impl.sampler_heap;
 
 				D3D12_CPU_DESCRIPTOR_HANDLE srvCpu = srvHeap->GetCPUDescriptorHandleForHeapStart();


### PR DESCRIPTION
Fixes crashing when testing armory stuff. Rendering still broken (flashing / wrong textures displayed), will investigate.