### PR TITLE
Improve Wasm backend

### DIFF
--- a/Backends/System/Wasm/JS-Sources/start.js
+++ b/Backends/System/Wasm/JS-Sources/start.js
@@ -386,6 +386,30 @@ async function init() {
 				glGenerateMipmap: function(target) {
 					gl.generateMipmap(target);
 				},
+				glFlush: function() {
+					gl.flush();
+				},
+				glDeleteBuffers: function(n, buffers) {
+					for (let i = 0; i < n; ++i) {
+						gl.deleteBuffer(gl_buffers[heapu32[buffers / 4 + i]]);
+					}
+				},
+				glDeleteTextures: function(n, textures) {
+					for (let i = 0; i < n; ++i) {
+						gl.deleteTexture(gl_textures[heapu32[textures / 4 + i]]);
+					}
+				},
+				glDeleteFramebuffers: function(n, framebuffers) {
+					for (let i = 0; i < n; ++i) {
+						gl.deleteFramebuffer(gl_framebuffers[heapu32[framebuffers / 4 + i]]);
+					}
+				},
+				glDeleteProgram: function(program) {
+					gl.deleteProgram(gl_programs[program]);
+				},
+				glDeleteShader: function(shader) {
+					gl.deleteShader(gl_shaders[shader]);
+				},
 				js_fprintf: function(format) {
 					console.log(read_string(format));
 				},

--- a/Backends/System/Wasm/JS-Sources/start.js
+++ b/Backends/System/Wasm/JS-Sources/start.js
@@ -468,6 +468,9 @@ async function init() {
 				},
 				js_sqrt: function(x) {
 					return Math.sqrt(x);
+				},
+				js_eval: function(str) {
+					(1, eval)(read_string(str));
 				}
 			}
 		}

--- a/miniClib/memory.c
+++ b/miniClib/memory.c
@@ -5,11 +5,15 @@ __attribute__((import_module("imports"), import_name("js_fprintf"))) void js_fpr
 
 #define HEAP_SIZE 1024 * 1024 * 8
 static unsigned char heap[HEAP_SIZE];
-static size_t heap_top = 1;
+static size_t heap_top = 4;
 #endif
 
 void *malloc(size_t size) {
 #ifdef KORE_WASM
+	// Align to 4 bytes to make js typed arrays work
+	if (size % 4 != 0) {
+		size += 4 - size % 4;
+	}
 	size_t old_top = heap_top;
 	heap_top += size;
 	if (heap_top >= HEAP_SIZE) {


### PR DESCRIPTION
It should be getting pretty usable by now, we just need to:
- copy basic `index.html` file to `Deployment`
- copy https://github.com/Kode/Kinc/tree/main/Backends/System/Wasm/JS-Sources to `Deployment`
- copy resulting `.wasm` file to `Deployment`
- set default shader version to 300 (should be safe to drop webgl1 in wasm backend?)

To be resolved:
- `start.js` has hard-coded `.wasm` file name: https://github.com/Kode/Kinc/blob/main/Backends/System/Wasm/JS-Sources/start.js#L48
- memory has hard-coded size: https://github.com/Kode/Kinc/blob/main/miniClib/memory.c#L6

(related https://github.com/Kode/Kinc/pull/755)