### PR TITLE
SIMD Improvements

### DIFF
--- a/Sources/kinc/simd/float32x4.h
+++ b/Sources/kinc/simd/float32x4.h
@@ -132,7 +132,7 @@ static inline kinc_float32x4_t kinc_float32x4_load_all(float t) {
 	return vdupq_n_f32(t);
 }
 
-static inline kinc_float32x4_t kinc_float32x4_store(float *destination, kinc_float32x4_t value) {
+static inline void kinc_float32x4_store(float *destination, kinc_float32x4_t value) {
 	vst1q_f32(destination, value);
 }
 

--- a/Sources/kinc/simd/float32x4.h
+++ b/Sources/kinc/simd/float32x4.h
@@ -119,11 +119,11 @@ static inline kinc_float32x4_t kinc_float32x4_intrin_load(const float *values) {
 }
 
 static inline kinc_float32x4_t kinc_float32x4_load(float a, float b, float c, float d) {
-	kinc_float32x4_t value;
-	value.n128_f32[0] = a;
-	value.n128_f32[1] = b;
-	value.n128_f32[2] = c;
-	value.n128_f32[3] = d;
+	kinc_float32x4_t value = vdupq_n_f32(0.0f);
+	value = vsetq_lane_f32(a, value, 0);
+	value = vsetq_lane_f32(b, value, 1);
+	value = vsetq_lane_f32(c, value, 2);
+	value = vsetq_lane_f32(d, value, 3);
 
 	return value;
 }

--- a/Sources/kinc/simd/float32x4.h
+++ b/Sources/kinc/simd/float32x4.h
@@ -12,12 +12,23 @@ extern "C" {
 
 #if defined(KINC_SSE)
 
+static inline kinc_float32x4_t kinc_float32x4_intrin_load(float const *values)
+{
+	//Parameter doesn't behave like SIMD int types
+	return _mm_load_ps(values);
+}
+
 static inline kinc_float32x4_t kinc_float32x4_load(float a, float b, float c, float d) {
 	return _mm_set_ps(d, c, b, a);
 }
 
 static inline kinc_float32x4_t kinc_float32x4_load_all(float t) {
 	return _mm_set_ps1(t);
+}
+
+static inline void kinc_float32x4_store(float *destination, kinc_float32x4_t value)
+{
+	_mm_store_ps(destination, value);
 }
 
 static inline float kinc_float32x4_get(kinc_float32x4_t t, int index) {
@@ -105,12 +116,22 @@ static inline kinc_float32x4_t kinc_float32x4_sel(kinc_float32x4_t a, kinc_float
 
 #elif defined(KINC_NEON)
 
+static inline kinc_float32x4_t kinc_float32x4_intrin_load(float const *values)
+{
+	return vld1q_f32(values);
+}
+
 static inline kinc_float32x4_t kinc_float32x4_load(float a, float b, float c, float d) {
 	return (kinc_float32x4_t){a, b, c, d};
 }
 
 static inline kinc_float32x4_t kinc_float32x4_load_all(float t) {
 	return (kinc_float32x4_t){t, t, t, t};
+}
+
+static inline kinc_float32x4_t kinc_float32x4_store(float *destination, kinc_float32x4_t value)
+{
+	vst1q_f32(destination, value);
 }
 
 static inline float kinc_float32x4_get(kinc_float32x4_t t, int index) {
@@ -204,6 +225,16 @@ static inline kinc_float32x4_t kinc_float32x4_sel(kinc_float32x4_t a, kinc_float
 
 #include <math.h>
 
+static inline kinc_float32x4_t kinc_float32x4_intrin_load(float const *values)
+{
+	kinc_float32x4_t value;
+	value.values[0] = values[0];
+	value.values[1] = values[1];
+	value.values[2] = values[2];
+	value.values[3] = values[3];
+	return value;
+}
+
 static inline kinc_float32x4_t kinc_float32x4_load(float a, float b, float c, float d) {
 	kinc_float32x4_t value;
 	value.values[0] = a;
@@ -220,6 +251,14 @@ static inline kinc_float32x4_t kinc_float32x4_load_all(float t) {
 	value.values[2] = t;
 	value.values[3] = t;
 	return value;
+}
+
+static inline void kinc_float32x4_store(float *destination, kinc_float32x4_t value)
+{
+	destination[0] = value.values[0];
+	destination[1] = value.values[1];
+	destination[2] = value.values[2];
+	destination[3] = value.values[3];
 }
 
 static inline float kinc_float32x4_get(kinc_float32x4_t t, int index) {

--- a/Sources/kinc/simd/float32x4.h
+++ b/Sources/kinc/simd/float32x4.h
@@ -12,8 +12,7 @@ extern "C" {
 
 #if defined(KINC_SSE)
 
-static inline kinc_float32x4_t kinc_float32x4_intrin_load(float const *values)
-{
+static inline kinc_float32x4_t kinc_float32x4_intrin_load(const float *values) {
 	//Parameter doesn't behave like SIMD int types
 	return _mm_load_ps(values);
 }
@@ -26,8 +25,7 @@ static inline kinc_float32x4_t kinc_float32x4_load_all(float t) {
 	return _mm_set_ps1(t);
 }
 
-static inline void kinc_float32x4_store(float *destination, kinc_float32x4_t value)
-{
+static inline void kinc_float32x4_store(float *destination, kinc_float32x4_t value) {
 	_mm_store_ps(destination, value);
 }
 
@@ -116,8 +114,7 @@ static inline kinc_float32x4_t kinc_float32x4_sel(kinc_float32x4_t a, kinc_float
 
 #elif defined(KINC_NEON)
 
-static inline kinc_float32x4_t kinc_float32x4_intrin_load(float const *values)
-{
+static inline kinc_float32x4_t kinc_float32x4_intrin_load(const float *values) {
 	return vld1q_f32(values);
 }
 
@@ -129,8 +126,7 @@ static inline kinc_float32x4_t kinc_float32x4_load_all(float t) {
 	return (kinc_float32x4_t){t, t, t, t};
 }
 
-static inline kinc_float32x4_t kinc_float32x4_store(float *destination, kinc_float32x4_t value)
-{
+static inline kinc_float32x4_t kinc_float32x4_store(float *destination, kinc_float32x4_t value) {
 	vst1q_f32(destination, value);
 }
 
@@ -225,8 +221,7 @@ static inline kinc_float32x4_t kinc_float32x4_sel(kinc_float32x4_t a, kinc_float
 
 #include <math.h>
 
-static inline kinc_float32x4_t kinc_float32x4_intrin_load(float const *values)
-{
+static inline kinc_float32x4_t kinc_float32x4_intrin_load(const float *values) {
 	kinc_float32x4_t value;
 	value.values[0] = values[0];
 	value.values[1] = values[1];
@@ -253,8 +248,7 @@ static inline kinc_float32x4_t kinc_float32x4_load_all(float t) {
 	return value;
 }
 
-static inline void kinc_float32x4_store(float *destination, kinc_float32x4_t value)
-{
+static inline void kinc_float32x4_store(float *destination, kinc_float32x4_t value) {
 	destination[0] = value.values[0];
 	destination[1] = value.values[1];
 	destination[2] = value.values[2];

--- a/Sources/kinc/simd/float32x4.h
+++ b/Sources/kinc/simd/float32x4.h
@@ -123,7 +123,7 @@ static inline kinc_float32x4_t kinc_float32x4_load(float a, float b, float c, fl
 }
 
 static inline kinc_float32x4_t kinc_float32x4_load_all(float t) {
-	return vdupq_n_f32(t);
+	return (kinc_float32x4_t){t, t, t, t};
 }
 
 static inline void kinc_float32x4_store(float *destination, kinc_float32x4_t value) {

--- a/Sources/kinc/simd/float32x4.h
+++ b/Sources/kinc/simd/float32x4.h
@@ -129,13 +129,7 @@ static inline kinc_float32x4_t kinc_float32x4_load(float a, float b, float c, fl
 }
 
 static inline kinc_float32x4_t kinc_float32x4_load_all(float t) {
-	kinc_float32x4_t value;
-	value.n128_f32[0] = t;
-	value.n128_f32[1] = t;
-	value.n128_f32[2] = t;
-	value.n128_f32[3] = t;
-
-	return value;
+	return vdupq_n_f32(t);
 }
 
 static inline kinc_float32x4_t kinc_float32x4_store(float *destination, kinc_float32x4_t value) {

--- a/Sources/kinc/simd/float32x4.h
+++ b/Sources/kinc/simd/float32x4.h
@@ -119,11 +119,23 @@ static inline kinc_float32x4_t kinc_float32x4_intrin_load(const float *values) {
 }
 
 static inline kinc_float32x4_t kinc_float32x4_load(float a, float b, float c, float d) {
-	return (kinc_float32x4_t){a, b, c, d};
+	kinc_float32x4_t value;
+	value.n128_f32[0] = a;
+	value.n128_f32[1] = b;
+	value.n128_f32[2] = c;
+	value.n128_f32[3] = d;
+
+	return value;
 }
 
 static inline kinc_float32x4_t kinc_float32x4_load_all(float t) {
-	return (kinc_float32x4_t){t, t, t, t};
+	kinc_float32x4_t value;
+	value.n128_f32[0] = t;
+	value.n128_f32[1] = t;
+	value.n128_f32[2] = t;
+	value.n128_f32[3] = t;
+
+	return value;
 }
 
 static inline kinc_float32x4_t kinc_float32x4_store(float *destination, kinc_float32x4_t value) {

--- a/Sources/kinc/simd/float32x4.h
+++ b/Sources/kinc/simd/float32x4.h
@@ -131,7 +131,7 @@ static inline kinc_float32x4_t kinc_float32x4_store(float *destination, kinc_flo
 }
 
 static inline float kinc_float32x4_get(kinc_float32x4_t t, int index) {
-	return t[index];
+	return t.n128_f32[index];
 }
 
 static inline kinc_float32x4_t kinc_float32x4_abs(kinc_float32x4_t t) {

--- a/Sources/kinc/simd/float32x4.h
+++ b/Sources/kinc/simd/float32x4.h
@@ -137,7 +137,7 @@ static inline kinc_float32x4_t kinc_float32x4_store(float *destination, kinc_flo
 }
 
 static inline float kinc_float32x4_get(kinc_float32x4_t t, int index) {
-	return vgetq_lane_f32(t, index);
+	return t[index];
 }
 
 static inline kinc_float32x4_t kinc_float32x4_abs(kinc_float32x4_t t) {

--- a/Sources/kinc/simd/float32x4.h
+++ b/Sources/kinc/simd/float32x4.h
@@ -137,7 +137,7 @@ static inline kinc_float32x4_t kinc_float32x4_store(float *destination, kinc_flo
 }
 
 static inline float kinc_float32x4_get(kinc_float32x4_t t, int index) {
-	return t.n128_f32[index];
+	return vgetq_lane_f32(t, index);
 }
 
 static inline kinc_float32x4_t kinc_float32x4_abs(kinc_float32x4_t t) {

--- a/Sources/kinc/simd/float32x4.h
+++ b/Sources/kinc/simd/float32x4.h
@@ -119,13 +119,7 @@ static inline kinc_float32x4_t kinc_float32x4_intrin_load(const float *values) {
 }
 
 static inline kinc_float32x4_t kinc_float32x4_load(float a, float b, float c, float d) {
-	kinc_float32x4_t value = vdupq_n_f32(0.0f);
-	value = vsetq_lane_f32(a, value, 0);
-	value = vsetq_lane_f32(b, value, 1);
-	value = vsetq_lane_f32(c, value, 2);
-	value = vsetq_lane_f32(d, value, 3);
-
-	return value;
+	return (kinc_float32x4_t){a, b, c, d};
 }
 
 static inline kinc_float32x4_t kinc_float32x4_load_all(float t) {

--- a/Sources/kinc/simd/int16x8.h
+++ b/Sources/kinc/simd/int16x8.h
@@ -128,7 +128,7 @@ static inline kinc_int16x8_t kinc_int16x8_store(int16_t *destination, kinc_int16
 }
 
 static inline int16_t kinc_int16x8_get(kinc_int16x8_t t, int index) {
-	return t.n128_i16[index];
+	return vgetq_lane_s16(t, index);
 }
 
 static inline kinc_int16x8_t kinc_int16x8_add(kinc_int16x8_t a, kinc_int16x8_t b) {

--- a/Sources/kinc/simd/int16x8.h
+++ b/Sources/kinc/simd/int16x8.h
@@ -120,17 +120,7 @@ static inline kinc_int16x8_t kinc_int16x8_load(const int16_t values[8]) {
 }
 
 static inline kinc_int16x8_t kinc_int16x8_load_all(int16_t t) {
-	kinc_int16x8_t value;
-	value.n128_i16[0] = t;
-	value.n128_i16[1] = t;
-	value.n128_i16[2] = t;
-	value.n128_i16[3] = t;
-	value.n128_i16[4] = t;
-	value.n128_i16[5] = t;
-	value.n128_i16[6] = t;
-	value.n128_i16[7] = t;
-
-	return value;
+	return vdupq_n_s16(t);
 }
 
 static inline kinc_int16x8_t kinc_int16x8_store(int16_t *destination, kinc_int16x8_t value) {

--- a/Sources/kinc/simd/int16x8.h
+++ b/Sources/kinc/simd/int16x8.h
@@ -110,7 +110,7 @@ static inline kinc_int16x8_t kinc_int16x8_load(const int16_t values[8]) {
 }
 
 static inline kinc_int16x8_t kinc_int16x8_load_all(int16_t t) {
-	return vdupq_n_s16(t);
+	return (kinc_int16x8_t){t, t, t, t, t, t, t, t};
 }
 
 static inline void kinc_int16x8_store(int16_t *destination, kinc_int16x8_t value) {

--- a/Sources/kinc/simd/int16x8.h
+++ b/Sources/kinc/simd/int16x8.h
@@ -106,15 +106,15 @@ static inline kinc_int16x8_t kinc_int16x8_intrin_load(const int16_t *values) {
 }
 
 static inline kinc_int16x8_t kinc_int16x8_load(const int16_t values[8]) {
-	kinc_int16x8_t value;
-	value.n128_i16[0] = values[0];
-	value.n128_i16[1] = values[1];
-	value.n128_i16[2] = values[2];
-	value.n128_i16[3] = values[3];
-	value.n128_i16[4] = values[4];
-	value.n128_i16[5] = values[5];
-	value.n128_i16[6] = values[6];
-	value.n128_i16[7] = values[7];
+	kinc_int16x8_t value = vdupq_n_s16(0);
+	value = vsetq_lane_s16(values[0], value, 0);
+	value = vsetq_lane_s16(values[1], value, 1);
+	value = vsetq_lane_s16(values[2], value, 2);
+	value = vsetq_lane_s16(values[3], value, 3);
+	value = vsetq_lane_s16(values[4], value, 4);
+	value = vsetq_lane_s16(values[5], value, 5);
+	value = vsetq_lane_s16(values[6], value, 6);
+	value = vsetq_lane_s16(values[7], value, 7);
 
 	return value;
 }

--- a/Sources/kinc/simd/int16x8.h
+++ b/Sources/kinc/simd/int16x8.h
@@ -128,7 +128,7 @@ static inline kinc_int16x8_t kinc_int16x8_store(int16_t *destination, kinc_int16
 }
 
 static inline int16_t kinc_int16x8_get(kinc_int16x8_t t, int index) {
-	return vgetq_lane_s16(t, index);
+	return t[index];
 }
 
 static inline kinc_int16x8_t kinc_int16x8_add(kinc_int16x8_t a, kinc_int16x8_t b) {

--- a/Sources/kinc/simd/int16x8.h
+++ b/Sources/kinc/simd/int16x8.h
@@ -12,9 +12,8 @@ extern "C" {
 
 #if defined(KINC_SSE2)
 
-static inline kinc_int16x8_t kinc_int16x8_intrin_load(int16_t const *values)
-{
-	return _mm_load_si128((kinc_int16x8_t const *)values);
+static inline kinc_int16x8_t kinc_int16x8_intrin_load(const int16_t *values) {
+	return _mm_load_si128((const kinc_int16x8_t *)values);
 }
 
 static inline kinc_int16x8_t kinc_int16x8_load(const int16_t values[8]) {
@@ -25,8 +24,7 @@ static inline kinc_int16x8_t kinc_int16x8_load_all(int16_t t) {
 	return _mm_set1_epi16(t);
 }
 
-static inline void kinc_int16x8_store(int16_t *destination, kinc_int16x8_t value)
-{
+static inline void kinc_int16x8_store(int16_t *destination, kinc_int16x8_t value) {
 	_mm_store_si128((kinc_int16x8_t *)destination, value);
 }
 
@@ -103,8 +101,7 @@ static inline kinc_int16x8_t kinc_int16x8_not(kinc_int16x8_t t) {
 
 #elif defined(KINC_NEON)
 
-static inline kinc_int16x8_t kinc_int16x8_intrin_load(int16_t const *values)
-{
+static inline kinc_int16x8_t kinc_int16x8_intrin_load(const int16_t *values) {
 	return vld1q_s16(values);
 }
 
@@ -116,8 +113,7 @@ static inline kinc_int16x8_t kinc_int16x8_load_all(int16_t t) {
 	return (kinc_int16x8_t){t, t, t, t, t, t, t, t};
 }
 
-static inline kinc_int16x8_t kinc_int16x8_store(int16_t *destination, kinc_int16x8_t value)
-{
+static inline kinc_int16x8_t kinc_int16x8_store(int16_t *destination, kinc_int16x8_t value) {
 	vst1q_s16(destination, value);
 }
 
@@ -187,8 +183,7 @@ static inline kinc_int16x8_t kinc_int16x8_not(kinc_int16x8_t t) {
 
 #else
 
-static inline kinc_int16x8_t kinc_int16x8_intrin_load(int16_t const *values)
-{
+static inline kinc_int16x8_t kinc_int16x8_intrin_load(const int16_t *values) {
 	kinc_int16x8_t value;
 	value.values[0] = values[0];
 	value.values[1] = values[1];
@@ -227,8 +222,7 @@ static inline kinc_int16x8_t kinc_int16x8_load_all(int16_t t) {
 	return value;
 }
 
-static inline void kinc_int16x8_store(int16_t *destination, kinc_int16x8_t value)
-{
+static inline void kinc_int16x8_store(int16_t *destination, kinc_int16x8_t value) {
 	destination[0] = value.values[0];
 	destination[1] = value.values[1];
 	destination[2] = value.values[2];

--- a/Sources/kinc/simd/int16x8.h
+++ b/Sources/kinc/simd/int16x8.h
@@ -12,12 +12,22 @@ extern "C" {
 
 #if defined(KINC_SSE2)
 
+static inline kinc_int16x8_t kinc_int16x8_intrin_load(int16_t const *values)
+{
+	return _mm_load_si128((kinc_int16x8_t const *)values);
+}
+
 static inline kinc_int16x8_t kinc_int16x8_load(const int16_t values[8]) {
 	return _mm_set_epi16(values[7], values[6], values[5], values[4], values[3], values[2], values[1], values[0]);
 }
 
 static inline kinc_int16x8_t kinc_int16x8_load_all(int16_t t) {
 	return _mm_set1_epi16(t);
+}
+
+static inline void kinc_int16x8_store(int16_t *destination, kinc_int16x8_t value)
+{
+	_mm_store_si128((kinc_int16x8_t *)destination, value);
 }
 
 static inline int16_t kinc_int16x8_get(kinc_int16x8_t t, int index) {
@@ -93,12 +103,22 @@ static inline kinc_int16x8_t kinc_int16x8_not(kinc_int16x8_t t) {
 
 #elif defined(KINC_NEON)
 
+static inline kinc_int16x8_t kinc_int16x8_intrin_load(int16_t const *values)
+{
+	return vld1q_s16(values);
+}
+
 static inline kinc_int16x8_t kinc_int16x8_load(const int16_t values[8]) {
 	return (kinc_int16x8_t){values[0], values[1], values[2], values[3], values[4], values[5], values[6], values[7]};
 }
 
 static inline kinc_int16x8_t kinc_int16x8_load_all(int16_t t) {
 	return (kinc_int16x8_t){t, t, t, t, t, t, t, t};
+}
+
+static inline kinc_int16x8_t kinc_int16x8_store(int16_t *destination, kinc_int16x8_t value)
+{
+	vst1q_s16(destination, value);
 }
 
 static inline int16_t kinc_int16x8_get(kinc_int16x8_t t, int index) {
@@ -167,6 +187,20 @@ static inline kinc_int16x8_t kinc_int16x8_not(kinc_int16x8_t t) {
 
 #else
 
+static inline kinc_int16x8_t kinc_int16x8_intrin_load(int16_t const *values)
+{
+	kinc_int16x8_t value;
+	value.values[0] = values[0];
+	value.values[1] = values[1];
+	value.values[2] = values[2];
+	value.values[3] = values[3];
+	value.values[4] = values[4];
+	value.values[5] = values[5];
+	value.values[6] = values[6];
+	value.values[7] = values[7];
+	return value;
+}
+
 static inline kinc_int16x8_t kinc_int16x8_load(const int16_t values[8]) {
 	kinc_int16x8_t value;
 	value.values[0] = values[0];
@@ -191,6 +225,18 @@ static inline kinc_int16x8_t kinc_int16x8_load_all(int16_t t) {
 	value.values[6] = t;
 	value.values[7] = t;
 	return value;
+}
+
+static inline void kinc_int16x8_store(int16_t *destination, kinc_int16x8_t value)
+{
+	destination[0] = value.values[0];
+	destination[1] = value.values[1];
+	destination[2] = value.values[2];
+	destination[3] = value.values[3];
+	destination[4] = value.values[4];
+	destination[5] = value.values[5];
+	destination[6] = value.values[6];
+	destination[7] = value.values[7];
 }
 
 static inline int16_t kinc_int16x8_get(kinc_int16x8_t t, int index) {

--- a/Sources/kinc/simd/int16x8.h
+++ b/Sources/kinc/simd/int16x8.h
@@ -225,27 +225,27 @@ static inline kinc_int16x8_t kinc_int16x8_sub(kinc_int16x8_t a, kinc_int16x8_t b
 
 static inline kinc_int16x8_t kinc_int16x8_max(kinc_int16x8_t a, kinc_int16x8_t b) {
 	kinc_int16x8_t value;
-	value.values[0] = kinc_max(a.values[0], b.values[0]);
-	value.values[1] = kinc_max(a.values[1], b.values[1]);
-	value.values[2] = kinc_max(a.values[2], b.values[2]);
-	value.values[3] = kinc_max(a.values[3], b.values[3]);
-	value.values[4] = kinc_max(a.values[4], b.values[4]);
-	value.values[5] = kinc_max(a.values[5], b.values[5]);
-	value.values[6] = kinc_max(a.values[6], b.values[6]);
-	value.values[7] = kinc_max(a.values[7], b.values[7]);
+	value.values[0] = a.values[0] > b.values[0] ? a.values[0] : b.values[0];
+	value.values[1] = a.values[1] > b.values[1] ? a.values[1] : b.values[1];
+	value.values[2] = a.values[2] > b.values[2] ? a.values[2] : b.values[2];
+	value.values[3] = a.values[3] > b.values[3] ? a.values[3] : b.values[3];
+	value.values[4] = a.values[4] > b.values[4] ? a.values[4] : b.values[4];
+	value.values[5] = a.values[5] > b.values[5] ? a.values[5] : b.values[5];
+	value.values[6] = a.values[6] > b.values[6] ? a.values[6] : b.values[6];
+	value.values[7] = a.values[7] > b.values[7] ? a.values[7] : b.values[7];
 	return value;
 }
 
 static inline kinc_int16x8_t kinc_int16x8_min(kinc_int16x8_t a, kinc_int16x8_t b) {
 	kinc_int16x8_t value;
-	value.values[0] = kinc_min(a.values[0], b.values[0]);
-	value.values[1] = kinc_min(a.values[1], b.values[1]);
-	value.values[2] = kinc_min(a.values[2], b.values[2]);
-	value.values[3] = kinc_min(a.values[3], b.values[3]);
-	value.values[4] = kinc_min(a.values[4], b.values[4]);
-	value.values[5] = kinc_min(a.values[5], b.values[5]);
-	value.values[6] = kinc_min(a.values[6], b.values[6]);
-	value.values[7] = kinc_min(a.values[7], b.values[7]);
+	value.values[0] = a.values[0] > b.values[0] ? b.values[0] : a.values[0];
+	value.values[1] = a.values[1] > b.values[1] ? b.values[1] : a.values[1];
+	value.values[2] = a.values[2] > b.values[2] ? b.values[2] : a.values[2];
+	value.values[3] = a.values[3] > b.values[3] ? b.values[3] : a.values[3];
+	value.values[4] = a.values[4] > b.values[4] ? b.values[4] : a.values[4];
+	value.values[5] = a.values[5] > b.values[5] ? b.values[5] : a.values[5];
+	value.values[6] = a.values[6] > b.values[6] ? b.values[6] : a.values[6];
+	value.values[7] = a.values[7] > b.values[7] ? b.values[7] : a.values[7];
 	return value;
 }
 

--- a/Sources/kinc/simd/int16x8.h
+++ b/Sources/kinc/simd/int16x8.h
@@ -106,17 +106,7 @@ static inline kinc_int16x8_t kinc_int16x8_intrin_load(const int16_t *values) {
 }
 
 static inline kinc_int16x8_t kinc_int16x8_load(const int16_t values[8]) {
-	kinc_int16x8_t value = vdupq_n_s16(0);
-	value = vsetq_lane_s16(values[0], value, 0);
-	value = vsetq_lane_s16(values[1], value, 1);
-	value = vsetq_lane_s16(values[2], value, 2);
-	value = vsetq_lane_s16(values[3], value, 3);
-	value = vsetq_lane_s16(values[4], value, 4);
-	value = vsetq_lane_s16(values[5], value, 5);
-	value = vsetq_lane_s16(values[6], value, 6);
-	value = vsetq_lane_s16(values[7], value, 7);
-
-	return value;
+	return (kinc_int16x8_t){values[0], values[1], values[2], values[3], values[4], values[5], values[6], values[7]};
 }
 
 static inline kinc_int16x8_t kinc_int16x8_load_all(int16_t t) {

--- a/Sources/kinc/simd/int16x8.h
+++ b/Sources/kinc/simd/int16x8.h
@@ -123,7 +123,7 @@ static inline kinc_int16x8_t kinc_int16x8_load_all(int16_t t) {
 	return vdupq_n_s16(t);
 }
 
-static inline kinc_int16x8_t kinc_int16x8_store(int16_t *destination, kinc_int16x8_t value) {
+static inline void kinc_int16x8_store(int16_t *destination, kinc_int16x8_t value) {
 	vst1q_s16(destination, value);
 }
 

--- a/Sources/kinc/simd/int16x8.h
+++ b/Sources/kinc/simd/int16x8.h
@@ -118,7 +118,7 @@ static inline kinc_int16x8_t kinc_int16x8_store(int16_t *destination, kinc_int16
 }
 
 static inline int16_t kinc_int16x8_get(kinc_int16x8_t t, int index) {
-	return t[index];
+	return t.n128_i16[index];
 }
 
 static inline kinc_int16x8_t kinc_int16x8_add(kinc_int16x8_t a, kinc_int16x8_t b) {

--- a/Sources/kinc/simd/int16x8.h
+++ b/Sources/kinc/simd/int16x8.h
@@ -106,11 +106,31 @@ static inline kinc_int16x8_t kinc_int16x8_intrin_load(const int16_t *values) {
 }
 
 static inline kinc_int16x8_t kinc_int16x8_load(const int16_t values[8]) {
-	return (kinc_int16x8_t){values[0], values[1], values[2], values[3], values[4], values[5], values[6], values[7]};
+	kinc_int16x8_t value;
+	value.n128_i16[0] = values[0];
+	value.n128_i16[1] = values[1];
+	value.n128_i16[2] = values[2];
+	value.n128_i16[3] = values[3];
+	value.n128_i16[4] = values[4];
+	value.n128_i16[5] = values[5];
+	value.n128_i16[6] = values[6];
+	value.n128_i16[7] = values[7];
+
+	return value;
 }
 
 static inline kinc_int16x8_t kinc_int16x8_load_all(int16_t t) {
-	return (kinc_int16x8_t){t, t, t, t, t, t, t, t};
+	kinc_int16x8_t value;
+	value.n128_i16[0] = t;
+	value.n128_i16[1] = t;
+	value.n128_i16[2] = t;
+	value.n128_i16[3] = t;
+	value.n128_i16[4] = t;
+	value.n128_i16[5] = t;
+	value.n128_i16[6] = t;
+	value.n128_i16[7] = t;
+
+	return value;
 }
 
 static inline kinc_int16x8_t kinc_int16x8_store(int16_t *destination, kinc_int16x8_t value) {

--- a/Sources/kinc/simd/int32x4.h
+++ b/Sources/kinc/simd/int32x4.h
@@ -101,7 +101,7 @@ static inline kinc_int32x4_t kinc_int32x4_not(kinc_int32x4_t t) {
 
 #elif defined(KINC_NEON)
 
-static inline kinc_int32x4_t kinc_int32x4_intrin_load(int32_t const *values) {
+static inline kinc_int32x4_t kinc_int32x4_intrin_load(const int32_t *values) {
 	return vld1q_s32(values);
 }
 

--- a/Sources/kinc/simd/int32x4.h
+++ b/Sources/kinc/simd/int32x4.h
@@ -110,7 +110,7 @@ static inline kinc_int32x4_t kinc_int32x4_load(const int32_t values[4]) {
 }
 
 static inline kinc_int32x4_t kinc_int32x4_load_all(int32_t t) {
-	return vdupq_n_s32(t);
+	return (kinc_int32x4_t){t, t, t, t};
 }
 
 static inline void kinc_int32x4_store(int32_t *destination, kinc_int32x4_t value) {

--- a/Sources/kinc/simd/int32x4.h
+++ b/Sources/kinc/simd/int32x4.h
@@ -124,7 +124,7 @@ static inline void kinc_int32x4_store(int32_t *destination, kinc_int32x4_t value
 }
 
 static inline int32_t kinc_int32x4_get(kinc_int32x4_t t, int index) {
-	return vgetq_lane_s32(t, index);
+	return t[index];
 }
 
 static inline kinc_int32x4_t kinc_int32x4_add(kinc_int32x4_t a, kinc_int32x4_t b) {

--- a/Sources/kinc/simd/int32x4.h
+++ b/Sources/kinc/simd/int32x4.h
@@ -116,13 +116,7 @@ static inline kinc_int32x4_t kinc_int32x4_load(const int32_t values[4]) {
 }
 
 static inline kinc_int32x4_t kinc_int32x4_load_all(int32_t t) {
-	kinc_int32x4_t value;
-	value.n128_i32[0] = t;
-	value.n128_i32[1] = t;
-	value.n128_i32[2] = t;
-	value.n128_i32[3] = t;
-
-	return value;
+	return vdupq_n_s32(t);
 }
 
 static inline void kinc_int32x4_store(int32_t *destination, kinc_int32x4_t value) {

--- a/Sources/kinc/simd/int32x4.h
+++ b/Sources/kinc/simd/int32x4.h
@@ -106,11 +106,11 @@ static inline kinc_int32x4_t kinc_int32x4_intrin_load(const int32_t *values) {
 }
 
 static inline kinc_int32x4_t kinc_int32x4_load(const int32_t values[4]) {
-	kinc_int32x4_t value;
-	value.n128_i32[0] = values[0];
-	value.n128_i32[1] = values[1];
-	value.n128_i32[2] = values[2];
-	value.n128_i32[3] = values[3];
+	kinc_int32x4_t value = vdupq_n_s32(0);
+	value = vsetq_lane_s32(values[0], value, 0);
+	value = vsetq_lane_s32(values[1], value, 1);
+	value = vsetq_lane_s32(values[2], value, 2);
+	value = vsetq_lane_s32(values[3], value, 3);
 
 	return value;
 }

--- a/Sources/kinc/simd/int32x4.h
+++ b/Sources/kinc/simd/int32x4.h
@@ -106,13 +106,7 @@ static inline kinc_int32x4_t kinc_int32x4_intrin_load(const int32_t *values) {
 }
 
 static inline kinc_int32x4_t kinc_int32x4_load(const int32_t values[4]) {
-	kinc_int32x4_t value = vdupq_n_s32(0);
-	value = vsetq_lane_s32(values[0], value, 0);
-	value = vsetq_lane_s32(values[1], value, 1);
-	value = vsetq_lane_s32(values[2], value, 2);
-	value = vsetq_lane_s32(values[3], value, 3);
-
-	return value;
+	return (kinc_int32x4_t){values[0], values[1], values[2], values[3]};
 }
 
 static inline kinc_int32x4_t kinc_int32x4_load_all(int32_t t) {

--- a/Sources/kinc/simd/int32x4.h
+++ b/Sources/kinc/simd/int32x4.h
@@ -124,7 +124,7 @@ static inline void kinc_int32x4_store(int32_t *destination, kinc_int32x4_t value
 }
 
 static inline int32_t kinc_int32x4_get(kinc_int32x4_t t, int index) {
-	return t.n128_i32[index];
+	return vgetq_lane_s32(t, index);
 }
 
 static inline kinc_int32x4_t kinc_int32x4_add(kinc_int32x4_t a, kinc_int32x4_t b) {

--- a/Sources/kinc/simd/int32x4.h
+++ b/Sources/kinc/simd/int32x4.h
@@ -12,9 +12,8 @@ extern "C" {
 
 #if defined(KINC_SSE2)
 
-static inline kinc_int32x4_t kinc_int32x4_intrin_load(int32_t const *values)
-{
-	return _mm_load_si128((kinc_int32x4_t const *)values);
+static inline kinc_int32x4_t kinc_int32x4_intrin_load(const int32_t *values) {
+	return _mm_load_si128((const kinc_int32x4_t *)values);
 }
 
 static inline kinc_int32x4_t kinc_int32x4_load(const int32_t values[4]) {
@@ -25,8 +24,7 @@ static inline kinc_int32x4_t kinc_int32x4_load_all(int32_t t) {
 	return _mm_set1_epi32(t);
 }
 
-static inline void kinc_int32x4_store(int32_t *destination, kinc_int32x4_t value)
-{
+static inline void kinc_int32x4_store(int32_t *destination, kinc_int32x4_t value) {
 	_mm_store_si128((kinc_int32x4_t *)destination, value);
 }
 
@@ -103,8 +101,7 @@ static inline kinc_int32x4_t kinc_int32x4_not(kinc_int32x4_t t) {
 
 #elif defined(KINC_NEON)
 
-static inline kinc_int32x4_t kinc_int32x4_intrin_load(int32_t const *values)
-{
+static inline kinc_int32x4_t kinc_int32x4_intrin_load(int32_t const *values) {
 	return vld1q_s32(values);
 }
 
@@ -116,8 +113,7 @@ static inline kinc_int32x4_t kinc_int32x4_load_all(int32_t t) {
 	return (kinc_int32x4_t){t, t, t, t};
 }
 
-static inline void kinc_int32x4_store(int32_t *destination, kinc_int32x4_t value)
-{
+static inline void kinc_int32x4_store(int32_t *destination, kinc_int32x4_t value) {
 	vst1q_s32(destination, value);
 }
 
@@ -187,8 +183,7 @@ static inline kinc_int32x4_t kinc_int32x4_not(kinc_int32x4_t t) {
 
 #else
 
-static inline kinc_int32x4_t kinc_int32x4_intrin_load(int32_t const *values)
-{
+static inline kinc_int32x4_t kinc_int32x4_intrin_load(const int32_t *values) {
 	kinc_int32x4_t value;
 	value.values[0] = values[0];
 	value.values[1] = values[1];
@@ -215,8 +210,7 @@ static inline kinc_int32x4_t kinc_int32x4_load_all(int32_t t) {
 	return value;
 }
 
-static inline void kinc_int32x4_store(int32_t *destination, kinc_int32x4_t value)
-{
+static inline void kinc_int32x4_store(int32_t *destination, kinc_int32x4_t value) {
 	destination[0] = value.values[0];
 	destination[1] = value.values[1];
 	destination[2] = value.values[2];

--- a/Sources/kinc/simd/int32x4.h
+++ b/Sources/kinc/simd/int32x4.h
@@ -209,19 +209,19 @@ static inline kinc_int32x4_t kinc_int32x4_sub(kinc_int32x4_t a, kinc_int32x4_t b
 
 static inline kinc_int32x4_t kinc_int32x4_max(kinc_int32x4_t a, kinc_int32x4_t b) {
 	kinc_int32x4_t value;
-	value.values[0] = kinc_max(a.values[0], b.values[0]);
-	value.values[1] = kinc_max(a.values[1], b.values[1]);
-	value.values[2] = kinc_max(a.values[2], b.values[2]);
-	value.values[3] = kinc_max(a.values[3], b.values[3]);
+	value.values[0] = a.values[0] > b.values[0] ? a.values[0] : b.values[0];
+	value.values[1] = a.values[1] > b.values[1] ? a.values[1] : b.values[1]; 
+	value.values[2] = a.values[2] > b.values[2] ? a.values[2] : b.values[2]; 
+	value.values[3] = a.values[3] > b.values[3] ? a.values[3] : b.values[3]; 
 	return value;
 }
 
 static inline kinc_int32x4_t kinc_int32x4_min(kinc_int32x4_t a, kinc_int32x4_t b) {
 	kinc_int32x4_t value;
-	value.values[0] = kinc_min(a.values[0], b.values[0]);
-	value.values[1] = kinc_min(a.values[1], b.values[1]);
-	value.values[2] = kinc_min(a.values[2], b.values[2]);
-	value.values[3] = kinc_min(a.values[3], b.values[3]);
+	value.values[0] = a.values[0] > b.values[0] ? b.values[0] : a.values[0];
+	value.values[1] = a.values[1] > b.values[1] ? b.values[1] : a.values[1]; 
+	value.values[2] = a.values[2] > b.values[2] ? b.values[2] : a.values[2]; 
+	value.values[3] = a.values[3] > b.values[3] ? b.values[3] : a.values[3]; 
 	return value;
 }
 

--- a/Sources/kinc/simd/int32x4.h
+++ b/Sources/kinc/simd/int32x4.h
@@ -118,7 +118,7 @@ static inline void kinc_int32x4_store(int32_t *destination, kinc_int32x4_t value
 }
 
 static inline int32_t kinc_int32x4_get(kinc_int32x4_t t, int index) {
-	return t[index];
+	return t.n128_i32[index];
 }
 
 static inline kinc_int32x4_t kinc_int32x4_add(kinc_int32x4_t a, kinc_int32x4_t b) {

--- a/Sources/kinc/simd/int32x4.h
+++ b/Sources/kinc/simd/int32x4.h
@@ -106,11 +106,23 @@ static inline kinc_int32x4_t kinc_int32x4_intrin_load(const int32_t *values) {
 }
 
 static inline kinc_int32x4_t kinc_int32x4_load(const int32_t values[4]) {
-	return (kinc_int32x4_t){values[0], values[1], values[2], values[3]};
+	kinc_int32x4_t value;
+	value.n128_i32[0] = values[0];
+	value.n128_i32[1] = values[1];
+	value.n128_i32[2] = values[2];
+	value.n128_i32[3] = values[3];
+
+	return value;
 }
 
 static inline kinc_int32x4_t kinc_int32x4_load_all(int32_t t) {
-	return (kinc_int32x4_t){t, t, t, t};
+	kinc_int32x4_t value;
+	value.n128_i32[0] = t;
+	value.n128_i32[1] = t;
+	value.n128_i32[2] = t;
+	value.n128_i32[3] = t;
+
+	return value;
 }
 
 static inline void kinc_int32x4_store(int32_t *destination, kinc_int32x4_t value) {

--- a/Sources/kinc/simd/int32x4.h
+++ b/Sources/kinc/simd/int32x4.h
@@ -12,12 +12,22 @@ extern "C" {
 
 #if defined(KINC_SSE2)
 
+static inline kinc_int32x4_t kinc_int32x4_intrin_load(int32_t const *values)
+{
+	return _mm_load_si128((kinc_int32x4_t const *)values);
+}
+
 static inline kinc_int32x4_t kinc_int32x4_load(const int32_t values[4]) {
 	return _mm_set_epi32(values[3], values[2], values[1], values[0]);
 }
 
 static inline kinc_int32x4_t kinc_int32x4_load_all(int32_t t) {
 	return _mm_set1_epi32(t);
+}
+
+static inline void kinc_int32x4_store(int32_t *destination, kinc_int32x4_t value)
+{
+	_mm_store_si128((kinc_int32x4_t *)destination, value);
 }
 
 static inline int32_t kinc_int32x4_get(kinc_int32x4_t t, int index) {
@@ -93,12 +103,22 @@ static inline kinc_int32x4_t kinc_int32x4_not(kinc_int32x4_t t) {
 
 #elif defined(KINC_NEON)
 
+static inline kinc_int32x4_t kinc_int32x4_intrin_load(int32_t const *values)
+{
+	return vld1q_s32(values);
+}
+
 static inline kinc_int32x4_t kinc_int32x4_load(const int32_t values[4]) {
 	return (kinc_int32x4_t){values[0], values[1], values[2], values[3]};
 }
 
 static inline kinc_int32x4_t kinc_int32x4_load_all(int32_t t) {
 	return (kinc_int32x4_t){t, t, t, t};
+}
+
+static inline void kinc_int32x4_store(int32_t *destination, kinc_int32x4_t value)
+{
+	vst1q_s32(destination, value);
 }
 
 static inline int32_t kinc_int32x4_get(kinc_int32x4_t t, int index) {
@@ -167,6 +187,16 @@ static inline kinc_int32x4_t kinc_int32x4_not(kinc_int32x4_t t) {
 
 #else
 
+static inline kinc_int32x4_t kinc_int32x4_intrin_load(int32_t const *values)
+{
+	kinc_int32x4_t value;
+	value.values[0] = values[0];
+	value.values[1] = values[1];
+	value.values[2] = values[2];
+	value.values[3] = values[3];
+	return value;
+}
+
 static inline kinc_int32x4_t kinc_int32x4_load(const int32_t values[4]) {
 	kinc_int32x4_t value;
 	value.values[0] = values[0];
@@ -183,6 +213,14 @@ static inline kinc_int32x4_t kinc_int32x4_load_all(int32_t t) {
 	value.values[2] = t;
 	value.values[3] = t;
 	return value;
+}
+
+static inline void kinc_int32x4_store(int32_t *destination, kinc_int32x4_t value)
+{
+	destination[0] = value.values[0];
+	destination[1] = value.values[1];
+	destination[2] = value.values[2];
+	destination[3] = value.values[3];
 }
 
 static inline int32_t kinc_int32x4_get(kinc_int32x4_t t, int index) {

--- a/Sources/kinc/simd/int8x16.h
+++ b/Sources/kinc/simd/int8x16.h
@@ -123,7 +123,7 @@ static inline void kinc_int8x16_store(int8_t *destination, kinc_int8x16_t value)
 }
 
 static inline int8_t kinc_int8x16_get(kinc_int8x16_t t, int index) {
-	return t[index];
+	return t.n128_i8[index];
 }
 
 static inline kinc_int8x16_t kinc_int8x16_add(kinc_int8x16_t a, kinc_int8x16_t b) {

--- a/Sources/kinc/simd/int8x16.h
+++ b/Sources/kinc/simd/int8x16.h
@@ -262,43 +262,43 @@ static inline kinc_int8x16_t kinc_int8x16_sub(kinc_int8x16_t a, kinc_int8x16_t b
 
 static inline kinc_int8x16_t kinc_int8x16_max(kinc_int8x16_t a, kinc_int8x16_t b) {
 	kinc_int8x16_t value;
-	value.values[0] = kinc_max(a.values[0], b.values[0]);
-	value.values[1] = kinc_max(a.values[1], b.values[1]);
-	value.values[2] = kinc_max(a.values[2], b.values[2]);
-	value.values[3] = kinc_max(a.values[3], b.values[3]);
-	value.values[4] = kinc_max(a.values[4], b.values[4]);
-	value.values[5] = kinc_max(a.values[5], b.values[5]);
-	value.values[6] = kinc_max(a.values[6], b.values[6]);
-	value.values[7] = kinc_max(a.values[7], b.values[7]);
-	value.values[8] = kinc_max(a.values[8], b.values[8]);
-	value.values[9] = kinc_max(a.values[9], b.values[9]);
-	value.values[10] = kinc_max(a.values[10], b.values[10]);
-	value.values[11] = kinc_max(a.values[11], b.values[11]);
-	value.values[12] = kinc_max(a.values[12], b.values[12]);
-	value.values[13] = kinc_max(a.values[13], b.values[13]);
-	value.values[14] = kinc_max(a.values[14], b.values[14]);
-	value.values[15] = kinc_max(a.values[15], b.values[15]);
+	value.values[0] =  a.values[0] > b.values[0] ? a.values[0] : b.values[0];
+	value.values[1] =  a.values[1] > b.values[1] ? a.values[1] : b.values[1];
+	value.values[2] =  a.values[2] > b.values[2] ? a.values[2] : b.values[2];
+	value.values[3] =  a.values[3] > b.values[3] ? a.values[3] : b.values[3];
+	value.values[4] =  a.values[4] > b.values[4] ? a.values[4] : b.values[4];
+	value.values[5] =  a.values[5] > b.values[5] ? a.values[5] : b.values[5];
+	value.values[6] =  a.values[6] > b.values[6] ? a.values[6] : b.values[6];
+	value.values[7] =  a.values[7] > b.values[7] ? a.values[7] : b.values[7];
+	value.values[8] =  a.values[8] > b.values[8] ? a.values[8] : b.values[8];
+	value.values[9] =  a.values[9] > b.values[9] ? a.values[9] : b.values[9];
+	value.values[10] = a.values[10] > b.values[10] ? a.values[10] : b.values[10];
+	value.values[11] = a.values[11] > b.values[11] ? a.values[11] : b.values[11];
+	value.values[12] = a.values[12] > b.values[12] ? a.values[12] : b.values[12];
+	value.values[13] = a.values[13] > b.values[13] ? a.values[13] : b.values[13];
+	value.values[14] = a.values[14] > b.values[14] ? a.values[14] : b.values[14];
+	value.values[15] = a.values[15] > b.values[15] ? a.values[15] : b.values[15];
 	return value;
 }
 
 static inline kinc_int8x16_t kinc_int8x16_min(kinc_int8x16_t a, kinc_int8x16_t b) {
 	kinc_int8x16_t value;
-	value.values[0] = kinc_min(a.values[0], b.values[0]);
-	value.values[1] = kinc_min(a.values[1], b.values[1]);
-	value.values[2] = kinc_min(a.values[2], b.values[2]);
-	value.values[3] = kinc_min(a.values[3], b.values[3]);
-	value.values[4] = kinc_min(a.values[4], b.values[4]);
-	value.values[5] = kinc_min(a.values[5], b.values[5]);
-	value.values[6] = kinc_min(a.values[6], b.values[6]);
-	value.values[7] = kinc_min(a.values[7], b.values[7]);
-	value.values[8] = kinc_min(a.values[8], b.values[8]);
-	value.values[9] = kinc_min(a.values[9], b.values[9]);
-	value.values[10] = kinc_min(a.values[10], b.values[10]);
-	value.values[11] = kinc_min(a.values[11], b.values[11]);
-	value.values[12] = kinc_min(a.values[12], b.values[12]);
-	value.values[13] = kinc_min(a.values[13], b.values[13]);
-	value.values[14] = kinc_min(a.values[14], b.values[14]);
-	value.values[15] = kinc_min(a.values[15], b.values[15]);
+	value.values[0] =  a.values[0] > b.values[0] ? b.values[0] : a.values[0];
+	value.values[1] =  a.values[1] > b.values[1] ? b.values[1] : a.values[1];
+	value.values[2] =  a.values[2] > b.values[2] ? b.values[2] : a.values[2];
+	value.values[3] =  a.values[3] > b.values[3] ? b.values[3] : a.values[3];
+	value.values[4] =  a.values[4] > b.values[4] ? b.values[4] : a.values[4];
+	value.values[5] =  a.values[5] > b.values[5] ? b.values[5] : a.values[5];
+	value.values[6] =  a.values[6] > b.values[6] ? b.values[6] : a.values[6];
+	value.values[7] =  a.values[7] > b.values[7] ? b.values[7] : a.values[7];
+	value.values[8] =  a.values[8] > b.values[8] ? b.values[8] : a.values[8];
+	value.values[9] =  a.values[9] > b.values[9] ? b.values[9] : a.values[9];
+	value.values[10] = a.values[10] > b.values[10] ? b.values[10] : a.values[10];
+	value.values[11] = a.values[11] > b.values[11] ? b.values[11] : a.values[11];
+	value.values[12] = a.values[12] > b.values[12] ? b.values[12] : a.values[12];
+	value.values[13] = a.values[13] > b.values[13] ? b.values[13] : a.values[13];
+	value.values[14] = a.values[14] > b.values[14] ? b.values[14] : a.values[14];
+	value.values[15] = a.values[15] > b.values[15] ? b.values[15] : a.values[15];
 	return value;
 }
 

--- a/Sources/kinc/simd/int8x16.h
+++ b/Sources/kinc/simd/int8x16.h
@@ -12,9 +12,8 @@ extern "C" {
 
 #if defined(KINC_SSE2)
 
-static inline kinc_int8x16_t kinc_int8x16_intrin_load(int8_t const *values)
-{
-	return _mm_load_si128((kinc_int8x16_t const *)values);
+static inline kinc_int8x16_t kinc_int8x16_intrin_load(const int8_t *values) {
+	return _mm_load_si128((const kinc_int8x16_t *)values);
 }
 
 static inline kinc_int8x16_t kinc_int8x16_load(const int8_t values[16]) {
@@ -26,8 +25,7 @@ static inline kinc_int8x16_t kinc_int8x16_load_all(int8_t t) {
 	return _mm_set1_epi8(t);
 }
 
-static inline void kinc_int8x16_store(int8_t *destination, kinc_int8x16_t value)
-{
+static inline void kinc_int8x16_store(int8_t *destination, kinc_int8x16_t value) {
 	_mm_store_si128((kinc_int8x16_t *)destination, value);
 }
 
@@ -107,8 +105,7 @@ static inline kinc_int8x16_t kinc_int8x16_not(kinc_int8x16_t t) {
 
 #elif defined(KINC_NEON)
 
-static inline kinc_int8x16_t kinc_int8x16_intrin_load(int8_t const *values)
-{
+static inline kinc_int8x16_t kinc_int8x16_intrin_load(const int8_t *values) {
 	return vld1q_s8(values);
 }
 
@@ -121,8 +118,7 @@ static inline kinc_int8x16_t kinc_int8x16_load_all(int8_t t) {
 	return (kinc_int8x16_t){t, t, t, t, t, t, t, t, t, t, t, t, t, t, t, t};
 }
 
-static inline kinc_int8x16_t kinc_int8x16_store(int8_t *destination, kinc_int8x16_t value)
-{
+static inline kinc_int8x16_t kinc_int8x16_store(int8_t *destination, kinc_int8x16_t value) {
 	vst1q_s8(destination, value);
 }
 
@@ -192,8 +188,7 @@ static inline kinc_int8x16_t kinc_int8x16_not(kinc_int8x16_t t) {
 
 #else
 
-static inline kinc_int8x16_t kinc_int8x16_intrin_load(int8_t const *values)
-{
+static inline kinc_int8x16_t kinc_int8x16_intrin_load(const int8_t *values) {
 	kinc_int8x16_t value;
 	value.values[0] = values[0];
 	value.values[1] = values[1];
@@ -256,8 +251,7 @@ static inline kinc_int8x16_t kinc_int8x16_load_all(int8_t t) {
 	return value;
 }
 
-static inline void kinc_int8x16_store(int8_t *destination, kinc_int8x16_t value)
-{
+static inline void kinc_int8x16_store(int8_t *destination, kinc_int8x16_t value) {
 	destination[0] = value.values[0];
 	destination[1] = value.values[1];
 	destination[2] = value.values[2];

--- a/Sources/kinc/simd/int8x16.h
+++ b/Sources/kinc/simd/int8x16.h
@@ -110,12 +110,47 @@ static inline kinc_int8x16_t kinc_int8x16_intrin_load(const int8_t *values) {
 }
 
 static inline kinc_int8x16_t kinc_int8x16_load(const int8_t values[16]) {
-	return (kinc_int8x16_t){values[0], values[1], values[2],  values[3],  values[4],  values[5],  values[6],  values[7],
-	                        values[8], values[9], values[10], values[11], values[12], values[13], values[14], values[15]};
+	kinc_int8x16_t value;
+	value.n128_i8[0] = values[0];
+	value.n128_i8[1] = values[1];
+	value.n128_i8[2] = values[2];
+	value.n128_i8[3] = values[3];
+	value.n128_i8[4] = values[4];
+	value.n128_i8[5] = values[5];
+	value.n128_i8[6] = values[6];
+	value.n128_i8[7] = values[7];
+	value.n128_i8[8] = values[8];
+	value.n128_i8[9] = values[9];
+	value.n128_i8[10] = values[10];
+	value.n128_i8[11] = values[11];
+	value.n128_i8[12] = values[12];
+	value.n128_i8[13] = values[13];
+	value.n128_i8[14] = values[14];
+	value.n128_i8[15] = values[15];
+	
+	return value;
 }
 
 static inline kinc_int8x16_t kinc_int8x16_load_all(int8_t t) {
-	return (kinc_int8x16_t){t, t, t, t, t, t, t, t, t, t, t, t, t, t, t, t};
+	kinc_int8x16_t value;
+	value.n128_i8[0] = t;
+	value.n128_i8[1] = t;
+	value.n128_i8[2] = t;
+	value.n128_i8[3] = t;
+	value.n128_i8[4] = t;
+	value.n128_i8[5] = t;
+	value.n128_i8[6] = t;
+	value.n128_i8[7] = t;
+	value.n128_i8[8] = t;
+	value.n128_i8[9] = t;
+	value.n128_i8[10] = t;
+	value.n128_i8[11] = t;
+	value.n128_i8[12] = t;
+	value.n128_i8[13] = t;
+	value.n128_i8[14] = t;
+	value.n128_i8[15] = t;
+	
+	return value;
 }
 
 static inline void kinc_int8x16_store(int8_t *destination, kinc_int8x16_t value) {

--- a/Sources/kinc/simd/int8x16.h
+++ b/Sources/kinc/simd/int8x16.h
@@ -118,7 +118,7 @@ static inline kinc_int8x16_t kinc_int8x16_load_all(int8_t t) {
 	return (kinc_int8x16_t){t, t, t, t, t, t, t, t, t, t, t, t, t, t, t, t};
 }
 
-static inline kinc_int8x16_t kinc_int8x16_store(int8_t *destination, kinc_int8x16_t value) {
+static inline void kinc_int8x16_store(int8_t *destination, kinc_int8x16_t value) {
 	vst1q_s8(destination, value);
 }
 

--- a/Sources/kinc/simd/int8x16.h
+++ b/Sources/kinc/simd/int8x16.h
@@ -110,23 +110,23 @@ static inline kinc_int8x16_t kinc_int8x16_intrin_load(const int8_t *values) {
 }
 
 static inline kinc_int8x16_t kinc_int8x16_load(const int8_t values[16]) {
-	kinc_int8x16_t value;
-	value.n128_i8[0] = values[0];
-	value.n128_i8[1] = values[1];
-	value.n128_i8[2] = values[2];
-	value.n128_i8[3] = values[3];
-	value.n128_i8[4] = values[4];
-	value.n128_i8[5] = values[5];
-	value.n128_i8[6] = values[6];
-	value.n128_i8[7] = values[7];
-	value.n128_i8[8] = values[8];
-	value.n128_i8[9] = values[9];
-	value.n128_i8[10] = values[10];
-	value.n128_i8[11] = values[11];
-	value.n128_i8[12] = values[12];
-	value.n128_i8[13] = values[13];
-	value.n128_i8[14] = values[14];
-	value.n128_i8[15] = values[15];
+	kinc_int8x16_t value = vdupq_n_s8(0);
+	value = vsetq_lane_s8(values[0], value, 0);
+	value = vsetq_lane_s8(values[1], value, 1);
+	value = vsetq_lane_s8(values[2], value, 2);
+	value = vsetq_lane_s8(values[3], value, 3);
+	value = vsetq_lane_s8(values[4], value, 4);
+	value = vsetq_lane_s8(values[5], value, 5);
+	value = vsetq_lane_s8(values[6], value, 6);
+	value = vsetq_lane_s8(values[7], value, 7);
+	value = vsetq_lane_s8(values[8], value, 8);
+	value = vsetq_lane_s8(values[9], value, 9);
+	value = vsetq_lane_s8(values[10], value, 10);
+	value = vsetq_lane_s8(values[11], value, 11);
+	value = vsetq_lane_s8(values[12], value, 12);
+	value = vsetq_lane_s8(values[13], value, 13);
+	value = vsetq_lane_s8(values[14], value, 14);
+	value = vsetq_lane_s8(values[15], value, 15);
 	
 	return value;
 }

--- a/Sources/kinc/simd/int8x16.h
+++ b/Sources/kinc/simd/int8x16.h
@@ -115,7 +115,7 @@ static inline kinc_int8x16_t kinc_int8x16_load(const int8_t values[16]) {
 }
 
 static inline kinc_int8x16_t kinc_int8x16_load_all(int8_t t) {
-	return vdupq_n_s8(t);
+	return (kinc_int8x16_t){t, t, t, t, t, t, t, t, t, t, t, t, t, t, t, t};
 }
 
 static inline void kinc_int8x16_store(int8_t *destination, kinc_int8x16_t value) {

--- a/Sources/kinc/simd/int8x16.h
+++ b/Sources/kinc/simd/int8x16.h
@@ -110,25 +110,8 @@ static inline kinc_int8x16_t kinc_int8x16_intrin_load(const int8_t *values) {
 }
 
 static inline kinc_int8x16_t kinc_int8x16_load(const int8_t values[16]) {
-	kinc_int8x16_t value = vdupq_n_s8(0);
-	value = vsetq_lane_s8(values[0], value, 0);
-	value = vsetq_lane_s8(values[1], value, 1);
-	value = vsetq_lane_s8(values[2], value, 2);
-	value = vsetq_lane_s8(values[3], value, 3);
-	value = vsetq_lane_s8(values[4], value, 4);
-	value = vsetq_lane_s8(values[5], value, 5);
-	value = vsetq_lane_s8(values[6], value, 6);
-	value = vsetq_lane_s8(values[7], value, 7);
-	value = vsetq_lane_s8(values[8], value, 8);
-	value = vsetq_lane_s8(values[9], value, 9);
-	value = vsetq_lane_s8(values[10], value, 10);
-	value = vsetq_lane_s8(values[11], value, 11);
-	value = vsetq_lane_s8(values[12], value, 12);
-	value = vsetq_lane_s8(values[13], value, 13);
-	value = vsetq_lane_s8(values[14], value, 14);
-	value = vsetq_lane_s8(values[15], value, 15);
-	
-	return value;
+	return (kinc_int8x16_t){values[0], values[1], values[2],  values[3],  values[4],  values[5],  values[6],  values[7],
+	                        values[8], values[9], values[10], values[11], values[12], values[13], values[14], values[15]};
 }
 
 static inline kinc_int8x16_t kinc_int8x16_load_all(int8_t t) {

--- a/Sources/kinc/simd/int8x16.h
+++ b/Sources/kinc/simd/int8x16.h
@@ -12,6 +12,11 @@ extern "C" {
 
 #if defined(KINC_SSE2)
 
+static inline kinc_int8x16_t kinc_int8x16_intrin_load(int8_t const *values)
+{
+	return _mm_load_si128((kinc_int8x16_t const *)values);
+}
+
 static inline kinc_int8x16_t kinc_int8x16_load(const int8_t values[16]) {
 	return _mm_set_epi8(values[15], values[14], values[13], values[12], values[11], values[10], values[9], values[8], values[7], values[6], values[5],
 	                    values[4], values[3], values[2], values[1], values[0]);
@@ -19,6 +24,11 @@ static inline kinc_int8x16_t kinc_int8x16_load(const int8_t values[16]) {
 
 static inline kinc_int8x16_t kinc_int8x16_load_all(int8_t t) {
 	return _mm_set1_epi8(t);
+}
+
+static inline void kinc_int8x16_store(int8_t *destination, kinc_int8x16_t value)
+{
+	_mm_store_si128((kinc_int8x16_t *)destination, value);
 }
 
 static inline int8_t kinc_int8x16_get(kinc_int8x16_t t, int index) {
@@ -97,6 +107,11 @@ static inline kinc_int8x16_t kinc_int8x16_not(kinc_int8x16_t t) {
 
 #elif defined(KINC_NEON)
 
+static inline kinc_int8x16_t kinc_int8x16_intrin_load(int8_t const *values)
+{
+	return vld1q_s8(values);
+}
+
 static inline kinc_int8x16_t kinc_int8x16_load(const int8_t values[16]) {
 	return (kinc_int8x16_t){values[0], values[1], values[2],  values[3],  values[4],  values[5],  values[6],  values[7],
 	                        values[8], values[9], values[10], values[11], values[12], values[13], values[14], values[15]};
@@ -104,6 +119,11 @@ static inline kinc_int8x16_t kinc_int8x16_load(const int8_t values[16]) {
 
 static inline kinc_int8x16_t kinc_int8x16_load_all(int8_t t) {
 	return (kinc_int8x16_t){t, t, t, t, t, t, t, t, t, t, t, t, t, t, t, t};
+}
+
+static inline kinc_int8x16_t kinc_int8x16_store(int8_t *destination, kinc_int8x16_t value)
+{
+	vst1q_s8(destination, value);
 }
 
 static inline int8_t kinc_int8x16_get(kinc_int8x16_t t, int index) {
@@ -172,6 +192,28 @@ static inline kinc_int8x16_t kinc_int8x16_not(kinc_int8x16_t t) {
 
 #else
 
+static inline kinc_int8x16_t kinc_int8x16_intrin_load(int8_t const *values)
+{
+	kinc_int8x16_t value;
+	value.values[0] = values[0];
+	value.values[1] = values[1];
+	value.values[2] = values[2];
+	value.values[3] = values[3];
+	value.values[4] = values[4];
+	value.values[5] = values[5];
+	value.values[6] = values[6];
+	value.values[7] = values[7];
+	value.values[8] = values[8];
+	value.values[9] = values[9];
+	value.values[10] = values[10];
+	value.values[11] = values[11];
+	value.values[12] = values[12];
+	value.values[13] = values[13];
+	value.values[14] = values[14];
+	value.values[15] = values[15];
+	return value;
+}
+
 static inline kinc_int8x16_t kinc_int8x16_load(const int8_t values[16]) {
 	kinc_int8x16_t value;
 	value.values[0] = values[0];
@@ -212,6 +254,26 @@ static inline kinc_int8x16_t kinc_int8x16_load_all(int8_t t) {
 	value.values[14] = t;
 	value.values[15] = t;
 	return value;
+}
+
+static inline void kinc_int8x16_store(int8_t *destination, kinc_int8x16_t value)
+{
+	destination[0] = value.values[0];
+	destination[1] = value.values[1];
+	destination[2] = value.values[2];
+	destination[3] = value.values[3];
+	destination[4] = value.values[4];
+	destination[5] = value.values[5];
+	destination[6] = value.values[6];
+	destination[7] = value.values[7];
+	destination[8] = value.values[8];
+	destination[9] = value.values[9];
+	destination[10] = value.values[10];
+	destination[11] = value.values[11];
+	destination[12] = value.values[12];
+	destination[13] = value.values[13];
+	destination[14] = value.values[14];
+	destination[15] = value.values[15];
 }
 
 static inline int8_t kinc_int8x16_get(kinc_int8x16_t t, int index) {

--- a/Sources/kinc/simd/int8x16.h
+++ b/Sources/kinc/simd/int8x16.h
@@ -132,25 +132,7 @@ static inline kinc_int8x16_t kinc_int8x16_load(const int8_t values[16]) {
 }
 
 static inline kinc_int8x16_t kinc_int8x16_load_all(int8_t t) {
-	kinc_int8x16_t value;
-	value.n128_i8[0] = t;
-	value.n128_i8[1] = t;
-	value.n128_i8[2] = t;
-	value.n128_i8[3] = t;
-	value.n128_i8[4] = t;
-	value.n128_i8[5] = t;
-	value.n128_i8[6] = t;
-	value.n128_i8[7] = t;
-	value.n128_i8[8] = t;
-	value.n128_i8[9] = t;
-	value.n128_i8[10] = t;
-	value.n128_i8[11] = t;
-	value.n128_i8[12] = t;
-	value.n128_i8[13] = t;
-	value.n128_i8[14] = t;
-	value.n128_i8[15] = t;
-	
-	return value;
+	return vdupq_n_s8(t);
 }
 
 static inline void kinc_int8x16_store(int8_t *destination, kinc_int8x16_t value) {

--- a/Sources/kinc/simd/int8x16.h
+++ b/Sources/kinc/simd/int8x16.h
@@ -140,7 +140,7 @@ static inline void kinc_int8x16_store(int8_t *destination, kinc_int8x16_t value)
 }
 
 static inline int8_t kinc_int8x16_get(kinc_int8x16_t t, int index) {
-	return vgetq_lane_s8(t, index);
+	return t[index];
 }
 
 static inline kinc_int8x16_t kinc_int8x16_add(kinc_int8x16_t a, kinc_int8x16_t b) {

--- a/Sources/kinc/simd/int8x16.h
+++ b/Sources/kinc/simd/int8x16.h
@@ -140,7 +140,7 @@ static inline void kinc_int8x16_store(int8_t *destination, kinc_int8x16_t value)
 }
 
 static inline int8_t kinc_int8x16_get(kinc_int8x16_t t, int index) {
-	return t.n128_i8[index];
+	return vgetq_lane_s8(t, index);
 }
 
 static inline kinc_int8x16_t kinc_int8x16_add(kinc_int8x16_t a, kinc_int8x16_t b) {

--- a/Sources/kinc/simd/types.h
+++ b/Sources/kinc/simd/types.h
@@ -10,117 +10,208 @@
 extern "C" {
 #endif
 
+//Any level of AVX Capability (Could be AVX, AVX2, AVX512, etc.)
+//(Currently) only used for checking existence of earlier SSE instruction sets
+#if defined(__AVX__)
+	//Unfortunate situation here
+	//MSVC does not provide compiletime macros for the following instruction sets
+	//but their existence is implied by AVX and higher
+	#define KINC_SSE4_2
+	#define KINC_SSE4_1
+	#define KINC_SSSE3
+	#define KINC_SSE3
+#endif
+
+//SSE2 Capability check
+//Note for Windows:
+//	_M_IX86_FP checks SSE2 and SSE for 32bit Windows programs only, and is unset if not a 32bit program.
+//	SSE2 and earlier is --guaranteed-- to be active for any 64bit Windows program
+#if defined(__SSE2__) || (_M_IX86_FP == 2) || ( defined(KORE_WINDOWS) && defined(KORE_64) )
+	#define KINC_SSE2
+#endif
+
+//SSE Capability check
 #if defined(__SSE__) || _M_IX86_FP == 2 || _M_IX86_FP == 1 || (defined(KORE_WINDOWS) && !defined(__aarch64__)) ||                                              \
     (defined(KORE_WINDOWSAPP) && !defined(__aarch64__)) || (defined(KORE_MACOS) && __x86_64)
 
-#include <xmmintrin.h>
-
-typedef __m128 kinc_float32x4_t;
-typedef __m128 kinc_float32x4_mask_t;
-
-#define KINC_SSE
-#if defined(__SSE2__) || _M_IX86_FP == 2
-#define KINC_SSE2
-typedef __m128i kinc_int8x16_t;
-typedef __m128i kinc_int8x16_mask_t;
-typedef __m128i kinc_uint8x16_t;
-typedef __m128i kinc_uint8x16_mask_t;
-typedef __m128i kinc_int16x8_t;
-typedef __m128i kinc_int16x8_mask_t;
-typedef __m128i kinc_uint16x8_t;
-typedef __m128i kinc_uint16x8_mask_t;
-typedef __m128i kinc_int32x4_t;
-typedef __m128i kinc_int32x4_mask_t;
-typedef __m128i kinc_uint32x4_t;
-typedef __m128i kinc_uint32x4_mask_t;
+	#define KINC_SSE
 #endif
 
-#elif defined(KORE_IOS) || defined(KORE_SWITCH) || defined(__aarch64__) || defined(KORE_NEON)
+//NEON Capability check
+#if defined(KORE_IOS) || defined(KORE_SWITCH) || defined(__aarch64__) || defined(KORE_NEON)
+	#define KINC_NEON
+#endif
 
-#define KINC_NEON
-#include <arm_neon.h>
+//No SIMD Capabilities
+#if !defined(KINC_AVX) && !defined(KINC_SSE) && !defined(KINC_SSE2) && !defined(KINC_NEON)
+	#define KINC_NOSIMD
+#endif
 
-typedef float32x4_t kinc_float32x4_t;
-typedef uint32x4_t kinc_float32x4_mask_t;
-typedef int8x16_t kinc_int8x16_t;
-typedef uint8x16_t kinc_int8x16_mask_t;
-typedef uint8x16_t kinc_uint8x16_t;
-typedef uint8x16_t kinc_uint8x16_mask_t;
-typedef int16x8_t kinc_int16x8_t;
-typedef uint16x8_t kinc_int16x8_mask_t;
-typedef uint16x8_t kinc_uint16x8_t;
-typedef uint16x8_t kinc_uint16x8_mask_t;
-typedef int32x4_t kinc_int32x4_t;
-typedef uint32x4_t kinc_int32x4_mask_t;
-typedef uint32x4_t kinc_uint32x4_t;
-typedef uint32x4_t kinc_uint32x4_mask_t;
 
-#else
 
-#define KINC_NOSIMD
-#include <kinc/math/core.h>
 
-typedef struct kinc_float32x4 {
-	float values[4];
-} kinc_float32x4_t;
+#if defined(KINC_SSE2)
 
-typedef struct kinc_float32x4_mask {
-	int values[4];
-} kinc_float32x4_mask_t;
+	//SSE_## related headers include earlier revisions, IE
+	//SSE2 contains all of SSE
+	#include <emmintrin.h>
+
+	typedef __m128 kinc_float32x4_t;
+	typedef __m128 kinc_float32x4_mask_t;
+
+	typedef __m128i kinc_int8x16_t;
+	typedef __m128i kinc_int8x16_mask_t;
+	typedef __m128i kinc_uint8x16_t;
+	typedef __m128i kinc_uint8x16_mask_t;
+	typedef __m128i kinc_int16x8_t;
+	typedef __m128i kinc_int16x8_mask_t;
+	typedef __m128i kinc_uint16x8_t;
+	typedef __m128i kinc_uint16x8_mask_t;
+	typedef __m128i kinc_int32x4_t;
+	typedef __m128i kinc_int32x4_mask_t;
+	typedef __m128i kinc_uint32x4_t;
+	typedef __m128i kinc_uint32x4_mask_t;
+
+#elif defined(KINC_SSE)
+
+	#include <xmmintrin.h>
+
+	typedef __m128 kinc_float32x4_t;
+	typedef __m128 kinc_float32x4_mask_t;
+
+	typedef struct kinc_int8x16 {
+		int8_t values[16];
+	} kinc_int8x16_t;
+
+	typedef struct kinc_int8x16_mask {
+		uint8_t values[16];
+	} kinc_int8x16_mask_t;
+
+	typedef struct kinc_uint8x16 {
+		uint8_t values[16];
+	} kinc_uint8x16_t;
+
+	typedef struct kinc_uint8x16_mask {
+		uint8_t values[16];
+	} kinc_uint8x16_mask_t;
+
+	typedef struct kinc_int16x8 {
+		int16_t values[8];
+	} kinc_int16x8_t;
+
+	typedef struct kinc_int16x8_mask {
+		int16_t values[8];
+	} kinc_int16x8_mask_t;
+
+	typedef struct kinc_uint16x8 {
+		uint16_t values[8];
+	} kinc_uint16x8_t;
+
+	typedef struct kinc_uint16x8_mask {
+		uint16_t values[8];
+	} kinc_uint16x8_mask_t;
+
+	typedef struct kinc_int32x4 {
+		int32_t values[4];
+	} kinc_int32x4_t;
+
+	typedef struct kinc_int32x4_mask {
+		int32_t values[4];
+	} kinc_int32x4_mask_t;
+
+	typedef struct kinc_uint32x4 {
+		uint32_t values[4];
+	} kinc_uint32x4_t;
+
+	typedef struct kinc_uint32x4_mask {
+		uint32_t values[4];
+	} kinc_uint32x4_mask_t;
+
+#elif defined(KINC_NEON)
+
+	#include <arm_neon.h>
+
+	typedef float32x4_t kinc_float32x4_t;
+	typedef uint32x4_t kinc_float32x4_mask_t;
+
+	typedef int8x16_t kinc_int8x16_t;
+	typedef uint8x16_t kinc_int8x16_mask_t;
+	typedef uint8x16_t kinc_uint8x16_t;
+	typedef uint8x16_t kinc_uint8x16_mask_t;
+	typedef int16x8_t kinc_int16x8_t;
+	typedef uint16x8_t kinc_int16x8_mask_t;
+	typedef uint16x8_t kinc_uint16x8_t;
+	typedef uint16x8_t kinc_uint16x8_mask_t;
+	typedef int32x4_t kinc_int32x4_t;
+	typedef uint32x4_t kinc_int32x4_mask_t;
+	typedef uint32x4_t kinc_uint32x4_t;
+	typedef uint32x4_t kinc_uint32x4_mask_t;
+
+#elif defined(KINC_NOSIMD)
+
+	#include <kinc/math/core.h>
+
+	typedef struct kinc_float32x4 {
+		float values[4];
+	} kinc_float32x4_t;
+
+	typedef struct kinc_float32x4_mask {
+		int values[4];
+	} kinc_float32x4_mask_t;
+
+
+
+	typedef struct kinc_int8x16 {
+		int8_t values[16];
+	} kinc_int8x16_t;
+
+	typedef struct kinc_int8x16_mask {
+		uint8_t values[16];
+	} kinc_int8x16_mask_t;
+
+	typedef struct kinc_uint8x16 {
+		uint8_t values[16];
+	} kinc_uint8x16_t;
+
+	typedef struct kinc_uint8x16_mask {
+		uint8_t values[16];
+	} kinc_uint8x16_mask_t;
+
+	typedef struct kinc_int16x8 {
+		int16_t values[8];
+	} kinc_int16x8_t;
+
+	typedef struct kinc_int16x8_mask {
+		int16_t values[8];
+	} kinc_int16x8_mask_t;
+
+	typedef struct kinc_uint16x8 {
+		uint16_t values[8];
+	} kinc_uint16x8_t;
+
+	typedef struct kinc_uint16x8_mask {
+		uint16_t values[8];
+	} kinc_uint16x8_mask_t;
+
+	typedef struct kinc_int32x4 {
+		int32_t values[4];
+	} kinc_int32x4_t;
+
+	typedef struct kinc_int32x4_mask {
+		int32_t values[4];
+	} kinc_int32x4_mask_t;
+
+	typedef struct kinc_uint32x4 {
+		uint32_t values[4];
+	} kinc_uint32x4_t;
+
+	typedef struct kinc_uint32x4_mask {
+		uint32_t values[4];
+	} kinc_uint32x4_mask_t;
 
 #endif
 
-#if (defined(KINC_SSE) && !defined(KINC_SSE2)) || defined(KINC_NOSIMD)
 
-typedef struct kinc_int8x16 {
-	int8_t values[16];
-} kinc_int8x16_t;
-
-typedef struct kinc_int8x16_mask {
-	uint8_t values[16];
-} kinc_int8x16_mask_t;
-
-typedef struct kinc_uint8x16 {
-	uint8_t values[16];
-} kinc_uint8x16_t;
-
-typedef struct kinc_uint8x16_mask {
-	uint8_t values[16];
-} kinc_uint8x16_mask_t;
-
-typedef struct kinc_int16x8 {
-	int16_t values[8];
-} kinc_int16x8_t;
-
-typedef struct kinc_int16x8_mask {
-	int16_t values[8];
-} kinc_int16x8_mask_t;
-
-typedef struct kinc_uint16x8 {
-	uint16_t values[8];
-} kinc_uint16x8_t;
-
-typedef struct kinc_uint16x8_mask {
-	uint16_t values[8];
-} kinc_uint16x8_mask_t;
-
-typedef struct kinc_int32x4 {
-	int32_t values[4];
-} kinc_int32x4_t;
-
-typedef struct kinc_int32x4_mask {
-	int32_t values[4];
-} kinc_int32x4_mask_t;
-
-typedef struct kinc_uint32x4 {
-	uint32_t values[4];
-} kinc_uint32x4_t;
-
-typedef struct kinc_uint32x4_mask {
-	uint32_t values[4];
-} kinc_uint32x4_mask_t;
-
-#endif
 
 #ifdef __cplusplus
 }

--- a/Sources/kinc/simd/types.h
+++ b/Sources/kinc/simd/types.h
@@ -31,7 +31,7 @@ extern "C" {
 #endif
 
 //SSE Capability check
-#if defined(__SSE__) || _M_IX86_FP == 2 || _M_IX86_FP == 1 || (defined(KORE_WINDOWS) && !defined(__aarch64__)) ||                                              \
+#if defined(__SSE__) || _M_IX86_FP == 2 || _M_IX86_FP == 1 || (defined(KORE_WINDOWS) && !defined(__aarch64__)) ||	\
     (defined(KORE_WINDOWSAPP) && !defined(__aarch64__)) || (defined(KORE_MACOS) && __x86_64)
 
 	#define KINC_SSE
@@ -43,7 +43,9 @@ extern "C" {
 #endif
 
 //No SIMD Capabilities
-#if !defined(KINC_AVX) && !defined(KINC_SSE) && !defined(KINC_SSE2) && !defined(KINC_NEON)
+#if !defined(KINC_SSE4_2) && !defined(KINC_SSE4_1) && !defined(KINC_SSSE3) && !defined(KINC_SSE3) && 	\
+	!defined(KINC_SSE2) && !defined(KINC_SSE) && !defined(KINC_NEON)
+
 	#define KINC_NOSIMD
 #endif
 

--- a/Sources/kinc/simd/types.h
+++ b/Sources/kinc/simd/types.h
@@ -85,49 +85,33 @@ extern "C" {
 		int8_t values[16];
 	} kinc_int8x16_t;
 
-	typedef struct kinc_int8x16_mask {
-		uint8_t values[16];
-	} kinc_int8x16_mask_t;
-
 	typedef struct kinc_uint8x16 {
 		uint8_t values[16];
 	} kinc_uint8x16_t;
-
-	typedef struct kinc_uint8x16_mask {
-		uint8_t values[16];
-	} kinc_uint8x16_mask_t;
 
 	typedef struct kinc_int16x8 {
 		int16_t values[8];
 	} kinc_int16x8_t;
 
-	typedef struct kinc_int16x8_mask {
-		int16_t values[8];
-	} kinc_int16x8_mask_t;
-
 	typedef struct kinc_uint16x8 {
 		uint16_t values[8];
 	} kinc_uint16x8_t;
-
-	typedef struct kinc_uint16x8_mask {
-		uint16_t values[8];
-	} kinc_uint16x8_mask_t;
 
 	typedef struct kinc_int32x4 {
 		int32_t values[4];
 	} kinc_int32x4_t;
 
-	typedef struct kinc_int32x4_mask {
-		int32_t values[4];
-	} kinc_int32x4_mask_t;
-
 	typedef struct kinc_uint32x4 {
 		uint32_t values[4];
 	} kinc_uint32x4_t;
 
-	typedef struct kinc_uint32x4_mask {
-		uint32_t values[4];
-	} kinc_uint32x4_mask_t;
+	typedef kinc_int8x16_t kinc_int8x16_mask_t;
+	typedef kinc_uint8x16_t kinc_uint8x16_mask_t;
+	typedef kinc_int16x8_t kinc_int16x8_mask_t;
+	typedef kinc_uint16x8_t kinc_uint16x8_mask_t;
+	typedef kinc_int32x4_t kinc_int32x4_mask_t;
+	typedef kinc_uint32x4_t kinc_uint32x4_mask_t;
+
 
 #elif defined(KINC_NEON)
 
@@ -157,59 +141,45 @@ extern "C" {
 		float values[4];
 	} kinc_float32x4_t;
 
+	//Note: Float mask operates a bit differently than int masks
+	//Int/UInt masks are intended to mixed with SIMD base type functions like and/or/xor etc.
+	//so they're basically just the underlying type in the first place
 	typedef struct kinc_float32x4_mask {
 		int values[4];
 	} kinc_float32x4_mask_t;
-
 
 
 	typedef struct kinc_int8x16 {
 		int8_t values[16];
 	} kinc_int8x16_t;
 
-	typedef struct kinc_int8x16_mask {
-		uint8_t values[16];
-	} kinc_int8x16_mask_t;
-
 	typedef struct kinc_uint8x16 {
 		uint8_t values[16];
 	} kinc_uint8x16_t;
-
-	typedef struct kinc_uint8x16_mask {
-		uint8_t values[16];
-	} kinc_uint8x16_mask_t;
 
 	typedef struct kinc_int16x8 {
 		int16_t values[8];
 	} kinc_int16x8_t;
 
-	typedef struct kinc_int16x8_mask {
-		int16_t values[8];
-	} kinc_int16x8_mask_t;
-
 	typedef struct kinc_uint16x8 {
 		uint16_t values[8];
 	} kinc_uint16x8_t;
-
-	typedef struct kinc_uint16x8_mask {
-		uint16_t values[8];
-	} kinc_uint16x8_mask_t;
 
 	typedef struct kinc_int32x4 {
 		int32_t values[4];
 	} kinc_int32x4_t;
 
-	typedef struct kinc_int32x4_mask {
-		int32_t values[4];
-	} kinc_int32x4_mask_t;
-
 	typedef struct kinc_uint32x4 {
 		uint32_t values[4];
 	} kinc_uint32x4_t;
 
-	typedef struct kinc_uint32x4_mask {
-		uint32_t values[4];
-	} kinc_uint32x4_mask_t;
+	typedef kinc_int8x16_t kinc_int8x16_mask_t;
+	typedef kinc_uint8x16_t kinc_uint8x16_mask_t;
+	typedef kinc_int16x8_t kinc_int16x8_mask_t;
+	typedef kinc_uint16x8_t kinc_uint16x8_mask_t;
+	typedef kinc_int32x4_t kinc_int32x4_mask_t;
+	typedef kinc_uint32x4_t kinc_uint32x4_mask_t;
+
 
 #endif
 

--- a/Sources/kinc/simd/uint16x8.h
+++ b/Sources/kinc/simd/uint16x8.h
@@ -122,7 +122,7 @@ static inline kinc_uint16x8_t kinc_uint16x8_store(uint16_t *destination, kinc_ui
 }
 
 static inline uint16_t kinc_uint16x8_get(kinc_uint16x8_t t, int index) {
-	return t[index];
+	return t.n128_u16[index];
 }
 
 static inline kinc_uint16x8_t kinc_uint16x8_add(kinc_uint16x8_t a, kinc_uint16x8_t b) {

--- a/Sources/kinc/simd/uint16x8.h
+++ b/Sources/kinc/simd/uint16x8.h
@@ -124,17 +124,7 @@ static inline kinc_uint16x8_t kinc_uint16x8_load(const uint16_t values[8]) {
 }
 
 static inline kinc_uint16x8_t kinc_uint16x8_load_all(uint16_t t) {
-	kinc_uint16x8_t value;
-	value.n128_u16[0] = t;
-	value.n128_u16[1] = t;
-	value.n128_u16[2] = t;
-	value.n128_u16[3] = t;
-	value.n128_u16[4] = t;
-	value.n128_u16[5] = t;
-	value.n128_u16[6] = t;
-	value.n128_u16[7] = t;
-
-	return value;
+	return vdupq_n_u16(t);
 }
 
 static inline kinc_uint16x8_t kinc_uint16x8_store(uint16_t *destination, kinc_uint16x8_t value) {

--- a/Sources/kinc/simd/uint16x8.h
+++ b/Sources/kinc/simd/uint16x8.h
@@ -114,7 +114,7 @@ static inline kinc_uint16x8_t kinc_uint16x8_load(const uint16_t values[8]) {
 }
 
 static inline kinc_uint16x8_t kinc_uint16x8_load_all(uint16_t t) {
-	return vdupq_n_u16(t);
+	return (kinc_uint16x8_t){t, t, t, t, t, t, t, t};
 }
 
 static inline void kinc_uint16x8_store(uint16_t *destination, kinc_uint16x8_t value) {

--- a/Sources/kinc/simd/uint16x8.h
+++ b/Sources/kinc/simd/uint16x8.h
@@ -72,7 +72,7 @@ static inline kinc_uint16x8_t kinc_uint16x8_xor(kinc_uint16x8_t a, kinc_uint16x8
 }
 
 static inline kinc_uint16x8_t kinc_uint16x8_not(kinc_uint16x8_t t) {
-	return ~t;
+	return _mm_xor_si128(t, _mm_set1_epi32(0xffffffff));
 }
 
 #elif defined(KINC_NEON)

--- a/Sources/kinc/simd/uint16x8.h
+++ b/Sources/kinc/simd/uint16x8.h
@@ -110,11 +110,31 @@ static inline kinc_uint16x8_t kinc_uint16x8_intrin_load(const uint16_t *values) 
 }
 
 static inline kinc_uint16x8_t kinc_uint16x8_load(const uint16_t values[8]) {
-	return (kinc_uint16x8_t){values[0], values[1], values[2], values[3], values[4], values[5], values[6], values[7]};
+	kinc_uint16x8_t value;
+	value.n128_u16[0] = values[0];
+	value.n128_u16[1] = values[1];
+	value.n128_u16[2] = values[2];
+	value.n128_u16[3] = values[3];
+	value.n128_u16[4] = values[4];
+	value.n128_u16[5] = values[5];
+	value.n128_u16[6] = values[6];
+	value.n128_u16[7] = values[7];
+
+	return value;
 }
 
 static inline kinc_uint16x8_t kinc_uint16x8_load_all(uint16_t t) {
-	return (kinc_uint16x8_t){t, t, t, t, t, t, t, t};
+	kinc_uint16x8_t value;
+	value.n128_u16[0] = t;
+	value.n128_u16[1] = t;
+	value.n128_u16[2] = t;
+	value.n128_u16[3] = t;
+	value.n128_u16[4] = t;
+	value.n128_u16[5] = t;
+	value.n128_u16[6] = t;
+	value.n128_u16[7] = t;
+
+	return value;
 }
 
 static inline kinc_uint16x8_t kinc_uint16x8_store(uint16_t *destination, kinc_uint16x8_t value) {

--- a/Sources/kinc/simd/uint16x8.h
+++ b/Sources/kinc/simd/uint16x8.h
@@ -110,17 +110,7 @@ static inline kinc_uint16x8_t kinc_uint16x8_intrin_load(const uint16_t *values) 
 }
 
 static inline kinc_uint16x8_t kinc_uint16x8_load(const uint16_t values[8]) {
-	kinc_uint16x8_t value = vdupq_n_u16(0);
-	value = vsetq_lane_u16(values[0], value, 0);
-	value = vsetq_lane_u16(values[1], value, 1);
-	value = vsetq_lane_u16(values[2], value, 2);
-	value = vsetq_lane_u16(values[3], value, 3);
-	value = vsetq_lane_u16(values[4], value, 4);
-	value = vsetq_lane_u16(values[5], value, 5);
-	value = vsetq_lane_u16(values[6], value, 6);
-	value = vsetq_lane_u16(values[7], value, 7);
-
-	return value;
+	return (kinc_uint16x8_t){values[0], values[1], values[2], values[3], values[4], values[5], values[6], values[7]};
 }
 
 static inline kinc_uint16x8_t kinc_uint16x8_load_all(uint16_t t) {

--- a/Sources/kinc/simd/uint16x8.h
+++ b/Sources/kinc/simd/uint16x8.h
@@ -12,12 +12,22 @@ extern "C" {
 
 #if defined(KINC_SSE2)
 
+static inline kinc_uint16x8_t kinc_uint16x8_intrin_load(uint16_t const *values)
+{
+	return _mm_load_si128((kinc_uint16x8_t const *)values);
+}
+
 static inline kinc_uint16x8_t kinc_uint16x8_load(const uint16_t values[8]) {
 	return _mm_set_epi16(values[7], values[6], values[5], values[4], values[3], values[2], values[1], values[0]);
 }
 
 static inline kinc_uint16x8_t kinc_uint16x8_load_all(uint16_t t) {
 	return _mm_set1_epi16(t);
+}
+
+static inline void kinc_uint16x8_store(uint16_t *destination, kinc_uint16x8_t value)
+{
+	_mm_store_si128((kinc_uint16x8_t *)destination, value);
 }
 
 static inline uint16_t kinc_uint16x8_get(kinc_uint16x8_t t, int index) {
@@ -67,12 +77,22 @@ static inline kinc_uint16x8_t kinc_uint16x8_not(kinc_uint16x8_t t) {
 
 #elif defined(KINC_NEON)
 
+static inline kinc_uint16x8_t kinc_uint16x8_intrin_load(uint16_t const *values)
+{
+	return vld1q_u16(values);
+}
+
 static inline kinc_uint16x8_t kinc_uint16x8_load(const uint16_t values[8]) {
 	return (kinc_uint16x8_t){values[0], values[1], values[2], values[3], values[4], values[5], values[6], values[7]};
 }
 
 static inline kinc_uint16x8_t kinc_uint16x8_load_all(uint16_t t) {
 	return (kinc_uint16x8_t){t, t, t, t, t, t, t, t};
+}
+
+static inline kinc_uint16x8_t kinc_uint16x8_store(uint16_t *destination, kinc_uint16x8_t value)
+{
+	vst1q_u16(destination, value);
 }
 
 static inline uint16_t kinc_uint16x8_get(kinc_uint16x8_t t, int index) {
@@ -117,6 +137,20 @@ static inline kinc_uint16x8_t kinc_uint16x8_not(kinc_uint16x8_t t) {
 
 #else
 
+static inline kinc_uint16x8_t kinc_uint16x8_intrin_load(uint16_t const *values)
+{
+	kinc_uint16x8_t value;
+	value.values[0] = values[0];
+	value.values[1] = values[1];
+	value.values[2] = values[2];
+	value.values[3] = values[3];
+	value.values[4] = values[4];
+	value.values[5] = values[5];
+	value.values[6] = values[6];
+	value.values[7] = values[7];
+	return value;
+}
+
 static inline kinc_uint16x8_t kinc_uint16x8_load(const uint16_t values[8]) {
 	kinc_uint16x8_t value;
 	value.values[0] = values[0];
@@ -141,6 +175,18 @@ static inline kinc_uint16x8_t kinc_uint16x8_load_all(uint16_t t) {
 	value.values[6] = t;
 	value.values[7] = t;
 	return value;
+}
+
+static inline void kinc_uint16x8_store(uint16_t *destination, kinc_uint16x8_t value)
+{
+	destination[0] = value.values[0];
+	destination[1] = value.values[1];
+	destination[2] = value.values[2];
+	destination[3] = value.values[3];
+	destination[4] = value.values[4];
+	destination[5] = value.values[5];
+	destination[6] = value.values[6];
+	destination[7] = value.values[7];
 }
 
 static inline uint16_t kinc_uint16x8_get(kinc_uint16x8_t t, int index) {

--- a/Sources/kinc/simd/uint16x8.h
+++ b/Sources/kinc/simd/uint16x8.h
@@ -110,15 +110,15 @@ static inline kinc_uint16x8_t kinc_uint16x8_intrin_load(const uint16_t *values) 
 }
 
 static inline kinc_uint16x8_t kinc_uint16x8_load(const uint16_t values[8]) {
-	kinc_uint16x8_t value;
-	value.n128_u16[0] = values[0];
-	value.n128_u16[1] = values[1];
-	value.n128_u16[2] = values[2];
-	value.n128_u16[3] = values[3];
-	value.n128_u16[4] = values[4];
-	value.n128_u16[5] = values[5];
-	value.n128_u16[6] = values[6];
-	value.n128_u16[7] = values[7];
+	kinc_uint16x8_t value = vdupq_n_u16(0);
+	value = vsetq_lane_u16(values[0], value, 0);
+	value = vsetq_lane_u16(values[1], value, 1);
+	value = vsetq_lane_u16(values[2], value, 2);
+	value = vsetq_lane_u16(values[3], value, 3);
+	value = vsetq_lane_u16(values[4], value, 4);
+	value = vsetq_lane_u16(values[5], value, 5);
+	value = vsetq_lane_u16(values[6], value, 6);
+	value = vsetq_lane_u16(values[7], value, 7);
 
 	return value;
 }

--- a/Sources/kinc/simd/uint16x8.h
+++ b/Sources/kinc/simd/uint16x8.h
@@ -54,7 +54,7 @@ static inline kinc_uint16x8_t kinc_uint16x8_max(kinc_uint16x8_t a, kinc_uint16x8
 		uint16_t a_single = kinc_uint16x8_get(a, i);
 		uint16_t b_single = kinc_uint16x8_get(b, i);
 
-		a_single > b_single ? values[i] = a_single : values[i] = b_single;
+		values[i] = a_single > b_single ? a_single : b_single;
 	}
 
 	return kinc_uint16x8_load(values);
@@ -69,7 +69,7 @@ static inline kinc_uint16x8_t kinc_uint16x8_min(kinc_uint16x8_t a, kinc_uint16x8
 		uint16_t a_single = kinc_uint16x8_get(a, i);
 		uint16_t b_single = kinc_uint16x8_get(b, i);
 
-		a_single > b_single ? values[i] = b_single : values[i] = a_single;
+		values[i] = a_single > b_single ? b_single : a_single;
 	}
 
 	return kinc_uint16x8_load(values);

--- a/Sources/kinc/simd/uint16x8.h
+++ b/Sources/kinc/simd/uint16x8.h
@@ -12,9 +12,8 @@ extern "C" {
 
 #if defined(KINC_SSE2)
 
-static inline kinc_uint16x8_t kinc_uint16x8_intrin_load(uint16_t const *values)
-{
-	return _mm_load_si128((kinc_uint16x8_t const *)values);
+static inline kinc_uint16x8_t kinc_uint16x8_intrin_load(const uint16_t *values) {
+	return _mm_load_si128((const kinc_uint16x8_t *)values);
 }
 
 static inline kinc_uint16x8_t kinc_uint16x8_load(const uint16_t values[8]) {
@@ -25,8 +24,7 @@ static inline kinc_uint16x8_t kinc_uint16x8_load_all(uint16_t t) {
 	return _mm_set1_epi16(t);
 }
 
-static inline void kinc_uint16x8_store(uint16_t *destination, kinc_uint16x8_t value)
-{
+static inline void kinc_uint16x8_store(uint16_t *destination, kinc_uint16x8_t value) {
 	_mm_store_si128((kinc_uint16x8_t *)destination, value);
 }
 
@@ -77,8 +75,7 @@ static inline kinc_uint16x8_t kinc_uint16x8_not(kinc_uint16x8_t t) {
 
 #elif defined(KINC_NEON)
 
-static inline kinc_uint16x8_t kinc_uint16x8_intrin_load(uint16_t const *values)
-{
+static inline kinc_uint16x8_t kinc_uint16x8_intrin_load(const uint16_t *values) {
 	return vld1q_u16(values);
 }
 
@@ -90,8 +87,7 @@ static inline kinc_uint16x8_t kinc_uint16x8_load_all(uint16_t t) {
 	return (kinc_uint16x8_t){t, t, t, t, t, t, t, t};
 }
 
-static inline kinc_uint16x8_t kinc_uint16x8_store(uint16_t *destination, kinc_uint16x8_t value)
-{
+static inline kinc_uint16x8_t kinc_uint16x8_store(uint16_t *destination, kinc_uint16x8_t value) {
 	vst1q_u16(destination, value);
 }
 
@@ -137,8 +133,7 @@ static inline kinc_uint16x8_t kinc_uint16x8_not(kinc_uint16x8_t t) {
 
 #else
 
-static inline kinc_uint16x8_t kinc_uint16x8_intrin_load(uint16_t const *values)
-{
+static inline kinc_uint16x8_t kinc_uint16x8_intrin_load(const uint16_t *values) {
 	kinc_uint16x8_t value;
 	value.values[0] = values[0];
 	value.values[1] = values[1];
@@ -177,8 +172,7 @@ static inline kinc_uint16x8_t kinc_uint16x8_load_all(uint16_t t) {
 	return value;
 }
 
-static inline void kinc_uint16x8_store(uint16_t *destination, kinc_uint16x8_t value)
-{
+static inline void kinc_uint16x8_store(uint16_t *destination, kinc_uint16x8_t value) {
 	destination[0] = value.values[0];
 	destination[1] = value.values[1];
 	destination[2] = value.values[2];

--- a/Sources/kinc/simd/uint16x8.h
+++ b/Sources/kinc/simd/uint16x8.h
@@ -45,6 +45,36 @@ static inline kinc_uint16x8_t kinc_uint16x8_sub(kinc_uint16x8_t a, kinc_uint16x8
 	return _mm_sub_epi16(a, b);
 }
 
+static inline kinc_uint16x8_t kinc_uint16x8_max(kinc_uint16x8_t a, kinc_uint16x8_t b) {
+	//No obvious intrinsic here; use a subpar fallback method
+	uint16_t values[8];
+
+	for(int i = 0; i < 8; ++i) {
+
+		uint16_t a_single = kinc_uint16x8_get(a, i);
+		uint16_t b_single = kinc_uint16x8_get(b, i);
+
+		a_single > b_single ? values[i] = a_single : values[i] = b_single;
+	}
+
+	return kinc_uint16x8_load(values);
+}
+
+static inline kinc_uint16x8_t kinc_uint16x8_min(kinc_uint16x8_t a, kinc_uint16x8_t b) {
+	//No obvious intrinsic here; use a subpar fallback method
+	uint16_t values[8];
+
+	for(int i = 0; i < 8; ++i) {
+
+		uint16_t a_single = kinc_uint16x8_get(a, i);
+		uint16_t b_single = kinc_uint16x8_get(b, i);
+
+		a_single > b_single ? values[i] = b_single : values[i] = a_single;
+	}
+
+	return kinc_uint16x8_load(values);
+}
+
 static inline kinc_uint16x8_mask_t kinc_uint16x8_cmpeq(kinc_uint16x8_t a, kinc_uint16x8_t b) {
 	return _mm_cmpeq_epi16(a, b);
 }
@@ -101,6 +131,14 @@ static inline kinc_uint16x8_t kinc_uint16x8_add(kinc_uint16x8_t a, kinc_uint16x8
 
 static inline kinc_uint16x8_t kinc_uint16x8_sub(kinc_uint16x8_t a, kinc_uint16x8_t b) {
 	return vsubq_u16(a, b);
+}
+
+static inline kinc_uint16x8_t kinc_uint16x8_max(kinc_uint16x8_t a, kinc_uint16x8_t b) {
+	return vmaxq_u16(a, b);
+}
+
+static inline kinc_uint16x8_t kinc_uint16x8_min(kinc_uint16x8_t a, kinc_uint16x8_t b) {
+	return vminq_u16(a, b);
 }
 
 static inline kinc_uint16x8_mask_t kinc_uint16x8_cmpeq(kinc_uint16x8_t a, kinc_uint16x8_t b) {

--- a/Sources/kinc/simd/uint16x8.h
+++ b/Sources/kinc/simd/uint16x8.h
@@ -132,7 +132,7 @@ static inline kinc_uint16x8_t kinc_uint16x8_store(uint16_t *destination, kinc_ui
 }
 
 static inline uint16_t kinc_uint16x8_get(kinc_uint16x8_t t, int index) {
-	return t.n128_u16[index];
+	return vgetq_lane_u16(t, index);
 }
 
 static inline kinc_uint16x8_t kinc_uint16x8_add(kinc_uint16x8_t a, kinc_uint16x8_t b) {

--- a/Sources/kinc/simd/uint16x8.h
+++ b/Sources/kinc/simd/uint16x8.h
@@ -175,27 +175,27 @@ static inline kinc_uint16x8_t kinc_uint16x8_sub(kinc_uint16x8_t a, kinc_uint16x8
 
 static inline kinc_uint16x8_t kinc_uint16x8_max(kinc_uint16x8_t a, kinc_uint16x8_t b) {
 	kinc_uint16x8_t value;
-	value.values[0] = kinc_max(a.values[0], b.values[0]);
-	value.values[1] = kinc_max(a.values[1], b.values[1]);
-	value.values[2] = kinc_max(a.values[2], b.values[2]);
-	value.values[3] = kinc_max(a.values[3], b.values[3]);
-	value.values[4] = kinc_max(a.values[4], b.values[4]);
-	value.values[5] = kinc_max(a.values[5], b.values[5]);
-	value.values[6] = kinc_max(a.values[6], b.values[6]);
-	value.values[7] = kinc_max(a.values[7], b.values[7]);
+	value.values[0] = a.values[0] > b.values[0] ? a.values[0] : b.values[0];
+	value.values[1] = a.values[1] > b.values[1] ? a.values[1] : b.values[1];
+	value.values[2] = a.values[2] > b.values[2] ? a.values[2] : b.values[2];
+	value.values[3] = a.values[3] > b.values[3] ? a.values[3] : b.values[3];
+	value.values[4] = a.values[4] > b.values[4] ? a.values[4] : b.values[4];
+	value.values[5] = a.values[5] > b.values[5] ? a.values[5] : b.values[5];
+	value.values[6] = a.values[6] > b.values[6] ? a.values[6] : b.values[6];
+	value.values[7] = a.values[7] > b.values[7] ? a.values[7] : b.values[7];
 	return value;
 }
 
 static inline kinc_uint16x8_t kinc_uint16x8_min(kinc_uint16x8_t a, kinc_uint16x8_t b) {
 	kinc_uint16x8_t value;
-	value.values[0] = kinc_min(a.values[0], b.values[0]);
-	value.values[1] = kinc_min(a.values[1], b.values[1]);
-	value.values[2] = kinc_min(a.values[2], b.values[2]);
-	value.values[3] = kinc_min(a.values[3], b.values[3]);
-	value.values[4] = kinc_min(a.values[4], b.values[4]);
-	value.values[5] = kinc_min(a.values[5], b.values[5]);
-	value.values[6] = kinc_min(a.values[6], b.values[6]);
-	value.values[7] = kinc_min(a.values[7], b.values[7]);
+	value.values[0] = a.values[0] > b.values[0] ? b.values[0] : a.values[0];
+	value.values[1] = a.values[1] > b.values[1] ? b.values[1] : a.values[1];
+	value.values[2] = a.values[2] > b.values[2] ? b.values[2] : a.values[2];
+	value.values[3] = a.values[3] > b.values[3] ? b.values[3] : a.values[3];
+	value.values[4] = a.values[4] > b.values[4] ? b.values[4] : a.values[4];
+	value.values[5] = a.values[5] > b.values[5] ? b.values[5] : a.values[5];
+	value.values[6] = a.values[6] > b.values[6] ? b.values[6] : a.values[6];
+	value.values[7] = a.values[7] > b.values[7] ? b.values[7] : a.values[7];
 	return value;
 }
 

--- a/Sources/kinc/simd/uint16x8.h
+++ b/Sources/kinc/simd/uint16x8.h
@@ -127,7 +127,7 @@ static inline kinc_uint16x8_t kinc_uint16x8_load_all(uint16_t t) {
 	return vdupq_n_u16(t);
 }
 
-static inline kinc_uint16x8_t kinc_uint16x8_store(uint16_t *destination, kinc_uint16x8_t value) {
+static inline void kinc_uint16x8_store(uint16_t *destination, kinc_uint16x8_t value) {
 	vst1q_u16(destination, value);
 }
 

--- a/Sources/kinc/simd/uint16x8.h
+++ b/Sources/kinc/simd/uint16x8.h
@@ -132,7 +132,7 @@ static inline kinc_uint16x8_t kinc_uint16x8_store(uint16_t *destination, kinc_ui
 }
 
 static inline uint16_t kinc_uint16x8_get(kinc_uint16x8_t t, int index) {
-	return vgetq_lane_u16(t, index);
+	return t[index];
 }
 
 static inline kinc_uint16x8_t kinc_uint16x8_add(kinc_uint16x8_t a, kinc_uint16x8_t b) {

--- a/Sources/kinc/simd/uint32x4.h
+++ b/Sources/kinc/simd/uint32x4.h
@@ -120,13 +120,7 @@ static inline kinc_uint32x4_t kinc_uint32x4_load(const uint32_t values[4]) {
 }
 
 static inline kinc_uint32x4_t kinc_uint32x4_load_all(uint32_t t) {
-	kinc_uint32x4_t value;
-	value.n128_u32[0] = t;
-	value.n128_u32[1] = t;
-	value.n128_u32[2] = t;
-	value.n128_u32[3] = t;
-
-	return value;
+	return vdupq_n_u32(t);
 }
 
 static inline void kinc_uint32x4_store(uint32_t *destination, kinc_uint32x4_t value) {

--- a/Sources/kinc/simd/uint32x4.h
+++ b/Sources/kinc/simd/uint32x4.h
@@ -72,7 +72,7 @@ static inline kinc_uint32x4_t kinc_uint32x4_xor(kinc_uint32x4_t a, kinc_uint32x4
 }
 
 static inline kinc_uint32x4_t kinc_uint32x4_not(kinc_uint32x4_t t) {
-	return ~t;
+	return _mm_xor_si128(t, _mm_set1_epi32(0xffffffff));
 }
 
 #elif defined(KINC_NEON)

--- a/Sources/kinc/simd/uint32x4.h
+++ b/Sources/kinc/simd/uint32x4.h
@@ -247,19 +247,19 @@ static inline kinc_uint32x4_t kinc_uint32x4_min(kinc_uint32x4_t a, kinc_uint32x4
 
 static inline kinc_uint32x4_mask_t kinc_uint32x4_cmpeq(kinc_uint32x4_t a, kinc_uint32x4_t b) {
 	kinc_uint32x4_mask_t mask;
-	mask.values[0] = a.values[0] == b.values[0] ? 0xffff : 0;
-	mask.values[1] = a.values[1] == b.values[1] ? 0xffff : 0;
-	mask.values[2] = a.values[2] == b.values[2] ? 0xffff : 0;
-	mask.values[3] = a.values[3] == b.values[3] ? 0xffff : 0;
+	mask.values[0] = a.values[0] == b.values[0] ? 0xffffffff : 0;
+	mask.values[1] = a.values[1] == b.values[1] ? 0xffffffff : 0;
+	mask.values[2] = a.values[2] == b.values[2] ? 0xffffffff : 0;
+	mask.values[3] = a.values[3] == b.values[3] ? 0xffffffff : 0;
 	return mask;
 }
 
 static inline kinc_uint32x4_mask_t kinc_uint32x4_cmpneq(kinc_uint32x4_t a, kinc_uint32x4_t b) {
 	kinc_uint32x4_mask_t mask;
-	mask.values[0] = a.values[0] != b.values[0] ? 0xffff : 0;
-	mask.values[1] = a.values[1] != b.values[1] ? 0xffff : 0;
-	mask.values[2] = a.values[2] != b.values[2] ? 0xffff : 0;
-	mask.values[3] = a.values[3] != b.values[3] ? 0xffff : 0;
+	mask.values[0] = a.values[0] != b.values[0] ? 0xffffffff : 0;
+	mask.values[1] = a.values[1] != b.values[1] ? 0xffffffff : 0;
+	mask.values[2] = a.values[2] != b.values[2] ? 0xffffffff : 0;
+	mask.values[3] = a.values[3] != b.values[3] ? 0xffffffff : 0;
 	return mask;
 }
 

--- a/Sources/kinc/simd/uint32x4.h
+++ b/Sources/kinc/simd/uint32x4.h
@@ -122,7 +122,7 @@ static inline void kinc_uint32x4_store(uint32_t *destination, kinc_uint32x4_t va
 }
 
 static inline uint32_t kinc_uint32x4_get(kinc_uint32x4_t t, int index) {
-	return t[index];
+	return t.n128_u32[index];
 }
 
 static inline kinc_uint32x4_t kinc_uint32x4_add(kinc_uint32x4_t a, kinc_uint32x4_t b) {

--- a/Sources/kinc/simd/uint32x4.h
+++ b/Sources/kinc/simd/uint32x4.h
@@ -110,13 +110,7 @@ static inline kinc_uint32x4_t kinc_uint32x4_intrin_load(const uint32_t *values) 
 }
 
 static inline kinc_uint32x4_t kinc_uint32x4_load(const uint32_t values[4]) {
-	kinc_uint32x4_t value = vdupq_n_u32(0);
-	value = vsetq_lane_u32(values[0], value, 0);
-	value = vsetq_lane_u32(values[1], value, 1);
-	value = vsetq_lane_u32(values[2], value, 2);
-	value = vsetq_lane_u32(values[3], value, 3);
-
-	return value;
+	return (kinc_uint32x4_t){values[0], values[1], values[2], values[3]};
 }
 
 static inline kinc_uint32x4_t kinc_uint32x4_load_all(uint32_t t) {

--- a/Sources/kinc/simd/uint32x4.h
+++ b/Sources/kinc/simd/uint32x4.h
@@ -12,12 +12,22 @@ extern "C" {
 
 #if defined(KINC_SSE2)
 
+static inline kinc_uint32x4_t kinc_uint32x4_intrin_load(uint32_t const *values)
+{
+	return _mm_load_si128((kinc_uint32x4_t const *)values);
+}
+
 static inline kinc_uint32x4_t kinc_uint32x4_load(const uint32_t values[4]) {
 	return _mm_set_epi32(values[3], values[2], values[1], values[0]);
 }
 
 static inline kinc_uint32x4_t kinc_uint32x4_load_all(uint32_t t) {
 	return _mm_set1_epi32(t);
+}
+
+static inline void kinc_uint32x4_store(uint32_t *destination, kinc_uint32x4_t value)
+{
+	_mm_store_si128((kinc_uint32x4_t *)destination, value);
 }
 
 static inline uint32_t kinc_uint32x4_get(kinc_uint32x4_t t, int index) {
@@ -67,12 +77,22 @@ static inline kinc_uint32x4_t kinc_uint32x4_not(kinc_uint32x4_t t) {
 
 #elif defined(KINC_NEON)
 
+static inline kinc_uint32x4_t kinc_uint32x4_intrin_load(uint32_t const *values)
+{
+	return vld1q_u32(values);
+}
+
 static inline kinc_uint32x4_t kinc_uint32x4_load(const uint32_t values[4]) {
 	return (kinc_uint32x4_t){values[0], values[1], values[2], values[3]};
 }
 
 static inline kinc_uint32x4_t kinc_uint32x4_load_all(uint32_t t) {
 	return (kinc_uint32x4_t){t, t, t, t};
+}
+
+static inline void kinc_uint32x4_store(uint32_t *destination, kinc_uint32x4_t value)
+{
+	vst1q_u32(destination, value);
 }
 
 static inline uint32_t kinc_uint32x4_get(kinc_uint32x4_t t, int index) {
@@ -117,6 +137,16 @@ static inline kinc_uint32x4_t kinc_uint32x4_not(kinc_uint32x4_t t) {
 
 #else
 
+static inline kinc_uint32x4_t kinc_uint32x4_intrin_load(uint32_t const *values)
+{
+	kinc_uint32x4_t value;
+	value.values[0] = values[0];
+	value.values[1] = values[1];
+	value.values[2] = values[2];
+	value.values[3] = values[3];
+	return value;
+}
+
 static inline kinc_uint32x4_t kinc_uint32x4_load(const uint32_t values[4]) {
 	kinc_uint32x4_t value;
 	value.values[0] = values[0];
@@ -133,6 +163,14 @@ static inline kinc_uint32x4_t kinc_uint32x4_load_all(uint32_t t) {
 	value.values[2] = t;
 	value.values[3] = t;
 	return value;
+}
+
+static inline void kinc_uint32x4_store(uint32_t *destination, kinc_uint32x4_t value)
+{
+	destination[0] = value.values[0];
+	destination[1] = value.values[1];
+	destination[2] = value.values[2];
+	destination[3] = value.values[3];
 }
 
 static inline uint32_t kinc_uint32x4_get(kinc_uint32x4_t t, int index) {

--- a/Sources/kinc/simd/uint32x4.h
+++ b/Sources/kinc/simd/uint32x4.h
@@ -159,19 +159,19 @@ static inline kinc_uint32x4_t kinc_uint32x4_sub(kinc_uint32x4_t a, kinc_uint32x4
 
 static inline kinc_uint32x4_t kinc_uint32x4_max(kinc_uint32x4_t a, kinc_uint32x4_t b) {
 	kinc_uint32x4_t value;
-	value.values[0] = kinc_max(a.values[0], b.values[0]);
-	value.values[1] = kinc_max(a.values[1], b.values[1]);
-	value.values[2] = kinc_max(a.values[2], b.values[2]);
-	value.values[3] = kinc_max(a.values[3], b.values[3]);
+	value.values[0] = a.values[0] > b.values[0] ? a.values[0] : b.values[0];
+	value.values[1] = a.values[1] > b.values[1] ? a.values[1] : b.values[1]; 
+	value.values[2] = a.values[2] > b.values[2] ? a.values[2] : b.values[2]; 
+	value.values[3] = a.values[3] > b.values[3] ? a.values[3] : b.values[3]; 
 	return value;
 }
 
 static inline kinc_uint32x4_t kinc_uint32x4_min(kinc_uint32x4_t a, kinc_uint32x4_t b) {
 	kinc_uint32x4_t value;
-	value.values[0] = kinc_min(a.values[0], b.values[0]);
-	value.values[1] = kinc_min(a.values[1], b.values[1]);
-	value.values[2] = kinc_min(a.values[2], b.values[2]);
-	value.values[3] = kinc_min(a.values[3], b.values[3]);
+	value.values[0] = a.values[0] > b.values[0] ? b.values[0] : a.values[0];
+	value.values[1] = a.values[1] > b.values[1] ? b.values[1] : a.values[1]; 
+	value.values[2] = a.values[2] > b.values[2] ? b.values[2] : a.values[2]; 
+	value.values[3] = a.values[3] > b.values[3] ? b.values[3] : a.values[3]; 
 	return value;
 }
 

--- a/Sources/kinc/simd/uint32x4.h
+++ b/Sources/kinc/simd/uint32x4.h
@@ -128,7 +128,7 @@ static inline void kinc_uint32x4_store(uint32_t *destination, kinc_uint32x4_t va
 }
 
 static inline uint32_t kinc_uint32x4_get(kinc_uint32x4_t t, int index) {
-	return vgetq_lane_u32(t, index);
+	return t[index];
 }
 
 static inline kinc_uint32x4_t kinc_uint32x4_add(kinc_uint32x4_t a, kinc_uint32x4_t b) {

--- a/Sources/kinc/simd/uint32x4.h
+++ b/Sources/kinc/simd/uint32x4.h
@@ -12,9 +12,8 @@ extern "C" {
 
 #if defined(KINC_SSE2)
 
-static inline kinc_uint32x4_t kinc_uint32x4_intrin_load(uint32_t const *values)
-{
-	return _mm_load_si128((kinc_uint32x4_t const *)values);
+static inline kinc_uint32x4_t kinc_uint32x4_intrin_load(const uint32_t *values) {
+	return _mm_load_si128((const kinc_uint32x4_t *)values);
 }
 
 static inline kinc_uint32x4_t kinc_uint32x4_load(const uint32_t values[4]) {
@@ -25,8 +24,7 @@ static inline kinc_uint32x4_t kinc_uint32x4_load_all(uint32_t t) {
 	return _mm_set1_epi32(t);
 }
 
-static inline void kinc_uint32x4_store(uint32_t *destination, kinc_uint32x4_t value)
-{
+static inline void kinc_uint32x4_store(uint32_t *destination, kinc_uint32x4_t value) {
 	_mm_store_si128((kinc_uint32x4_t *)destination, value);
 }
 
@@ -77,8 +75,7 @@ static inline kinc_uint32x4_t kinc_uint32x4_not(kinc_uint32x4_t t) {
 
 #elif defined(KINC_NEON)
 
-static inline kinc_uint32x4_t kinc_uint32x4_intrin_load(uint32_t const *values)
-{
+static inline kinc_uint32x4_t kinc_uint32x4_intrin_load(const uint32_t *values) {
 	return vld1q_u32(values);
 }
 
@@ -90,8 +87,7 @@ static inline kinc_uint32x4_t kinc_uint32x4_load_all(uint32_t t) {
 	return (kinc_uint32x4_t){t, t, t, t};
 }
 
-static inline void kinc_uint32x4_store(uint32_t *destination, kinc_uint32x4_t value)
-{
+static inline void kinc_uint32x4_store(uint32_t *destination, kinc_uint32x4_t value) {
 	vst1q_u32(destination, value);
 }
 
@@ -137,8 +133,7 @@ static inline kinc_uint32x4_t kinc_uint32x4_not(kinc_uint32x4_t t) {
 
 #else
 
-static inline kinc_uint32x4_t kinc_uint32x4_intrin_load(uint32_t const *values)
-{
+static inline kinc_uint32x4_t kinc_uint32x4_intrin_load(const uint32_t *values) {
 	kinc_uint32x4_t value;
 	value.values[0] = values[0];
 	value.values[1] = values[1];
@@ -165,8 +160,7 @@ static inline kinc_uint32x4_t kinc_uint32x4_load_all(uint32_t t) {
 	return value;
 }
 
-static inline void kinc_uint32x4_store(uint32_t *destination, kinc_uint32x4_t value)
-{
+static inline void kinc_uint32x4_store(uint32_t *destination, kinc_uint32x4_t value) {
 	destination[0] = value.values[0];
 	destination[1] = value.values[1];
 	destination[2] = value.values[2];

--- a/Sources/kinc/simd/uint32x4.h
+++ b/Sources/kinc/simd/uint32x4.h
@@ -114,7 +114,7 @@ static inline kinc_uint32x4_t kinc_uint32x4_load(const uint32_t values[4]) {
 }
 
 static inline kinc_uint32x4_t kinc_uint32x4_load_all(uint32_t t) {
-	return vdupq_n_u32(t);
+	return (kinc_uint32x4_t){t, t, t, t};
 }
 
 static inline void kinc_uint32x4_store(uint32_t *destination, kinc_uint32x4_t value) {

--- a/Sources/kinc/simd/uint32x4.h
+++ b/Sources/kinc/simd/uint32x4.h
@@ -45,6 +45,36 @@ static inline kinc_uint32x4_t kinc_uint32x4_sub(kinc_uint32x4_t a, kinc_uint32x4
 	return _mm_sub_epi32(a, b);
 }
 
+static inline kinc_uint32x4_t kinc_uint32x4_max(kinc_uint32x4_t a, kinc_uint32x4_t b) {
+	//No obvious intrinsic here; use a subpar fallback method
+	uint32_t values[4];
+
+	for(int i = 0; i < 4; ++i) {
+
+		uint32_t a_single = kinc_uint32x4_get(a, i);
+		uint32_t b_single = kinc_uint32x4_get(b, i);
+
+		a_single > b_single ? values[i] = a_single : values[i] = b_single;
+	}
+
+	return kinc_uint32x4_load(values);
+}
+
+static inline kinc_uint32x4_t kinc_uint32x4_min(kinc_uint32x4_t a, kinc_uint32x4_t b) {
+	//No obvious intrinsic here; use a subpar fallback method
+	uint32_t values[4];
+
+	for(int i = 0; i < 4; ++i) {
+
+		uint32_t a_single = kinc_uint32x4_get(a, i);
+		uint32_t b_single = kinc_uint32x4_get(b, i);
+
+		a_single > b_single ? values[i] = b_single : values[i] = a_single;
+	}
+
+	return kinc_uint32x4_load(values);
+}
+
 static inline kinc_uint32x4_mask_t kinc_uint32x4_cmpeq(kinc_uint32x4_t a, kinc_uint32x4_t b) {
 	return _mm_cmpeq_epi32(a, b);
 }
@@ -101,6 +131,14 @@ static inline kinc_uint32x4_t kinc_uint32x4_add(kinc_uint32x4_t a, kinc_uint32x4
 
 static inline kinc_uint32x4_t kinc_uint32x4_sub(kinc_uint32x4_t a, kinc_uint32x4_t b) {
 	return vsubq_u32(a, b);
+}
+
+static inline kinc_uint32x4_t kinc_uint32x4_max(kinc_uint32x4_t a, kinc_uint32x4_t b) {
+	return vmaxq_u32(a, b);
+}
+
+static inline kinc_uint32x4_t kinc_uint32x4_min(kinc_uint32x4_t a, kinc_uint32x4_t b) {
+	return vminq_u32(a, b);
 }
 
 static inline kinc_uint32x4_mask_t kinc_uint32x4_cmpeq(kinc_uint32x4_t a, kinc_uint32x4_t b) {

--- a/Sources/kinc/simd/uint32x4.h
+++ b/Sources/kinc/simd/uint32x4.h
@@ -110,11 +110,11 @@ static inline kinc_uint32x4_t kinc_uint32x4_intrin_load(const uint32_t *values) 
 }
 
 static inline kinc_uint32x4_t kinc_uint32x4_load(const uint32_t values[4]) {
-	kinc_uint32x4_t value;
-	value.n128_u32[0] = values[0];
-	value.n128_u32[1] = values[1];
-	value.n128_u32[2] = values[2];
-	value.n128_u32[3] = values[3];
+	kinc_uint32x4_t value = vdupq_n_u32(0);
+	value = vsetq_lane_u32(values[0], value, 0);
+	value = vsetq_lane_u32(values[1], value, 1);
+	value = vsetq_lane_u32(values[2], value, 2);
+	value = vsetq_lane_u32(values[3], value, 3);
 
 	return value;
 }

--- a/Sources/kinc/simd/uint32x4.h
+++ b/Sources/kinc/simd/uint32x4.h
@@ -110,11 +110,23 @@ static inline kinc_uint32x4_t kinc_uint32x4_intrin_load(const uint32_t *values) 
 }
 
 static inline kinc_uint32x4_t kinc_uint32x4_load(const uint32_t values[4]) {
-	return (kinc_uint32x4_t){values[0], values[1], values[2], values[3]};
+	kinc_uint32x4_t value;
+	value.n128_u32[0] = values[0];
+	value.n128_u32[1] = values[1];
+	value.n128_u32[2] = values[2];
+	value.n128_u32[3] = values[3];
+
+	return value;
 }
 
 static inline kinc_uint32x4_t kinc_uint32x4_load_all(uint32_t t) {
-	return (kinc_uint32x4_t){t, t, t, t};
+	kinc_uint32x4_t value;
+	value.n128_u32[0] = t;
+	value.n128_u32[1] = t;
+	value.n128_u32[2] = t;
+	value.n128_u32[3] = t;
+
+	return value;
 }
 
 static inline void kinc_uint32x4_store(uint32_t *destination, kinc_uint32x4_t value) {

--- a/Sources/kinc/simd/uint32x4.h
+++ b/Sources/kinc/simd/uint32x4.h
@@ -54,7 +54,7 @@ static inline kinc_uint32x4_t kinc_uint32x4_max(kinc_uint32x4_t a, kinc_uint32x4
 		uint32_t a_single = kinc_uint32x4_get(a, i);
 		uint32_t b_single = kinc_uint32x4_get(b, i);
 
-		a_single > b_single ? values[i] = a_single : values[i] = b_single;
+		values[i] = a_single > b_single ? a_single : b_single;
 	}
 
 	return kinc_uint32x4_load(values);
@@ -69,7 +69,7 @@ static inline kinc_uint32x4_t kinc_uint32x4_min(kinc_uint32x4_t a, kinc_uint32x4
 		uint32_t a_single = kinc_uint32x4_get(a, i);
 		uint32_t b_single = kinc_uint32x4_get(b, i);
 
-		a_single > b_single ? values[i] = b_single : values[i] = a_single;
+		values[i] = a_single > b_single ? b_single : a_single;
 	}
 
 	return kinc_uint32x4_load(values);

--- a/Sources/kinc/simd/uint32x4.h
+++ b/Sources/kinc/simd/uint32x4.h
@@ -128,7 +128,7 @@ static inline void kinc_uint32x4_store(uint32_t *destination, kinc_uint32x4_t va
 }
 
 static inline uint32_t kinc_uint32x4_get(kinc_uint32x4_t t, int index) {
-	return t.n128_u32[index];
+	return vgetq_lane_u32(t, index);
 }
 
 static inline kinc_uint32x4_t kinc_uint32x4_add(kinc_uint32x4_t a, kinc_uint32x4_t b) {

--- a/Sources/kinc/simd/uint8x16.h
+++ b/Sources/kinc/simd/uint8x16.h
@@ -118,7 +118,7 @@ static inline void kinc_uint8x16_store(uint8_t *destination, kinc_uint8x16_t val
 }
 
 static inline uint8_t kinc_uint8x16_get(kinc_uint8x16_t t, int index) {
-	return t[index];
+	return t.n128_u8[index];
 }
 
 static inline kinc_uint8x16_t kinc_uint8x16_add(kinc_uint8x16_t a, kinc_uint8x16_t b) {

--- a/Sources/kinc/simd/uint8x16.h
+++ b/Sources/kinc/simd/uint8x16.h
@@ -12,6 +12,11 @@ extern "C" {
 
 #if defined(KINC_SSE2)
 
+static inline kinc_uint8x16_t kinc_uint8x16_intrin_load(uint8_t const *values)
+{
+	return _mm_load_si128((kinc_uint8x16_t const *)values);
+}
+
 static inline kinc_uint8x16_t kinc_uint8x16_load(const uint8_t values[16]) {
 	return _mm_set_epi8(values[15], values[14], values[13], values[12], values[11], values[10], values[9], values[8], values[7], values[6], values[5],
 	                    values[4], values[3], values[2], values[1], values[0]);
@@ -19,6 +24,11 @@ static inline kinc_uint8x16_t kinc_uint8x16_load(const uint8_t values[16]) {
 
 static inline kinc_uint8x16_t kinc_uint8x16_load_all(uint8_t t) {
 	return _mm_set1_epi8(t);
+}
+
+static inline void kinc_uint8x16_store(uint8_t *destination, kinc_uint8x16_t value)
+{
+	_mm_store_si128((kinc_uint8x16_t *)destination, value);
 }
 
 static inline uint8_t kinc_uint8x16_get(kinc_uint8x16_t t, int index) {
@@ -94,6 +104,11 @@ static inline kinc_uint8x16_t kinc_uint8x16_not(kinc_uint8x16_t t) {
 
 #elif defined(KINC_NEON)
 
+static inline kinc_uint8x16_t kinc_uint8x16_intrin_load(uint8_t const *values)
+{
+	return vld1q_u8(values);
+}
+
 static inline kinc_uint8x16_t kinc_uint8x16_load(const uint8_t values[16]) {
 	return (kinc_uint8x16_t){values[0], values[1], values[2],  values[3],  values[4],  values[5],  values[6],  values[7],
 	                         values[8], values[9], values[10], values[11], values[12], values[13], values[14], values[15]};
@@ -101,6 +116,11 @@ static inline kinc_uint8x16_t kinc_uint8x16_load(const uint8_t values[16]) {
 
 static inline kinc_uint8x16_t kinc_uint8x16_load_all(uint8_t t) {
 	return (kinc_uint8x16_t){t, t, t, t, t, t, t, t, t, t, t, t, t, t, t, t};
+}
+
+static inline kinc_uint8x16_t kinc_uint8x16_store(uint8_t *destination, kinc_uint8x16_t value)
+{
+	vst1q_u8(destination, value);
 }
 
 static inline uint8_t kinc_uint8x16_get(kinc_uint8x16_t t, int index) {
@@ -169,6 +189,28 @@ static inline kinc_uint8x16_t kinc_uint8x16_not(kinc_uint8x16_t t) {
 
 #else
 
+static inline kinc_uint8x16_t kinc_uint8x16_intrin_load(uint8_t const *values)
+{
+	kinc_uint8x16_t value;
+	value.values[0] = values[0];
+	value.values[1] = values[1];
+	value.values[2] = values[2];
+	value.values[3] = values[3];
+	value.values[4] = values[4];
+	value.values[5] = values[5];
+	value.values[6] = values[6];
+	value.values[7] = values[7];
+	value.values[8] = values[8];
+	value.values[9] = values[9];
+	value.values[10] = values[10];
+	value.values[11] = values[11];
+	value.values[12] = values[12];
+	value.values[13] = values[13];
+	value.values[14] = values[14];
+	value.values[15] = values[15];
+	return value;
+}
+
 static inline kinc_uint8x16_t kinc_uint8x16_load(const uint8_t values[16]) {
 	kinc_uint8x16_t value;
 	value.values[0] = values[0];
@@ -209,6 +251,26 @@ static inline kinc_uint8x16_t kinc_uint8x16_load_all(uint8_t t) {
 	value.values[14] = t;
 	value.values[15] = t;
 	return value;
+}
+
+static inline void kinc_uint8x16_store(uint8_t *destination, kinc_uint8x16_t value)
+{
+	destination[0] = value.values[0];
+	destination[1] = value.values[1];
+	destination[2] = value.values[2];
+	destination[3] = value.values[3];
+	destination[4] = value.values[4];
+	destination[5] = value.values[5];
+	destination[6] = value.values[6];
+	destination[7] = value.values[7];
+	destination[8] = value.values[8];
+	destination[9] = value.values[9];
+	destination[10] = value.values[10];
+	destination[11] = value.values[11];
+	destination[12] = value.values[12];
+	destination[13] = value.values[13];
+	destination[14] = value.values[14];
+	destination[15] = value.values[15];
 }
 
 static inline uint8_t kinc_uint8x16_get(kinc_uint8x16_t t, int index) {

--- a/Sources/kinc/simd/uint8x16.h
+++ b/Sources/kinc/simd/uint8x16.h
@@ -97,9 +97,7 @@ static inline kinc_uint8x16_t kinc_uint8x16_xor(kinc_uint8x16_t a, kinc_uint8x16
 }
 
 static inline kinc_uint8x16_t kinc_uint8x16_not(kinc_uint8x16_t t) {
-	//__m128i mask = _mm_set1_epi8(0xff);
-	// return _mm_xor_si128(t, mask);
-	return ~t;
+	return _mm_xor_si128(t, _mm_set1_epi32(0xffffffff));
 }
 
 #elif defined(KINC_NEON)

--- a/Sources/kinc/simd/uint8x16.h
+++ b/Sources/kinc/simd/uint8x16.h
@@ -127,25 +127,7 @@ static inline kinc_uint8x16_t kinc_uint8x16_load(const uint8_t values[16]) {
 }
 
 static inline kinc_uint8x16_t kinc_uint8x16_load_all(uint8_t t) {
-	kinc_uint8x16_t value;
-	value.n128_u8[0] = t;
-	value.n128_u8[1] = t;
-	value.n128_u8[2] = t;
-	value.n128_u8[3] = t;
-	value.n128_u8[4] = t;
-	value.n128_u8[5] = t;
-	value.n128_u8[6] = t;
-	value.n128_u8[7] = t;
-	value.n128_u8[8] = t;
-	value.n128_u8[9] = t;
-	value.n128_u8[10] = t;
-	value.n128_u8[11] = t;
-	value.n128_u8[12] = t;
-	value.n128_u8[13] = t;
-	value.n128_u8[14] = t;
-	value.n128_u8[15] = t;
-
-	return value;
+	return vdupq_n_u8(t);
 }
 
 static inline void kinc_uint8x16_store(uint8_t *destination, kinc_uint8x16_t value) {

--- a/Sources/kinc/simd/uint8x16.h
+++ b/Sources/kinc/simd/uint8x16.h
@@ -105,25 +105,8 @@ static inline kinc_uint8x16_t kinc_uint8x16_intrin_load(const uint8_t *values) {
 }
 
 static inline kinc_uint8x16_t kinc_uint8x16_load(const uint8_t values[16]) {
-	kinc_uint8x16_t value = vdupq_n_u8(0);
-	value = vsetq_lane_u8(values[0], value, 0);
-	value = vsetq_lane_u8(values[1], value, 1);
-	value = vsetq_lane_u8(values[2], value, 2);
-	value = vsetq_lane_u8(values[3], value, 3);
-	value = vsetq_lane_u8(values[4], value, 4);
-	value = vsetq_lane_u8(values[5], value, 5);
-	value = vsetq_lane_u8(values[6], value, 6);
-	value = vsetq_lane_u8(values[7], value, 7);
-	value = vsetq_lane_u8(values[8], value, 8);
-	value = vsetq_lane_u8(values[9], value, 9);
-	value = vsetq_lane_u8(values[10], value, 10);
-	value = vsetq_lane_u8(values[11], value, 11);
-	value = vsetq_lane_u8(values[12], value, 12);
-	value = vsetq_lane_u8(values[13], value, 13);
-	value = vsetq_lane_u8(values[14], value, 14);
-	value = vsetq_lane_u8(values[15], value, 15);
-
-	return value;
+	return (kinc_uint8x16_t){values[0], values[1], values[2],  values[3],  values[4],  values[5],  values[6],  values[7],
+	                         values[8], values[9], values[10], values[11], values[12], values[13], values[14], values[15]};
 }
 
 static inline kinc_uint8x16_t kinc_uint8x16_load_all(uint8_t t) {

--- a/Sources/kinc/simd/uint8x16.h
+++ b/Sources/kinc/simd/uint8x16.h
@@ -135,7 +135,7 @@ static inline void kinc_uint8x16_store(uint8_t *destination, kinc_uint8x16_t val
 }
 
 static inline uint8_t kinc_uint8x16_get(kinc_uint8x16_t t, int index) {
-	return vgetq_lane_u8(t, index);
+	return t[index];
 }
 
 static inline kinc_uint8x16_t kinc_uint8x16_add(kinc_uint8x16_t a, kinc_uint8x16_t b) {

--- a/Sources/kinc/simd/uint8x16.h
+++ b/Sources/kinc/simd/uint8x16.h
@@ -105,23 +105,23 @@ static inline kinc_uint8x16_t kinc_uint8x16_intrin_load(const uint8_t *values) {
 }
 
 static inline kinc_uint8x16_t kinc_uint8x16_load(const uint8_t values[16]) {
-	kinc_uint8x16_t value;
-	value.n128_u8[0] = values[0];
-	value.n128_u8[1] = values[1];
-	value.n128_u8[2] = values[2];
-	value.n128_u8[3] = values[3];
-	value.n128_u8[4] = values[4];
-	value.n128_u8[5] = values[5];
-	value.n128_u8[6] = values[6];
-	value.n128_u8[7] = values[7];
-	value.n128_u8[8] = values[8];
-	value.n128_u8[9] = values[9];
-	value.n128_u8[10] = values[10];
-	value.n128_u8[11] = values[11];
-	value.n128_u8[12] = values[12];
-	value.n128_u8[13] = values[13];
-	value.n128_u8[14] = values[14];
-	value.n128_u8[15] = values[15];
+	kinc_uint8x16_t value = vdupq_n_u8(0);
+	value = vsetq_lane_u8(values[0], value, 0);
+	value = vsetq_lane_u8(values[1], value, 1);
+	value = vsetq_lane_u8(values[2], value, 2);
+	value = vsetq_lane_u8(values[3], value, 3);
+	value = vsetq_lane_u8(values[4], value, 4);
+	value = vsetq_lane_u8(values[5], value, 5);
+	value = vsetq_lane_u8(values[6], value, 6);
+	value = vsetq_lane_u8(values[7], value, 7);
+	value = vsetq_lane_u8(values[8], value, 8);
+	value = vsetq_lane_u8(values[9], value, 9);
+	value = vsetq_lane_u8(values[10], value, 10);
+	value = vsetq_lane_u8(values[11], value, 11);
+	value = vsetq_lane_u8(values[12], value, 12);
+	value = vsetq_lane_u8(values[13], value, 13);
+	value = vsetq_lane_u8(values[14], value, 14);
+	value = vsetq_lane_u8(values[15], value, 15);
 
 	return value;
 }

--- a/Sources/kinc/simd/uint8x16.h
+++ b/Sources/kinc/simd/uint8x16.h
@@ -110,7 +110,7 @@ static inline kinc_uint8x16_t kinc_uint8x16_load(const uint8_t values[16]) {
 }
 
 static inline kinc_uint8x16_t kinc_uint8x16_load_all(uint8_t t) {
-	return vdupq_n_u8(t);
+	return (kinc_uint8x16_t){t, t, t, t, t, t, t, t, t, t, t, t, t, t, t, t};
 }
 
 static inline void kinc_uint8x16_store(uint8_t *destination, kinc_uint8x16_t value) {

--- a/Sources/kinc/simd/uint8x16.h
+++ b/Sources/kinc/simd/uint8x16.h
@@ -135,7 +135,7 @@ static inline void kinc_uint8x16_store(uint8_t *destination, kinc_uint8x16_t val
 }
 
 static inline uint8_t kinc_uint8x16_get(kinc_uint8x16_t t, int index) {
-	return t.n128_u8[index];
+	return vgetq_lane_u8(t, index);
 }
 
 static inline kinc_uint8x16_t kinc_uint8x16_add(kinc_uint8x16_t a, kinc_uint8x16_t b) {

--- a/Sources/kinc/simd/uint8x16.h
+++ b/Sources/kinc/simd/uint8x16.h
@@ -113,7 +113,7 @@ static inline kinc_uint8x16_t kinc_uint8x16_load_all(uint8_t t) {
 	return (kinc_uint8x16_t){t, t, t, t, t, t, t, t, t, t, t, t, t, t, t, t};
 }
 
-static inline kinc_uint8x16_t kinc_uint8x16_store(uint8_t *destination, kinc_uint8x16_t value) {
+static inline void kinc_uint8x16_store(uint8_t *destination, kinc_uint8x16_t value) {
 	vst1q_u8(destination, value);
 }
 

--- a/Sources/kinc/simd/uint8x16.h
+++ b/Sources/kinc/simd/uint8x16.h
@@ -259,43 +259,43 @@ static inline kinc_uint8x16_t kinc_uint8x16_sub(kinc_uint8x16_t a, kinc_uint8x16
 
 static inline kinc_uint8x16_t kinc_uint8x16_max(kinc_uint8x16_t a, kinc_uint8x16_t b) {
 	kinc_uint8x16_t value;
-	value.values[0] = kinc_max(a.values[0], b.values[0]);
-	value.values[1] = kinc_max(a.values[1], b.values[1]);
-	value.values[2] = kinc_max(a.values[2], b.values[2]);
-	value.values[3] = kinc_max(a.values[3], b.values[3]);
-	value.values[4] = kinc_max(a.values[4], b.values[4]);
-	value.values[5] = kinc_max(a.values[5], b.values[5]);
-	value.values[6] = kinc_max(a.values[6], b.values[6]);
-	value.values[7] = kinc_max(a.values[7], b.values[7]);
-	value.values[8] = kinc_max(a.values[8], b.values[8]);
-	value.values[9] = kinc_max(a.values[9], b.values[9]);
-	value.values[10] = kinc_max(a.values[10], b.values[10]);
-	value.values[11] = kinc_max(a.values[11], b.values[11]);
-	value.values[12] = kinc_max(a.values[12], b.values[12]);
-	value.values[13] = kinc_max(a.values[13], b.values[13]);
-	value.values[14] = kinc_max(a.values[14], b.values[14]);
-	value.values[15] = kinc_max(a.values[15], b.values[15]);
+	value.values[0] =  a.values[0] > b.values[0] ? a.values[0] : b.values[0];
+	value.values[1] =  a.values[1] > b.values[1] ? a.values[1] : b.values[1];
+	value.values[2] =  a.values[2] > b.values[2] ? a.values[2] : b.values[2];
+	value.values[3] =  a.values[3] > b.values[3] ? a.values[3] : b.values[3];
+	value.values[4] =  a.values[4] > b.values[4] ? a.values[4] : b.values[4];
+	value.values[5] =  a.values[5] > b.values[5] ? a.values[5] : b.values[5];
+	value.values[6] =  a.values[6] > b.values[6] ? a.values[6] : b.values[6];
+	value.values[7] =  a.values[7] > b.values[7] ? a.values[7] : b.values[7];
+	value.values[8] =  a.values[8] > b.values[8] ? a.values[8] : b.values[8];
+	value.values[9] =  a.values[9] > b.values[9] ? a.values[9] : b.values[9];
+	value.values[10] = a.values[10] > b.values[10] ? a.values[10] : b.values[10];
+	value.values[11] = a.values[11] > b.values[11] ? a.values[11] : b.values[11];
+	value.values[12] = a.values[12] > b.values[12] ? a.values[12] : b.values[12];
+	value.values[13] = a.values[13] > b.values[13] ? a.values[13] : b.values[13];
+	value.values[14] = a.values[14] > b.values[14] ? a.values[14] : b.values[14];
+	value.values[15] = a.values[15] > b.values[15] ? a.values[15] : b.values[15];
 	return value;
 }
 
 static inline kinc_uint8x16_t kinc_uint8x16_min(kinc_uint8x16_t a, kinc_uint8x16_t b) {
 	kinc_uint8x16_t value;
-	value.values[0] = kinc_min(a.values[0], b.values[0]);
-	value.values[1] = kinc_min(a.values[1], b.values[1]);
-	value.values[2] = kinc_min(a.values[2], b.values[2]);
-	value.values[3] = kinc_min(a.values[3], b.values[3]);
-	value.values[4] = kinc_min(a.values[4], b.values[4]);
-	value.values[5] = kinc_min(a.values[5], b.values[5]);
-	value.values[6] = kinc_min(a.values[6], b.values[6]);
-	value.values[7] = kinc_min(a.values[7], b.values[7]);
-	value.values[8] = kinc_min(a.values[8], b.values[8]);
-	value.values[9] = kinc_min(a.values[9], b.values[9]);
-	value.values[10] = kinc_min(a.values[10], b.values[10]);
-	value.values[11] = kinc_min(a.values[11], b.values[11]);
-	value.values[12] = kinc_min(a.values[12], b.values[12]);
-	value.values[13] = kinc_min(a.values[13], b.values[13]);
-	value.values[14] = kinc_min(a.values[14], b.values[14]);
-	value.values[15] = kinc_min(a.values[15], b.values[15]);
+	value.values[0] =  a.values[0] > b.values[0] ? b.values[0] : a.values[0];
+	value.values[1] =  a.values[1] > b.values[1] ? b.values[1] : a.values[1];
+	value.values[2] =  a.values[2] > b.values[2] ? b.values[2] : a.values[2];
+	value.values[3] =  a.values[3] > b.values[3] ? b.values[3] : a.values[3];
+	value.values[4] =  a.values[4] > b.values[4] ? b.values[4] : a.values[4];
+	value.values[5] =  a.values[5] > b.values[5] ? b.values[5] : a.values[5];
+	value.values[6] =  a.values[6] > b.values[6] ? b.values[6] : a.values[6];
+	value.values[7] =  a.values[7] > b.values[7] ? b.values[7] : a.values[7];
+	value.values[8] =  a.values[8] > b.values[8] ? b.values[8] : a.values[8];
+	value.values[9] =  a.values[9] > b.values[9] ? b.values[9] : a.values[9];
+	value.values[10] = a.values[10] > b.values[10] ? b.values[10] : a.values[10];
+	value.values[11] = a.values[11] > b.values[11] ? b.values[11] : a.values[11];
+	value.values[12] = a.values[12] > b.values[12] ? b.values[12] : a.values[12];
+	value.values[13] = a.values[13] > b.values[13] ? b.values[13] : a.values[13];
+	value.values[14] = a.values[14] > b.values[14] ? b.values[14] : a.values[14];
+	value.values[15] = a.values[15] > b.values[15] ? b.values[15] : a.values[15];
 	return value;
 }
 

--- a/Sources/kinc/simd/uint8x16.h
+++ b/Sources/kinc/simd/uint8x16.h
@@ -105,12 +105,47 @@ static inline kinc_uint8x16_t kinc_uint8x16_intrin_load(const uint8_t *values) {
 }
 
 static inline kinc_uint8x16_t kinc_uint8x16_load(const uint8_t values[16]) {
-	return (kinc_uint8x16_t){values[0], values[1], values[2],  values[3],  values[4],  values[5],  values[6],  values[7],
-	                         values[8], values[9], values[10], values[11], values[12], values[13], values[14], values[15]};
+	kinc_uint8x16_t value;
+	value.n128_u8[0] = values[0];
+	value.n128_u8[1] = values[1];
+	value.n128_u8[2] = values[2];
+	value.n128_u8[3] = values[3];
+	value.n128_u8[4] = values[4];
+	value.n128_u8[5] = values[5];
+	value.n128_u8[6] = values[6];
+	value.n128_u8[7] = values[7];
+	value.n128_u8[8] = values[8];
+	value.n128_u8[9] = values[9];
+	value.n128_u8[10] = values[10];
+	value.n128_u8[11] = values[11];
+	value.n128_u8[12] = values[12];
+	value.n128_u8[13] = values[13];
+	value.n128_u8[14] = values[14];
+	value.n128_u8[15] = values[15];
+
+	return value;
 }
 
 static inline kinc_uint8x16_t kinc_uint8x16_load_all(uint8_t t) {
-	return (kinc_uint8x16_t){t, t, t, t, t, t, t, t, t, t, t, t, t, t, t, t};
+	kinc_uint8x16_t value;
+	value.n128_u8[0] = t;
+	value.n128_u8[1] = t;
+	value.n128_u8[2] = t;
+	value.n128_u8[3] = t;
+	value.n128_u8[4] = t;
+	value.n128_u8[5] = t;
+	value.n128_u8[6] = t;
+	value.n128_u8[7] = t;
+	value.n128_u8[8] = t;
+	value.n128_u8[9] = t;
+	value.n128_u8[10] = t;
+	value.n128_u8[11] = t;
+	value.n128_u8[12] = t;
+	value.n128_u8[13] = t;
+	value.n128_u8[14] = t;
+	value.n128_u8[15] = t;
+
+	return value;
 }
 
 static inline void kinc_uint8x16_store(uint8_t *destination, kinc_uint8x16_t value) {

--- a/Sources/kinc/simd/uint8x16.h
+++ b/Sources/kinc/simd/uint8x16.h
@@ -12,9 +12,8 @@ extern "C" {
 
 #if defined(KINC_SSE2)
 
-static inline kinc_uint8x16_t kinc_uint8x16_intrin_load(uint8_t const *values)
-{
-	return _mm_load_si128((kinc_uint8x16_t const *)values);
+static inline kinc_uint8x16_t kinc_uint8x16_intrin_load(const uint8_t *values) {
+	return _mm_load_si128((const kinc_uint8x16_t *)values);
 }
 
 static inline kinc_uint8x16_t kinc_uint8x16_load(const uint8_t values[16]) {
@@ -26,8 +25,7 @@ static inline kinc_uint8x16_t kinc_uint8x16_load_all(uint8_t t) {
 	return _mm_set1_epi8(t);
 }
 
-static inline void kinc_uint8x16_store(uint8_t *destination, kinc_uint8x16_t value)
-{
+static inline void kinc_uint8x16_store(uint8_t *destination, kinc_uint8x16_t value) {
 	_mm_store_si128((kinc_uint8x16_t *)destination, value);
 }
 
@@ -102,8 +100,7 @@ static inline kinc_uint8x16_t kinc_uint8x16_not(kinc_uint8x16_t t) {
 
 #elif defined(KINC_NEON)
 
-static inline kinc_uint8x16_t kinc_uint8x16_intrin_load(uint8_t const *values)
-{
+static inline kinc_uint8x16_t kinc_uint8x16_intrin_load(const uint8_t *values) {
 	return vld1q_u8(values);
 }
 
@@ -116,8 +113,7 @@ static inline kinc_uint8x16_t kinc_uint8x16_load_all(uint8_t t) {
 	return (kinc_uint8x16_t){t, t, t, t, t, t, t, t, t, t, t, t, t, t, t, t};
 }
 
-static inline kinc_uint8x16_t kinc_uint8x16_store(uint8_t *destination, kinc_uint8x16_t value)
-{
+static inline kinc_uint8x16_t kinc_uint8x16_store(uint8_t *destination, kinc_uint8x16_t value) {
 	vst1q_u8(destination, value);
 }
 
@@ -187,8 +183,7 @@ static inline kinc_uint8x16_t kinc_uint8x16_not(kinc_uint8x16_t t) {
 
 #else
 
-static inline kinc_uint8x16_t kinc_uint8x16_intrin_load(uint8_t const *values)
-{
+static inline kinc_uint8x16_t kinc_uint8x16_intrin_load(const uint8_t *values) {
 	kinc_uint8x16_t value;
 	value.values[0] = values[0];
 	value.values[1] = values[1];
@@ -251,8 +246,7 @@ static inline kinc_uint8x16_t kinc_uint8x16_load_all(uint8_t t) {
 	return value;
 }
 
-static inline void kinc_uint8x16_store(uint8_t *destination, kinc_uint8x16_t value)
-{
+static inline void kinc_uint8x16_store(uint8_t *destination, kinc_uint8x16_t value) {
 	destination[0] = value.values[0];
 	destination[1] = value.values[1];
 	destination[2] = value.values[2];


### PR DESCRIPTION
This was supposed to just be some small fixes to address https://github.com/Kode/Kinc/issues/762, but this surprisingly became a game of whack-a-mole really fast as I started testing the current headers, some things were broken, not compiling, or a little off unfortunately. There's a mix of additions, bug-fixes, and maybe-bug-fixes in here.

I'll add that I was using the headers with a CPP project, so some compilation issues may have not actually been a problem in pure C. Hopefully that's ok.

Fixes:
* SSE2 now actually works as its header is now included when appropriate
* SSE2 now actually works for uint types as it actually compiles now (bitwise not intrinsics were broken)
* Windows 64bit is now properly checked for SSE2 support
* kinc_min and kinc_max for floats were being used on fallback int/uint types, but not anymore
* Some headers didn't have a uniform API (ex. some had missing SSE2 min and max, but had a fallback)
* Fallback int/uint masks are now just weak typedefs around the underlying SIMD type, the NEON and SSE APIs both seem to expect you to use masks as basic SIMD types in some cases (ex. intrinsic and/or functions)
* Fixes one or two incorrectly sized masks (0xffff instead of 0xffffffff) used inside the int fallbacks
* A mask and underlying type mismatch 

Maybe-Fixes:
* Bitwise not is now implemented for unsigned int types in SSE2 but is kind of sketchy, seems to work though
* SIMD types header is now IMO easier to read at the expense of some copy and paste.

Additions:
* Adds intrinsic aligned load/store instructions for all types. To avoid an API break the SIMD load instruction is referred to as "[type]_intrin_load" for now.
* New Kinc defines for SSE4.2, SSE4.1, SSSE3, and SSE3, although there aren't any new instructions utilizing these instruction sets

Intentionally excluded from this PR:
* No changes to the current load and load_all functions **naming** (should have clarified that) to avoid breaking things (although I still think they should be renamed eventually)
* No changes to the inconsistent "load/load_all" parameter lists between float, and everything else

I did some not-super-comprehensive 5-second messing around with the SSE2 and NOSIMD fallbacks, and things seem to be working alright...after several adjustments