### PR TITLE
SIMD Improvements 2: Add missing unsigned int comparisons and improve SSE2 unsigned min/max functions

### DIFF
--- a/Sources/kinc/simd/uint16x8.h
+++ b/Sources/kinc/simd/uint16x8.h
@@ -83,6 +83,26 @@ static inline kinc_uint16x8_mask_t kinc_uint16x8_cmpneq(kinc_uint16x8_t a, kinc_
 	return _mm_andnot_si128(_mm_cmpeq_epi16(a, b), _mm_set1_epi32(0xffffffff));
 }
 
+static inline kinc_uint16x8_mask_t kinc_uint16x8_cmpge(kinc_uint16x8_t a, kinc_uint16x8_t b) {
+	__m128i bias_by = _mm_set1_epi16((uint16_t)0x8000);
+	return _mm_or_si128(_mm_cmpgt_epi16(_mm_sub_epi16(a, bias_by), _mm_sub_epi16(b, bias_by)), _mm_cmpeq_epi16(a, b));
+}
+
+static inline kinc_uint16x8_mask_t kinc_uint16x8_cmpgt(kinc_uint16x8_t a, kinc_uint16x8_t b) {
+	__m128i bias_by = _mm_set1_epi16((uint16_t)0x8000);
+	return _mm_cmpgt_epi16(_mm_sub_epi16(a, bias_by), _mm_sub_epi16(b, bias_by));
+}
+
+static inline kinc_uint16x8_mask_t kinc_uint16x8_cmple(kinc_uint16x8_t a, kinc_uint16x8_t b) {
+	__m128i bias_by = _mm_set1_epi16((uint16_t)0x8000);
+	return _mm_or_si128(_mm_cmplt_epi16(_mm_sub_epi16(a, bias_by), _mm_sub_epi16(b, bias_by)), _mm_cmpeq_epi16(a, b));
+}
+
+static inline kinc_uint16x8_mask_t kinc_uint16x8_cmplt(kinc_uint16x8_t a, kinc_uint16x8_t b) {
+	__m128i bias_by = _mm_set1_epi16((uint16_t)0x8000);
+	return _mm_cmplt_epi16(_mm_sub_epi16(a, bias_by), _mm_sub_epi16(b, bias_by));
+}
+
 static inline kinc_uint16x8_t kinc_uint16x8_sel(kinc_uint16x8_t a, kinc_uint16x8_t b, kinc_uint16x8_mask_t mask) {
 	return _mm_xor_si128(b, _mm_and_si128(mask, _mm_xor_si128(a, b)));
 }
@@ -147,6 +167,22 @@ static inline kinc_uint16x8_mask_t kinc_uint16x8_cmpeq(kinc_uint16x8_t a, kinc_u
 
 static inline kinc_uint16x8_mask_t kinc_uint16x8_cmpneq(kinc_uint16x8_t a, kinc_uint16x8_t b) {
 	return vmvnq_u16(vceqq_u16(a, b));
+}
+
+static inline kinc_uint16x8_mask_t kinc_uint16x8_cmpge(kinc_uint16x8_t a, kinc_uint16x8_t b) {
+	return vcgeq_u16(a, b);
+}
+
+static inline kinc_uint16x8_mask_t kinc_uint16x8_cmpgt(kinc_uint16x8_t a, kinc_uint16x8_t b) {
+	return vcgtq_u16(a, b);
+}
+
+static inline kinc_uint16x8_mask_t kinc_uint16x8_cmple(kinc_uint16x8_t a, kinc_uint16x8_t b) {
+	return vcleq_u16(a, b);
+}
+
+static inline kinc_uint16x8_mask_t kinc_uint16x8_cmplt(kinc_uint16x8_t a, kinc_uint16x8_t b) {
+	return vcltq_u16(a, b);
 }
 
 static inline kinc_uint16x8_t kinc_uint16x8_sel(kinc_uint16x8_t a, kinc_uint16x8_t b, kinc_uint16x8_mask_t mask) {
@@ -300,6 +336,58 @@ static inline kinc_uint16x8_mask_t kinc_uint16x8_cmpneq(kinc_uint16x8_t a, kinc_
 	mask.values[5] = a.values[5] != b.values[5] ? 0xffff : 0;
 	mask.values[6] = a.values[6] != b.values[6] ? 0xffff : 0;
 	mask.values[7] = a.values[7] != b.values[7] ? 0xffff : 0;
+	return mask;
+}
+
+static inline kinc_uint16x8_mask_t kinc_uint16x8_cmpge(kinc_uint16x8_t a, kinc_uint16x8_t b) {
+	kinc_uint16x8_mask_t mask;
+	mask.values[0] = a.values[0] >= b.values[0] ? 0xffff : 0;
+	mask.values[1] = a.values[1] >= b.values[1] ? 0xffff : 0;
+	mask.values[2] = a.values[2] >= b.values[2] ? 0xffff : 0;
+	mask.values[3] = a.values[3] >= b.values[3] ? 0xffff : 0;
+	mask.values[4] = a.values[4] >= b.values[4] ? 0xffff : 0;
+	mask.values[5] = a.values[5] >= b.values[5] ? 0xffff : 0;
+	mask.values[6] = a.values[6] >= b.values[6] ? 0xffff : 0;
+	mask.values[7] = a.values[7] >= b.values[7] ? 0xffff : 0;
+	return mask;
+}
+
+static inline kinc_uint16x8_mask_t kinc_uint16x8_cmpgt(kinc_uint16x8_t a, kinc_uint16x8_t b) {
+	kinc_uint16x8_mask_t mask;
+	mask.values[0] = a.values[0] > b.values[0] ? 0xffff : 0;
+	mask.values[1] = a.values[1] > b.values[1] ? 0xffff : 0;
+	mask.values[2] = a.values[2] > b.values[2] ? 0xffff : 0;
+	mask.values[3] = a.values[3] > b.values[3] ? 0xffff : 0;
+	mask.values[4] = a.values[4] > b.values[4] ? 0xffff : 0;
+	mask.values[5] = a.values[5] > b.values[5] ? 0xffff : 0;
+	mask.values[6] = a.values[6] > b.values[6] ? 0xffff : 0;
+	mask.values[7] = a.values[7] > b.values[7] ? 0xffff : 0;
+	return mask;
+}
+
+static inline kinc_uint16x8_mask_t kinc_uint16x8_cmple(kinc_uint16x8_t a, kinc_uint16x8_t b) {
+	kinc_uint16x8_mask_t mask;
+	mask.values[0] = a.values[0] <= b.values[0] ? 0xffff : 0;
+	mask.values[1] = a.values[1] <= b.values[1] ? 0xffff : 0;
+	mask.values[2] = a.values[2] <= b.values[2] ? 0xffff : 0;
+	mask.values[3] = a.values[3] <= b.values[3] ? 0xffff : 0;
+	mask.values[4] = a.values[4] <= b.values[4] ? 0xffff : 0;
+	mask.values[5] = a.values[5] <= b.values[5] ? 0xffff : 0;
+	mask.values[6] = a.values[6] <= b.values[6] ? 0xffff : 0;
+	mask.values[7] = a.values[7] <= b.values[7] ? 0xffff : 0;
+	return mask;
+}
+
+static inline kinc_uint16x8_mask_t kinc_uint16x8_cmplt(kinc_uint16x8_t a, kinc_uint16x8_t b) {
+	kinc_uint16x8_mask_t mask;
+	mask.values[0] = a.values[0] < b.values[0] ? 0xffff : 0;
+	mask.values[1] = a.values[1] < b.values[1] ? 0xffff : 0;
+	mask.values[2] = a.values[2] < b.values[2] ? 0xffff : 0;
+	mask.values[3] = a.values[3] < b.values[3] ? 0xffff : 0;
+	mask.values[4] = a.values[4] < b.values[4] ? 0xffff : 0;
+	mask.values[5] = a.values[5] < b.values[5] ? 0xffff : 0;
+	mask.values[6] = a.values[6] < b.values[6] ? 0xffff : 0;
+	mask.values[7] = a.values[7] < b.values[7] ? 0xffff : 0;
 	return mask;
 }
 

--- a/Sources/kinc/simd/uint16x8.h
+++ b/Sources/kinc/simd/uint16x8.h
@@ -45,36 +45,6 @@ static inline kinc_uint16x8_t kinc_uint16x8_sub(kinc_uint16x8_t a, kinc_uint16x8
 	return _mm_sub_epi16(a, b);
 }
 
-static inline kinc_uint16x8_t kinc_uint16x8_max(kinc_uint16x8_t a, kinc_uint16x8_t b) {
-	//No obvious intrinsic here; use a subpar fallback method
-	uint16_t values[8];
-
-	for(int i = 0; i < 8; ++i) {
-
-		uint16_t a_single = kinc_uint16x8_get(a, i);
-		uint16_t b_single = kinc_uint16x8_get(b, i);
-
-		values[i] = a_single > b_single ? a_single : b_single;
-	}
-
-	return kinc_uint16x8_load(values);
-}
-
-static inline kinc_uint16x8_t kinc_uint16x8_min(kinc_uint16x8_t a, kinc_uint16x8_t b) {
-	//No obvious intrinsic here; use a subpar fallback method
-	uint16_t values[8];
-
-	for(int i = 0; i < 8; ++i) {
-
-		uint16_t a_single = kinc_uint16x8_get(a, i);
-		uint16_t b_single = kinc_uint16x8_get(b, i);
-
-		values[i] = a_single > b_single ? b_single : a_single;
-	}
-
-	return kinc_uint16x8_load(values);
-}
-
 static inline kinc_uint16x8_mask_t kinc_uint16x8_cmpeq(kinc_uint16x8_t a, kinc_uint16x8_t b) {
 	return _mm_cmpeq_epi16(a, b);
 }
@@ -105,6 +75,14 @@ static inline kinc_uint16x8_mask_t kinc_uint16x8_cmplt(kinc_uint16x8_t a, kinc_u
 
 static inline kinc_uint16x8_t kinc_uint16x8_sel(kinc_uint16x8_t a, kinc_uint16x8_t b, kinc_uint16x8_mask_t mask) {
 	return _mm_xor_si128(b, _mm_and_si128(mask, _mm_xor_si128(a, b)));
+}
+
+static inline kinc_uint16x8_t kinc_uint16x8_max(kinc_uint16x8_t a, kinc_uint16x8_t b) {
+	return kinc_uint16x8_sel(a, b, kinc_uint16x8_cmpgt(a, b));
+}
+
+static inline kinc_uint16x8_t kinc_uint16x8_min(kinc_uint16x8_t a, kinc_uint16x8_t b) {
+	return kinc_uint16x8_sel(a, b, kinc_uint16x8_cmplt(a, b));
 }
 
 static inline kinc_uint16x8_t kinc_uint16x8_or(kinc_uint16x8_t a, kinc_uint16x8_t b) {

--- a/Sources/kinc/simd/uint32x4.h
+++ b/Sources/kinc/simd/uint32x4.h
@@ -83,6 +83,30 @@ static inline kinc_uint32x4_mask_t kinc_uint32x4_cmpneq(kinc_uint32x4_t a, kinc_
 	return _mm_andnot_si128(_mm_cmpeq_epi32(a, b), _mm_set1_epi32(0xffffffff));
 }
 
+static inline kinc_uint32x4_mask_t kinc_uint32x4_cmpge(kinc_uint32x4_t a, kinc_uint32x4_t b)
+{
+	__m128i bias_by = _mm_set1_epi32((uint32_t)0x80000000);
+	return _mm_or_si128(_mm_cmpgt_epi32(_mm_sub_epi32(a, bias_by), _mm_sub_epi32(b, bias_by)), _mm_cmpeq_epi32(a, b));
+}
+
+static inline kinc_uint32x4_mask_t kinc_uint32x4_cmpgt(kinc_uint32x4_t a, kinc_uint32x4_t b)
+{
+	__m128i bias_by = _mm_set1_epi32((uint32_t)0x80000000);
+	return _mm_cmpgt_epi32(_mm_sub_epi32(a, bias_by), _mm_sub_epi32(b, bias_by));
+}
+
+static inline kinc_uint32x4_mask_t kinc_uint32x4_cmple(kinc_uint32x4_t a, kinc_uint32x4_t b)
+{
+	__m128i bias_by = _mm_set1_epi32((uint32_t)0x80000000);
+	return _mm_or_si128(_mm_cmplt_epi32(_mm_sub_epi32(a, bias_by), _mm_sub_epi32(b, bias_by)), _mm_cmpeq_epi32(a, b));
+}
+
+static inline kinc_uint32x4_mask_t kinc_uint32x4_cmplt(kinc_uint32x4_t a, kinc_uint32x4_t b)
+{
+	__m128i bias_by = _mm_set1_epi32((uint32_t)0x80000000);
+	return _mm_cmplt_epi32(_mm_sub_epi32(a, bias_by), _mm_sub_epi32(b, bias_by));
+}
+
 static inline kinc_uint32x4_t kinc_uint32x4_sel(kinc_uint32x4_t a, kinc_uint32x4_t b, kinc_uint32x4_mask_t mask) {
 	return _mm_xor_si128(b, _mm_and_si128(mask, _mm_xor_si128(a, b)));
 }
@@ -147,6 +171,26 @@ static inline kinc_uint32x4_mask_t kinc_uint32x4_cmpeq(kinc_uint32x4_t a, kinc_u
 
 static inline kinc_uint32x4_mask_t kinc_uint32x4_cmpneq(kinc_uint32x4_t a, kinc_uint32x4_t b) {
 	return vmvnq_u32(vceqq_u32(a, b));
+}
+
+static inline kinc_uint32x4_mask_t kinc_uint32x4_cmpge(kinc_uint32x4_t a, kinc_uint32x4_t b)
+{
+	return vcgeq_u32(a, b);
+}
+
+static inline kinc_uint32x4_mask_t kinc_uint32x4_cmpgt(kinc_uint32x4_t a, kinc_uint32x4_t b)
+{
+	return vcgtq_u32(a, b);
+}
+
+static inline kinc_uint32x4_mask_t kinc_uint32x4_cmple(kinc_uint32x4_t a, kinc_uint32x4_t b)
+{
+	return vcleq_u32(a, b);
+}
+
+static inline kinc_uint32x4_mask_t kinc_uint32x4_cmplt(kinc_uint32x4_t a, kinc_uint32x4_t b)
+{
+	return vcltq_u32(a, b);
 }
 
 static inline kinc_uint32x4_t kinc_uint32x4_sel(kinc_uint32x4_t a, kinc_uint32x4_t b, kinc_uint32x4_mask_t mask) {
@@ -260,6 +304,46 @@ static inline kinc_uint32x4_mask_t kinc_uint32x4_cmpneq(kinc_uint32x4_t a, kinc_
 	mask.values[1] = a.values[1] != b.values[1] ? 0xffffffff : 0;
 	mask.values[2] = a.values[2] != b.values[2] ? 0xffffffff : 0;
 	mask.values[3] = a.values[3] != b.values[3] ? 0xffffffff : 0;
+	return mask;
+}
+
+static inline kinc_uint32x4_mask_t kinc_uint32x4_cmpge(kinc_uint32x4_t a, kinc_uint32x4_t b)
+{
+	kinc_uint32x4_mask_t mask;
+	mask.values[0] = a.values[0] >= b.values[0] ? 0xffffffff : 0;
+	mask.values[1] = a.values[1] >= b.values[1] ? 0xffffffff : 0;
+	mask.values[2] = a.values[2] >= b.values[2] ? 0xffffffff : 0;
+	mask.values[3] = a.values[3] >= b.values[3] ? 0xffffffff : 0;
+	return mask;
+}
+
+static inline kinc_uint32x4_mask_t kinc_uint32x4_cmpgt(kinc_uint32x4_t a, kinc_uint32x4_t b)
+{
+	kinc_uint32x4_mask_t mask;
+	mask.values[0] = a.values[0] > b.values[0] ? 0xffffffff : 0;
+	mask.values[1] = a.values[1] > b.values[1] ? 0xffffffff : 0;
+	mask.values[2] = a.values[2] > b.values[2] ? 0xffffffff : 0;
+	mask.values[3] = a.values[3] > b.values[3] ? 0xffffffff : 0;
+	return mask;
+}
+
+static inline kinc_uint32x4_mask_t kinc_uint32x4_cmple(kinc_uint32x4_t a, kinc_uint32x4_t b)
+{
+	kinc_uint32x4_mask_t mask;
+	mask.values[0] = a.values[0] <= b.values[0] ? 0xffffffff : 0;
+	mask.values[1] = a.values[1] <= b.values[1] ? 0xffffffff : 0;
+	mask.values[2] = a.values[2] <= b.values[2] ? 0xffffffff : 0;
+	mask.values[3] = a.values[3] <= b.values[3] ? 0xffffffff : 0;
+	return mask;
+}
+
+static inline kinc_uint32x4_mask_t kinc_uint32x4_cmplt(kinc_uint32x4_t a, kinc_uint32x4_t b)
+{
+	kinc_uint32x4_mask_t mask;
+	mask.values[0] = a.values[0] < b.values[0] ? 0xffffffff : 0;
+	mask.values[1] = a.values[1] < b.values[1] ? 0xffffffff : 0;
+	mask.values[2] = a.values[2] < b.values[2] ? 0xffffffff : 0;
+	mask.values[3] = a.values[3] < b.values[3] ? 0xffffffff : 0;
 	return mask;
 }
 

--- a/Sources/kinc/simd/uint32x4.h
+++ b/Sources/kinc/simd/uint32x4.h
@@ -45,36 +45,6 @@ static inline kinc_uint32x4_t kinc_uint32x4_sub(kinc_uint32x4_t a, kinc_uint32x4
 	return _mm_sub_epi32(a, b);
 }
 
-static inline kinc_uint32x4_t kinc_uint32x4_max(kinc_uint32x4_t a, kinc_uint32x4_t b) {
-	//No obvious intrinsic here; use a subpar fallback method
-	uint32_t values[4];
-
-	for(int i = 0; i < 4; ++i) {
-
-		uint32_t a_single = kinc_uint32x4_get(a, i);
-		uint32_t b_single = kinc_uint32x4_get(b, i);
-
-		values[i] = a_single > b_single ? a_single : b_single;
-	}
-
-	return kinc_uint32x4_load(values);
-}
-
-static inline kinc_uint32x4_t kinc_uint32x4_min(kinc_uint32x4_t a, kinc_uint32x4_t b) {
-	//No obvious intrinsic here; use a subpar fallback method
-	uint32_t values[4];
-
-	for(int i = 0; i < 4; ++i) {
-
-		uint32_t a_single = kinc_uint32x4_get(a, i);
-		uint32_t b_single = kinc_uint32x4_get(b, i);
-
-		values[i] = a_single > b_single ? b_single : a_single;
-	}
-
-	return kinc_uint32x4_load(values);
-}
-
 static inline kinc_uint32x4_mask_t kinc_uint32x4_cmpeq(kinc_uint32x4_t a, kinc_uint32x4_t b) {
 	return _mm_cmpeq_epi32(a, b);
 }
@@ -109,6 +79,14 @@ static inline kinc_uint32x4_mask_t kinc_uint32x4_cmplt(kinc_uint32x4_t a, kinc_u
 
 static inline kinc_uint32x4_t kinc_uint32x4_sel(kinc_uint32x4_t a, kinc_uint32x4_t b, kinc_uint32x4_mask_t mask) {
 	return _mm_xor_si128(b, _mm_and_si128(mask, _mm_xor_si128(a, b)));
+}
+
+static inline kinc_uint32x4_t kinc_uint32x4_max(kinc_uint32x4_t a, kinc_uint32x4_t b) {
+	return kinc_uint32x4_sel(a, b, kinc_uint32x4_cmpgt(a, b));
+}
+
+static inline kinc_uint32x4_t kinc_uint32x4_min(kinc_uint32x4_t a, kinc_uint32x4_t b) {
+	return kinc_uint32x4_sel(a, b, kinc_uint32x4_cmplt(a, b));
 }
 
 static inline kinc_uint32x4_t kinc_uint32x4_or(kinc_uint32x4_t a, kinc_uint32x4_t b) {


### PR DESCRIPTION
Bonus round, uint32x4 and uint16x8 were missing GT/GTE/LT/LTE comparisons for SSE2/NEON/and the fallback presumably because SSE2/SSE doesn't have unsigned comparisons at all (???). This PR adds them all to all implementations and uses a Cute Trick™ for SSE2 to get around the missing instruction problem.

Also, with working comparisons the SSE2 min and max functions for uint32x4 and uint16x8 can now not be terrible.

uint8x16 already has these comparisons implemented since there are a couple of existing SSE2 intrinsics that you can leverage for this type.