### PR TITLE
prevent 'incompatible pointer type' warning

### DIFF
--- a/Backends/System/Linux/Sources/kinc/backend/wayland/system.c.h
+++ b/Backends/System/Linux/Sources/kinc/backend/wayland/system.c.h
@@ -1181,7 +1181,7 @@ bool kinc_wayland_handle_messages() {
 
 #ifdef KINC_EGL
 EGLDisplay kinc_wayland_egl_get_display() {
-	return eglGetDisplay(wl_ctx.display);
+	return eglGetDisplay((EGLNativeDisplayType)wl_ctx.display);
 }
 
 EGLNativeWindowType kinc_wayland_egl_get_native_window(EGLDisplay display, EGLConfig config, int window_index) {


### PR DESCRIPTION
Fix a compiler warning with gcc 10.2.1.

```
In file included from ../../Kinc/Backends/System/Linux/Sources/kinc/backend/linuxunit.c:27:
../../Kinc/Backends/System/Linux/Sources/kinc/backend/wayland/system.c.h: In function ‘kinc_wayland_egl_get_display’:
../../Kinc/Backends/System/Linux/Sources/kinc/backend/wayland/system.c.h:1184:29: warning: passing argument 1 of ‘eglGetDisplay’ from incompatible pointer type [-Wincompatible-pointer-types]
 1184 |  return eglGetDisplay(wl_ctx.display);
      |                       ~~~~~~^~~~~~~~
      |                             |
      |                             struct wl_display *
In file included from ../../Kinc/Backends/System/Linux/Sources/kinc/backend/funcs.h:8,
                 from ../../Kinc/Backends/System/Linux/Sources/kinc/backend/linuxunit.c:4:
/usr/include/EGL/egl.h:162:67: note: expected ‘EGLNativeDisplayType’ {aka ‘Display *’} but argument is of type ‘struct wl_display *’
  162 | EGLAPI EGLDisplay EGLAPIENTRY eglGetDisplay (EGLNativeDisplayType display_id);
      |                                              ~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~
```