### PR TITLE
SIMD Improvements 3: Float shuffles, float bitops, type casts

### DIFF
--- a/Sources/kinc/simd/float32x4.h
+++ b/Sources/kinc/simd/float32x4.h
@@ -130,7 +130,7 @@ static inline kinc_float32x4_t kinc_float32x4_not(kinc_float32x4_t t) {
 }
 
 #define kinc_float32x4_shuffle_custom(abcd, efgh, left_1, left_2, right_1, right_2)\
-	_mm_shuffle_ps(abcd, efgh, KINC_SHUFFLE_TABLE((left_1), (left_2), (right_1), (right_2)))
+	_mm_shuffle_ps((abcd), (efgh), KINC_SHUFFLE_TABLE((left_1), (left_2), (right_1), (right_2)))
 
 static inline kinc_float32x4_t kinc_float32x4_shuffle_aebf(kinc_float32x4_t abcd, kinc_float32x4_t efgh) {
 	//aka unpacklo aka zip1 aka interleave low
@@ -287,10 +287,10 @@ static inline kinc_float32x4_t kinc_float32x4_not(kinc_float32x4_t t) {
 
 #define kinc_float32x4_shuffle_custom(abcd, efgh, left_1, left_2, right_1, right_2)\
 	(kinc_float32x4_t){\
-		vgetq_lane_f32(abcd, (left_1 & 0x3)),\
-		vgetq_lane_f32(abcd, (left_2 & 0x3)),\
-		vgetq_lane_f32(efgh, (right_1 & 0x3)),\
-		vgetq_lane_f32(efgh, (right_2 & 0x3))\
+		vgetq_lane_f32((abcd), ((left_1) & 0x3)),\
+		vgetq_lane_f32((abcd), ((left_2) & 0x3)),\
+		vgetq_lane_f32((efgh), ((right_1) & 0x3)),\
+		vgetq_lane_f32((efgh), ((right_2) & 0x3))\
 	}
 
 static inline kinc_float32x4_t kinc_float32x4_shuffle_aebf(kinc_float32x4_t abcd, kinc_float32x4_t efgh) {
@@ -328,7 +328,6 @@ static inline kinc_float32x4_t kinc_float32x4_shuffle_cgdh(kinc_float32x4_t abcd
 }
 
 static inline kinc_float32x4_t kinc_float32x4_shuffle_abef(kinc_float32x4_t abcd, kinc_float32x4_t efgh) {
-	//aka movelh
 	float32x2_t ab = vget_low_f32(abcd);
 	float32x2_t ef = vget_low_f32(efgh);
 
@@ -336,7 +335,6 @@ static inline kinc_float32x4_t kinc_float32x4_shuffle_abef(kinc_float32x4_t abcd
 }
 
 static inline kinc_float32x4_t kinc_float32x4_shuffle_ghcd(kinc_float32x4_t abcd, kinc_float32x4_t efgh) {
-	//aka movehl
 	float32x2_t cd = vget_high_f32(abcd);
 	float32x2_t gh = vget_high_f32(efgh);
 
@@ -651,7 +649,6 @@ static inline kinc_float32x4_t kinc_float32x4_shuffle_custom(kinc_float32x4_t ab
 }
 
 static inline kinc_float32x4_t kinc_float32x4_shuffle_aebf(kinc_float32x4_t abcd, kinc_float32x4_t efgh) {
-	//aka unpacklo aka zip1 aka interleave low
 	kinc_float32x4_t value;
 
 	value.values[0] = abcd.values[0];

--- a/Sources/kinc/simd/float32x4.h
+++ b/Sources/kinc/simd/float32x4.h
@@ -113,6 +113,24 @@ static inline kinc_float32x4_t kinc_float32x4_sel(kinc_float32x4_t a, kinc_float
 	return _mm_xor_ps(b, _mm_and_ps(mask, _mm_xor_ps(a, b)));
 }
 
+static inline kinc_float32x4_t kinc_float32x4_or(kinc_float32x4_t a, kinc_float32x4_t b) {
+	return _mm_or_ps(a, b);
+}
+
+static inline kinc_float32x4_t kinc_float32x4_and(kinc_float32x4_t a, kinc_float32x4_t b) {
+	return _mm_and_ps(a, b);
+}
+
+static inline kinc_float32x4_t kinc_float32x4_xor(kinc_float32x4_t a, kinc_float32x4_t b) {
+	return _mm_xor_ps(a, b);
+}
+
+static inline kinc_float32x4_t kinc_float32x4_not(kinc_float32x4_t t) {
+	__m128 zeroes = _mm_setzero_ps();
+	return _mm_xor_ps(t, _mm_cmpeq_ps(zeroes, zeroes));
+}
+
+
 #elif defined(KINC_NEON)
 
 static inline kinc_float32x4_t kinc_float32x4_intrin_load(const float *values) {
@@ -217,6 +235,34 @@ static inline kinc_float32x4_mask_t kinc_float32x4_cmpneq(kinc_float32x4_t a, ki
 static inline kinc_float32x4_t kinc_float32x4_sel(kinc_float32x4_t a, kinc_float32x4_t b, kinc_float32x4_mask_t mask) {
 	return vbslq_f32(mask, a, b);
 }
+
+static inline kinc_float32x4_t kinc_float32x4_or(kinc_float32x4_t a, kinc_float32x4_t b) {
+	uint32x4_t acvt = vreinterpretq_u32_f32(a);
+	uint32x4_t bcvt = vreinterpretq_u32_f32(b);
+
+	return vreinterpretq_f32_u32(vorrq_u32(acvt, bcvt));
+}
+
+static inline kinc_float32x4_t kinc_float32x4_and(kinc_float32x4_t a, kinc_float32x4_t b) {
+	uint32x4_t acvt = vreinterpretq_u32_f32(a);
+	uint32x4_t bcvt = vreinterpretq_u32_f32(b);
+
+	return vreinterpretq_f32_u32(vandq_u32(acvt, bcvt));
+}
+
+static inline kinc_float32x4_t kinc_float32x4_xor(kinc_float32x4_t a, kinc_float32x4_t b) {
+	uint32x4_t acvt = vreinterpretq_u32_f32(a);
+	uint32x4_t bcvt = vreinterpretq_u32_f32(b);
+
+	return vreinterpretq_f32_u32(veorq_u32(acvt, bcvt));
+}
+
+static inline kinc_float32x4_t kinc_float32x4_not(kinc_float32x4_t t) {
+	uint32x4_t tcvt = vreinterpretq_u32_f32(t);
+
+	return vreinterpretq_f32_u32(vmvnq_u32(tcvt));
+}
+
 
 #else
 
@@ -445,6 +491,73 @@ static inline kinc_float32x4_t kinc_float32x4_sel(kinc_float32x4_t a, kinc_float
 	value.values[3] = mask.values[3] != 0.0f ? a.values[3] : b.values[3];
 	return value;
 }
+
+static inline kinc_float32x4_t kinc_float32x4_or(kinc_float32x4_t a, kinc_float32x4_t b) {
+	kinc_float32x4_t value; 
+	kinc_internal_float32x4_converter_t acvt;
+	kinc_internal_float32x4_converter_t bcvt;
+	memcpy(&acvt, &a, sizeof(a));
+	memcpy(&bcvt, &b, sizeof(b));
+
+	acvt.as_ints[0] |= bcvt.as_ints[0];
+	acvt.as_ints[1] |= bcvt.as_ints[1];
+	acvt.as_ints[2] |= bcvt.as_ints[2];
+	acvt.as_ints[3] |= bcvt.as_ints[3];
+
+	memcpy(&value, &acvt, sizeof(acvt));
+
+	return value;
+}
+
+static inline kinc_float32x4_t kinc_float32x4_and(kinc_float32x4_t a, kinc_float32x4_t b) {
+	kinc_float32x4_t value; 
+	kinc_internal_float32x4_converter_t acvt;
+	kinc_internal_float32x4_converter_t bcvt;
+	memcpy(&acvt, &a, sizeof(a));
+	memcpy(&bcvt, &b, sizeof(b));
+
+	acvt.as_ints[0] &= bcvt.as_ints[0];
+	acvt.as_ints[1] &= bcvt.as_ints[1];
+	acvt.as_ints[2] &= bcvt.as_ints[2];
+	acvt.as_ints[3] &= bcvt.as_ints[3];
+
+	memcpy(&value, &acvt, sizeof(acvt));
+
+	return value;
+}
+
+static inline kinc_float32x4_t kinc_float32x4_xor(kinc_float32x4_t a, kinc_float32x4_t b) {
+	kinc_float32x4_t value; 
+	kinc_internal_float32x4_converter_t acvt;
+	kinc_internal_float32x4_converter_t bcvt;
+	memcpy(&acvt, &a, sizeof(a));
+	memcpy(&bcvt, &b, sizeof(b));
+
+	acvt.as_ints[0] ^= bcvt.as_ints[0];
+	acvt.as_ints[1] ^= bcvt.as_ints[1];
+	acvt.as_ints[2] ^= bcvt.as_ints[2];
+	acvt.as_ints[3] ^= bcvt.as_ints[3];
+
+	memcpy(&value, &acvt, sizeof(acvt));
+
+	return value;
+}
+
+static inline kinc_float32x4_t kinc_float32x4_not(kinc_float32x4_t t) {
+	kinc_float32x4_t value; 
+	kinc_internal_float32x4_converter_t tcvt;
+	memcpy(&tcvt, &t, sizeof(t));
+
+	tcvt.as_ints[0] = ~tcvt.as_ints[0];
+	tcvt.as_ints[1] = ~tcvt.as_ints[1];
+	tcvt.as_ints[2] = ~tcvt.as_ints[2];
+	tcvt.as_ints[3] = ~tcvt.as_ints[3];
+
+	memcpy(&value, &tcvt, sizeof(tcvt));
+
+	return value;
+}
+
 
 #endif
 

--- a/Sources/kinc/simd/float32x4.h
+++ b/Sources/kinc/simd/float32x4.h
@@ -129,6 +129,29 @@ static inline kinc_float32x4_t kinc_float32x4_not(kinc_float32x4_t t) {
 	return _mm_xor_ps(t, _mm_cmpeq_ps(zeroes, zeroes));
 }
 
+#define kinc_float32x4_shuffle_custom(abcd, efgh, left_1, left_2, right_1, right_2)\
+	_mm_shuffle_ps(abcd, efgh, KINC_SHUFFLE_TABLE((left_1), (left_2), (right_1), (right_2)))
+
+static inline kinc_float32x4_t kinc_float32x4_shuffle_aebf(kinc_float32x4_t abcd, kinc_float32x4_t efgh) {
+	//aka unpacklo aka zip1 aka interleave low
+	return _mm_unpacklo_ps(abcd, efgh);
+}
+
+static inline kinc_float32x4_t kinc_float32x4_shuffle_cgdh(kinc_float32x4_t abcd, kinc_float32x4_t efgh) {
+	//aka unpackhi aka zip2 aka interleave high
+	return _mm_unpackhi_ps(abcd, efgh);
+}
+
+static inline kinc_float32x4_t kinc_float32x4_shuffle_abef(kinc_float32x4_t abcd, kinc_float32x4_t efgh) {
+	//aka movelh
+	return _mm_movelh_ps(abcd, efgh);
+}
+
+static inline kinc_float32x4_t kinc_float32x4_shuffle_ghcd(kinc_float32x4_t abcd, kinc_float32x4_t efgh) {
+	//aka movehl
+	return _mm_movehl_ps(abcd, efgh);
+}
+
 
 #elif defined(KINC_NEON)
 
@@ -260,6 +283,56 @@ static inline kinc_float32x4_t kinc_float32x4_not(kinc_float32x4_t t) {
 	uint32x4_t tcvt = vreinterpretq_u32_f32(t);
 
 	return vreinterpretq_f32_u32(vmvnq_u32(tcvt));
+}
+
+#define kinc_float32x4_shuffle_custom(abcd, efgh, left_1, left_2, right_1, right_2)\
+	(kinc_float32x4_t){\
+		vgetq_lane_f32(abcd, (left_1 & 0x3)),\
+		vgetq_lane_f32(abcd, (left_2 & 0x3)),\
+		vgetq_lane_f32(efgh, (right_1 & 0x3)),\
+		vgetq_lane_f32(efgh, (right_2 & 0x3))\
+	}
+
+static inline kinc_float32x4_t kinc_float32x4_shuffle_aebf(kinc_float32x4_t abcd, kinc_float32x4_t efgh) {
+	// #if defined(__aarch64__)
+	// return vzip1q_f32(abcd, efgh);
+	// #endif
+
+	float a = vgetq_lane_f32(abcd, 0);
+	float b = vgetq_lane_f32(abcd, 1);
+	float e = vgetq_lane_f32(efgh, 0);
+	float f = vgetq_lane_f32(efgh, 1);
+
+	return (kinc_float32x4_t){a, e, b, f};
+}
+
+static inline kinc_float32x4_t kinc_float32x4_shuffle_cgdh(kinc_float32x4_t abcd, kinc_float32x4_t efgh) {
+	// #if defined(__aarch64__)
+	// return vzip2q_f32(abcd, efgh);
+	// #endif
+
+	float c = vgetq_lane_f32(abcd, 2);
+	float d = vgetq_lane_f32(abcd, 3);
+	float g = vgetq_lane_f32(efgh, 2);
+	float h = vgetq_lane_f32(efgh, 3);
+
+	return (kinc_float32x4_t){c, g, d, h};
+}
+
+static inline kinc_float32x4_t kinc_float32x4_shuffle_abef(kinc_float32x4_t abcd, kinc_float32x4_t efgh) {
+	//aka movelh
+	float32x2_t ab = vget_low_f32(abcd);
+	float32x2_t ef = vget_low_f32(efgh);
+
+	return vcombine_f32(ab, ef);
+}
+
+static inline kinc_float32x4_t kinc_float32x4_shuffle_ghcd(kinc_float32x4_t abcd, kinc_float32x4_t efgh) {
+	//aka movehl
+	float32x2_t cd = vget_high_f32(abcd);
+	float32x2_t gh = vget_high_f32(efgh);
+
+	return vcombine_f32(gh, cd);
 }
 
 
@@ -556,6 +629,64 @@ static inline kinc_float32x4_t kinc_float32x4_not(kinc_float32x4_t t) {
 
 	return value;
 }
+
+static inline kinc_float32x4_t kinc_float32x4_shuffle_custom(kinc_float32x4_t abcd, kinc_float32x4_t efgh, 
+	const uint32_t left_1, const uint32_t left_2, const uint32_t right_1, const uint32_t right_2) {
+	kinc_float32x4_t value;
+
+	value.values[0] = abcd.values[left_1 & 0x3];
+	value.values[1] = abcd.values[left_2 & 0x3];
+	value.values[2] = efgh.values[right_1 & 0x3];
+	value.values[3] = efgh.values[right_2 & 0x3];
+
+	return value;
+}
+
+static inline kinc_float32x4_t kinc_float32x4_shuffle_aebf(kinc_float32x4_t abcd, kinc_float32x4_t efgh) {
+	//aka unpacklo aka zip1 aka interleave low
+	kinc_float32x4_t value;
+
+	value.values[0] = abcd.values[0];
+	value.values[1] = efgh.values[0];
+	value.values[2] = abcd.values[1];
+	value.values[3] = efgh.values[1];
+
+	return value;
+}
+
+static inline kinc_float32x4_t kinc_float32x4_shuffle_cgdh(kinc_float32x4_t abcd, kinc_float32x4_t efgh) {
+	kinc_float32x4_t value;
+
+	value.values[0] = abcd.values[2];
+	value.values[1] = efgh.values[2];
+	value.values[2] = abcd.values[3];
+	value.values[3] = efgh.values[3];
+
+	return value;
+}
+
+static inline kinc_float32x4_t kinc_float32x4_shuffle_abef(kinc_float32x4_t abcd, kinc_float32x4_t efgh) {
+	kinc_float32x4_t value;
+
+	value.values[0] = abcd.values[0];
+	value.values[1] = abcd.values[1];
+	value.values[2] = efgh.values[0];
+	value.values[3] = efgh.values[1];
+
+	return value;
+}
+
+static inline kinc_float32x4_t kinc_float32x4_shuffle_ghcd(kinc_float32x4_t abcd, kinc_float32x4_t efgh) {
+	kinc_float32x4_t value;
+
+	value.values[0] = efgh.values[2];
+	value.values[1] = efgh.values[3];
+	value.values[2] = abcd.values[2];
+	value.values[3] = abcd.values[3];
+
+	return value;
+}
+
 
 
 #endif

--- a/Sources/kinc/simd/float32x4.h
+++ b/Sources/kinc/simd/float32x4.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "types.h"
+#include <string.h>
 
 /*! \file float32x4.h
     \brief Provides 128bit four-element floating point SIMD operations which are mapped to equivalent SSE or Neon operations.
@@ -13,7 +14,7 @@ extern "C" {
 #if defined(KINC_SSE)
 
 static inline kinc_float32x4_t kinc_float32x4_intrin_load(const float *values) {
-	// Parameter doesn't behave like SIMD int types
+	//Parameter doesn't behave like SIMD int types
 	return _mm_load_ps(values);
 }
 
@@ -359,65 +360,89 @@ static inline kinc_float32x4_t kinc_float32x4_min(kinc_float32x4_t a, kinc_float
 }
 
 static inline kinc_float32x4_mask_t kinc_float32x4_cmpeq(kinc_float32x4_t a, kinc_float32x4_t b) {
+	kinc_internal_float32x4_converter_t mask_cvt;
+	mask_cvt.as_ints[0] = a.values[0] == b.values[0] ? 0xffffffff : 0;
+	mask_cvt.as_ints[1] = a.values[1] == b.values[1] ? 0xffffffff : 0;
+	mask_cvt.as_ints[2] = a.values[2] == b.values[2] ? 0xffffffff : 0;
+	mask_cvt.as_ints[3] = a.values[3] == b.values[3] ? 0xffffffff : 0;
+
 	kinc_float32x4_mask_t mask;
-	mask.values[0] = a.values[0] == b.values[0] ? 0xffffffff : 0;
-	mask.values[1] = a.values[1] == b.values[1] ? 0xffffffff : 0;
-	mask.values[2] = a.values[2] == b.values[2] ? 0xffffffff : 0;
-	mask.values[3] = a.values[3] == b.values[3] ? 0xffffffff : 0;
+	memcpy(&mask, &mask_cvt, sizeof(mask_cvt));
+
 	return mask;
 }
 
 static inline kinc_float32x4_mask_t kinc_float32x4_cmpge(kinc_float32x4_t a, kinc_float32x4_t b) {
+	kinc_internal_float32x4_converter_t mask_cvt;
+	mask_cvt.as_ints[0] = a.values[0] >= b.values[0] ? 0xffffffff : 0;
+	mask_cvt.as_ints[1] = a.values[1] >= b.values[1] ? 0xffffffff : 0;
+	mask_cvt.as_ints[2] = a.values[2] >= b.values[2] ? 0xffffffff : 0;
+	mask_cvt.as_ints[3] = a.values[3] >= b.values[3] ? 0xffffffff : 0;
+
 	kinc_float32x4_mask_t mask;
-	mask.values[0] = a.values[0] >= b.values[0] ? 0xffffffff : 0;
-	mask.values[1] = a.values[1] >= b.values[1] ? 0xffffffff : 0;
-	mask.values[2] = a.values[2] >= b.values[2] ? 0xffffffff : 0;
-	mask.values[3] = a.values[3] >= b.values[3] ? 0xffffffff : 0;
+	memcpy(&mask, &mask_cvt, sizeof(mask_cvt));
+
 	return mask;
 }
 
 static inline kinc_float32x4_mask_t kinc_float32x4_cmpgt(kinc_float32x4_t a, kinc_float32x4_t b) {
+	kinc_internal_float32x4_converter_t mask_cvt;
+	mask_cvt.as_ints[0] = a.values[0] > b.values[0] ? 0xffffffff : 0;
+	mask_cvt.as_ints[1] = a.values[1] > b.values[1] ? 0xffffffff : 0;
+	mask_cvt.as_ints[2] = a.values[2] > b.values[2] ? 0xffffffff : 0;
+	mask_cvt.as_ints[3] = a.values[3] > b.values[3] ? 0xffffffff : 0;
+
 	kinc_float32x4_mask_t mask;
-	mask.values[0] = a.values[0] > b.values[0] ? 0xffffffff : 0;
-	mask.values[1] = a.values[1] > b.values[1] ? 0xffffffff : 0;
-	mask.values[2] = a.values[2] > b.values[2] ? 0xffffffff : 0;
-	mask.values[3] = a.values[3] > b.values[3] ? 0xffffffff : 0;
+	memcpy(&mask, &mask_cvt, sizeof(mask_cvt));
+
 	return mask;
 }
 
 static inline kinc_float32x4_mask_t kinc_float32x4_cmple(kinc_float32x4_t a, kinc_float32x4_t b) {
+	kinc_internal_float32x4_converter_t mask_cvt;
+	mask_cvt.as_ints[0] = a.values[0] <= b.values[0] ? 0xffffffff : 0;
+	mask_cvt.as_ints[1] = a.values[1] <= b.values[1] ? 0xffffffff : 0;
+	mask_cvt.as_ints[2] = a.values[2] <= b.values[2] ? 0xffffffff : 0;
+	mask_cvt.as_ints[3] = a.values[3] <= b.values[3] ? 0xffffffff : 0;
+
 	kinc_float32x4_mask_t mask;
-	mask.values[0] = a.values[0] <= b.values[0] ? 0xffffffff : 0;
-	mask.values[1] = a.values[1] <= b.values[1] ? 0xffffffff : 0;
-	mask.values[2] = a.values[2] <= b.values[2] ? 0xffffffff : 0;
-	mask.values[3] = a.values[3] <= b.values[3] ? 0xffffffff : 0;
+	memcpy(&mask, &mask_cvt, sizeof(mask_cvt));
+
 	return mask;
 }
 
 static inline kinc_float32x4_mask_t kinc_float32x4_cmplt(kinc_float32x4_t a, kinc_float32x4_t b) {
+	kinc_internal_float32x4_converter_t mask_cvt;
+	mask_cvt.as_ints[0] = a.values[0] < b.values[0] ? 0xffffffff : 0;
+	mask_cvt.as_ints[1] = a.values[1] < b.values[1] ? 0xffffffff : 0;
+	mask_cvt.as_ints[2] = a.values[2] < b.values[2] ? 0xffffffff : 0;
+	mask_cvt.as_ints[3] = a.values[3] < b.values[3] ? 0xffffffff : 0;
+
 	kinc_float32x4_mask_t mask;
-	mask.values[0] = a.values[0] < b.values[0] ? 0xffffffff : 0;
-	mask.values[1] = a.values[1] < b.values[1] ? 0xffffffff : 0;
-	mask.values[2] = a.values[2] < b.values[2] ? 0xffffffff : 0;
-	mask.values[3] = a.values[3] < b.values[3] ? 0xffffffff : 0;
+	memcpy(&mask, &mask_cvt, sizeof(mask_cvt));
+
 	return mask;
 }
 
 static inline kinc_float32x4_mask_t kinc_float32x4_cmpneq(kinc_float32x4_t a, kinc_float32x4_t b) {
+	kinc_internal_float32x4_converter_t mask_cvt;
+	mask_cvt.as_ints[0] = a.values[0] != b.values[0] ? 0xffffffff : 0;
+	mask_cvt.as_ints[1] = a.values[1] != b.values[1] ? 0xffffffff : 0;
+	mask_cvt.as_ints[2] = a.values[2] != b.values[2] ? 0xffffffff : 0;
+	mask_cvt.as_ints[3] = a.values[3] != b.values[3] ? 0xffffffff : 0;
+
 	kinc_float32x4_mask_t mask;
-	mask.values[0] = a.values[0] != b.values[0] ? 0xffffffff : 0;
-	mask.values[1] = a.values[1] != b.values[1] ? 0xffffffff : 0;
-	mask.values[2] = a.values[2] != b.values[2] ? 0xffffffff : 0;
-	mask.values[3] = a.values[3] != b.values[3] ? 0xffffffff : 0;
+	memcpy(&mask, &mask_cvt, sizeof(mask_cvt));
+
 	return mask;
 }
 
 static inline kinc_float32x4_t kinc_float32x4_sel(kinc_float32x4_t a, kinc_float32x4_t b, kinc_float32x4_mask_t mask) {
 	kinc_float32x4_t value;
-	value.values[0] = mask.values[0] != 0 ? a.values[0] : b.values[0];
-	value.values[1] = mask.values[1] != 0 ? a.values[1] : b.values[1];
-	value.values[2] = mask.values[2] != 0 ? a.values[2] : b.values[2];
-	value.values[3] = mask.values[3] != 0 ? a.values[3] : b.values[3];
+	value.values[0] = mask.values[0] != 0.0f ? a.values[0] : b.values[0];
+	value.values[1] = mask.values[1] != 0.0f ? a.values[1] : b.values[1];
+	value.values[2] = mask.values[2] != 0.0f ? a.values[2] : b.values[2];
+	value.values[3] = mask.values[3] != 0.0f ? a.values[3] : b.values[3];
 	return value;
 }
 

--- a/Sources/kinc/simd/float32x4.h
+++ b/Sources/kinc/simd/float32x4.h
@@ -412,7 +412,7 @@ static inline kinc_float32x4_mask_t kinc_float32x4_cmpeq(kinc_float32x4_t a, kin
 	mask_cvt[3] = a.values[3] == b.values[3] ? 0xffffffff : 0;
 
 	kinc_float32x4_mask_t mask;
-	memcpy(&mask, &mask_cvt, sizeof(mask_cvt));
+	memcpy(&mask.values[0], &mask_cvt[0], sizeof(mask_cvt));
 
 	return mask;
 }
@@ -425,7 +425,7 @@ static inline kinc_float32x4_mask_t kinc_float32x4_cmpge(kinc_float32x4_t a, kin
 	mask_cvt[3] = a.values[3] >= b.values[3] ? 0xffffffff : 0;
 
 	kinc_float32x4_mask_t mask;
-	memcpy(&mask, &mask_cvt, sizeof(mask_cvt));
+	memcpy(&mask.values[0], &mask_cvt[0], sizeof(mask_cvt));
 
 	return mask;
 }
@@ -438,7 +438,7 @@ static inline kinc_float32x4_mask_t kinc_float32x4_cmpgt(kinc_float32x4_t a, kin
 	mask_cvt[3] = a.values[3] > b.values[3] ? 0xffffffff : 0;
 
 	kinc_float32x4_mask_t mask;
-	memcpy(&mask, &mask_cvt, sizeof(mask_cvt));
+	memcpy(&mask.values[0], &mask_cvt[0], sizeof(mask_cvt));
 
 	return mask;
 }
@@ -451,7 +451,7 @@ static inline kinc_float32x4_mask_t kinc_float32x4_cmple(kinc_float32x4_t a, kin
 	mask_cvt[3] = a.values[3] <= b.values[3] ? 0xffffffff : 0;
 
 	kinc_float32x4_mask_t mask;
-	memcpy(&mask, &mask_cvt, sizeof(mask_cvt));
+	memcpy(&mask.values[0], &mask_cvt[0], sizeof(mask_cvt));
 
 	return mask;
 }
@@ -464,7 +464,7 @@ static inline kinc_float32x4_mask_t kinc_float32x4_cmplt(kinc_float32x4_t a, kin
 	mask_cvt[3] = a.values[3] < b.values[3] ? 0xffffffff : 0;
 
 	kinc_float32x4_mask_t mask;
-	memcpy(&mask, &mask_cvt, sizeof(mask_cvt));
+	memcpy(&mask.values[0], &mask_cvt[0], sizeof(mask_cvt));
 
 	return mask;
 }
@@ -477,7 +477,7 @@ static inline kinc_float32x4_mask_t kinc_float32x4_cmpneq(kinc_float32x4_t a, ki
 	mask_cvt[3] = a.values[3] != b.values[3] ? 0xffffffff : 0;
 
 	kinc_float32x4_mask_t mask;
-	memcpy(&mask, &mask_cvt, sizeof(mask_cvt));
+	memcpy(&mask.values[0], &mask_cvt[0], sizeof(mask_cvt));
 
 	return mask;
 }
@@ -494,8 +494,8 @@ static inline kinc_float32x4_t kinc_float32x4_sel(kinc_float32x4_t a, kinc_float
 static inline kinc_float32x4_t kinc_float32x4_or(kinc_float32x4_t a, kinc_float32x4_t b) {
 	uint32_t acvt[4];
 	uint32_t bcvt[4];
-	memcpy(&acvt, &a, sizeof(a));
-	memcpy(&bcvt, &b, sizeof(b));
+	memcpy(&acvt[0], &a.values[0], sizeof(a));
+	memcpy(&bcvt[0], &b.values[0], sizeof(b));
 
 	acvt[0] |= bcvt[0];
 	acvt[1] |= bcvt[1];
@@ -503,7 +503,7 @@ static inline kinc_float32x4_t kinc_float32x4_or(kinc_float32x4_t a, kinc_float3
 	acvt[3] |= bcvt[3];
 
 	kinc_float32x4_t value; 
-	memcpy(&value, &acvt, sizeof(acvt));
+	memcpy(&value.values[0], &acvt[0], sizeof(acvt));
 
 	return value;
 }
@@ -511,8 +511,8 @@ static inline kinc_float32x4_t kinc_float32x4_or(kinc_float32x4_t a, kinc_float3
 static inline kinc_float32x4_t kinc_float32x4_and(kinc_float32x4_t a, kinc_float32x4_t b) {
 	uint32_t acvt[4];
 	uint32_t bcvt[4];
-	memcpy(&acvt, &a, sizeof(a));
-	memcpy(&bcvt, &b, sizeof(b));
+	memcpy(&acvt[0], &a.values[0], sizeof(a));
+	memcpy(&bcvt[0], &b.values[0], sizeof(b));
 
 	acvt[0] &= bcvt[0];
 	acvt[1] &= bcvt[1];
@@ -520,7 +520,7 @@ static inline kinc_float32x4_t kinc_float32x4_and(kinc_float32x4_t a, kinc_float
 	acvt[3] &= bcvt[3];
 
 	kinc_float32x4_t value; 
-	memcpy(&value, &acvt, sizeof(acvt));
+	memcpy(&value.values[0], &acvt[0], sizeof(acvt));
 
 	return value;
 }
@@ -528,8 +528,8 @@ static inline kinc_float32x4_t kinc_float32x4_and(kinc_float32x4_t a, kinc_float
 static inline kinc_float32x4_t kinc_float32x4_xor(kinc_float32x4_t a, kinc_float32x4_t b) {
 	uint32_t acvt[4];
 	uint32_t bcvt[4];
-	memcpy(&acvt, &a, sizeof(a));
-	memcpy(&bcvt, &b, sizeof(b));
+	memcpy(&acvt[0], &a.values[0], sizeof(a));
+	memcpy(&bcvt[0], &b.values[0], sizeof(b));
 
 	acvt[0] ^= bcvt[0];
 	acvt[1] ^= bcvt[1];
@@ -537,14 +537,14 @@ static inline kinc_float32x4_t kinc_float32x4_xor(kinc_float32x4_t a, kinc_float
 	acvt[3] ^= bcvt[3];
 
 	kinc_float32x4_t value; 
-	memcpy(&value, &acvt, sizeof(acvt));
+	memcpy(&value.values[0], &acvt[0], sizeof(acvt));
 
 	return value;
 }
 
 static inline kinc_float32x4_t kinc_float32x4_not(kinc_float32x4_t t) {
 	uint32_t tcvt[4];
-	memcpy(&tcvt, &t, sizeof(t));
+	memcpy(&tcvt[0], &t.values[0], sizeof(t));
 
 	tcvt[0] = ~tcvt[0];
 	tcvt[1] = ~tcvt[1];
@@ -552,7 +552,7 @@ static inline kinc_float32x4_t kinc_float32x4_not(kinc_float32x4_t t) {
 	tcvt[3] = ~tcvt[3];
 
 	kinc_float32x4_t value; 
-	memcpy(&value, &tcvt, sizeof(tcvt));
+	memcpy(&value.values[0], &tcvt[0], sizeof(tcvt));
 
 	return value;
 }

--- a/Sources/kinc/simd/float32x4.h
+++ b/Sources/kinc/simd/float32x4.h
@@ -14,7 +14,6 @@ extern "C" {
 #if defined(KINC_SSE)
 
 static inline kinc_float32x4_t kinc_float32x4_intrin_load(const float *values) {
-	//Parameter doesn't behave like SIMD int types
 	return _mm_load_ps(values);
 }
 

--- a/Sources/kinc/simd/float32x4.h
+++ b/Sources/kinc/simd/float32x4.h
@@ -405,11 +405,11 @@ static inline kinc_float32x4_t kinc_float32x4_min(kinc_float32x4_t a, kinc_float
 }
 
 static inline kinc_float32x4_mask_t kinc_float32x4_cmpeq(kinc_float32x4_t a, kinc_float32x4_t b) {
-	kinc_internal_float32x4_converter_t mask_cvt;
-	mask_cvt.as_ints[0] = a.values[0] == b.values[0] ? 0xffffffff : 0;
-	mask_cvt.as_ints[1] = a.values[1] == b.values[1] ? 0xffffffff : 0;
-	mask_cvt.as_ints[2] = a.values[2] == b.values[2] ? 0xffffffff : 0;
-	mask_cvt.as_ints[3] = a.values[3] == b.values[3] ? 0xffffffff : 0;
+	uint32_t mask_cvt[4];
+	mask_cvt[0] = a.values[0] == b.values[0] ? 0xffffffff : 0;
+	mask_cvt[1] = a.values[1] == b.values[1] ? 0xffffffff : 0;
+	mask_cvt[2] = a.values[2] == b.values[2] ? 0xffffffff : 0;
+	mask_cvt[3] = a.values[3] == b.values[3] ? 0xffffffff : 0;
 
 	kinc_float32x4_mask_t mask;
 	memcpy(&mask, &mask_cvt, sizeof(mask_cvt));
@@ -418,11 +418,11 @@ static inline kinc_float32x4_mask_t kinc_float32x4_cmpeq(kinc_float32x4_t a, kin
 }
 
 static inline kinc_float32x4_mask_t kinc_float32x4_cmpge(kinc_float32x4_t a, kinc_float32x4_t b) {
-	kinc_internal_float32x4_converter_t mask_cvt;
-	mask_cvt.as_ints[0] = a.values[0] >= b.values[0] ? 0xffffffff : 0;
-	mask_cvt.as_ints[1] = a.values[1] >= b.values[1] ? 0xffffffff : 0;
-	mask_cvt.as_ints[2] = a.values[2] >= b.values[2] ? 0xffffffff : 0;
-	mask_cvt.as_ints[3] = a.values[3] >= b.values[3] ? 0xffffffff : 0;
+	uint32_t mask_cvt[4];
+	mask_cvt[0] = a.values[0] >= b.values[0] ? 0xffffffff : 0;
+	mask_cvt[1] = a.values[1] >= b.values[1] ? 0xffffffff : 0;
+	mask_cvt[2] = a.values[2] >= b.values[2] ? 0xffffffff : 0;
+	mask_cvt[3] = a.values[3] >= b.values[3] ? 0xffffffff : 0;
 
 	kinc_float32x4_mask_t mask;
 	memcpy(&mask, &mask_cvt, sizeof(mask_cvt));
@@ -431,11 +431,11 @@ static inline kinc_float32x4_mask_t kinc_float32x4_cmpge(kinc_float32x4_t a, kin
 }
 
 static inline kinc_float32x4_mask_t kinc_float32x4_cmpgt(kinc_float32x4_t a, kinc_float32x4_t b) {
-	kinc_internal_float32x4_converter_t mask_cvt;
-	mask_cvt.as_ints[0] = a.values[0] > b.values[0] ? 0xffffffff : 0;
-	mask_cvt.as_ints[1] = a.values[1] > b.values[1] ? 0xffffffff : 0;
-	mask_cvt.as_ints[2] = a.values[2] > b.values[2] ? 0xffffffff : 0;
-	mask_cvt.as_ints[3] = a.values[3] > b.values[3] ? 0xffffffff : 0;
+	uint32_t mask_cvt[4];
+	mask_cvt[0] = a.values[0] > b.values[0] ? 0xffffffff : 0;
+	mask_cvt[1] = a.values[1] > b.values[1] ? 0xffffffff : 0;
+	mask_cvt[2] = a.values[2] > b.values[2] ? 0xffffffff : 0;
+	mask_cvt[3] = a.values[3] > b.values[3] ? 0xffffffff : 0;
 
 	kinc_float32x4_mask_t mask;
 	memcpy(&mask, &mask_cvt, sizeof(mask_cvt));
@@ -444,11 +444,11 @@ static inline kinc_float32x4_mask_t kinc_float32x4_cmpgt(kinc_float32x4_t a, kin
 }
 
 static inline kinc_float32x4_mask_t kinc_float32x4_cmple(kinc_float32x4_t a, kinc_float32x4_t b) {
-	kinc_internal_float32x4_converter_t mask_cvt;
-	mask_cvt.as_ints[0] = a.values[0] <= b.values[0] ? 0xffffffff : 0;
-	mask_cvt.as_ints[1] = a.values[1] <= b.values[1] ? 0xffffffff : 0;
-	mask_cvt.as_ints[2] = a.values[2] <= b.values[2] ? 0xffffffff : 0;
-	mask_cvt.as_ints[3] = a.values[3] <= b.values[3] ? 0xffffffff : 0;
+	uint32_t mask_cvt[4];
+	mask_cvt[0] = a.values[0] <= b.values[0] ? 0xffffffff : 0;
+	mask_cvt[1] = a.values[1] <= b.values[1] ? 0xffffffff : 0;
+	mask_cvt[2] = a.values[2] <= b.values[2] ? 0xffffffff : 0;
+	mask_cvt[3] = a.values[3] <= b.values[3] ? 0xffffffff : 0;
 
 	kinc_float32x4_mask_t mask;
 	memcpy(&mask, &mask_cvt, sizeof(mask_cvt));
@@ -457,11 +457,11 @@ static inline kinc_float32x4_mask_t kinc_float32x4_cmple(kinc_float32x4_t a, kin
 }
 
 static inline kinc_float32x4_mask_t kinc_float32x4_cmplt(kinc_float32x4_t a, kinc_float32x4_t b) {
-	kinc_internal_float32x4_converter_t mask_cvt;
-	mask_cvt.as_ints[0] = a.values[0] < b.values[0] ? 0xffffffff : 0;
-	mask_cvt.as_ints[1] = a.values[1] < b.values[1] ? 0xffffffff : 0;
-	mask_cvt.as_ints[2] = a.values[2] < b.values[2] ? 0xffffffff : 0;
-	mask_cvt.as_ints[3] = a.values[3] < b.values[3] ? 0xffffffff : 0;
+	uint32_t mask_cvt[4];
+	mask_cvt[0] = a.values[0] < b.values[0] ? 0xffffffff : 0;
+	mask_cvt[1] = a.values[1] < b.values[1] ? 0xffffffff : 0;
+	mask_cvt[2] = a.values[2] < b.values[2] ? 0xffffffff : 0;
+	mask_cvt[3] = a.values[3] < b.values[3] ? 0xffffffff : 0;
 
 	kinc_float32x4_mask_t mask;
 	memcpy(&mask, &mask_cvt, sizeof(mask_cvt));
@@ -470,11 +470,11 @@ static inline kinc_float32x4_mask_t kinc_float32x4_cmplt(kinc_float32x4_t a, kin
 }
 
 static inline kinc_float32x4_mask_t kinc_float32x4_cmpneq(kinc_float32x4_t a, kinc_float32x4_t b) {
-	kinc_internal_float32x4_converter_t mask_cvt;
-	mask_cvt.as_ints[0] = a.values[0] != b.values[0] ? 0xffffffff : 0;
-	mask_cvt.as_ints[1] = a.values[1] != b.values[1] ? 0xffffffff : 0;
-	mask_cvt.as_ints[2] = a.values[2] != b.values[2] ? 0xffffffff : 0;
-	mask_cvt.as_ints[3] = a.values[3] != b.values[3] ? 0xffffffff : 0;
+	uint32_t mask_cvt[4];
+	mask_cvt[0] = a.values[0] != b.values[0] ? 0xffffffff : 0;
+	mask_cvt[1] = a.values[1] != b.values[1] ? 0xffffffff : 0;
+	mask_cvt[2] = a.values[2] != b.values[2] ? 0xffffffff : 0;
+	mask_cvt[3] = a.values[3] != b.values[3] ? 0xffffffff : 0;
 
 	kinc_float32x4_mask_t mask;
 	memcpy(&mask, &mask_cvt, sizeof(mask_cvt));
@@ -492,66 +492,66 @@ static inline kinc_float32x4_t kinc_float32x4_sel(kinc_float32x4_t a, kinc_float
 }
 
 static inline kinc_float32x4_t kinc_float32x4_or(kinc_float32x4_t a, kinc_float32x4_t b) {
-	kinc_float32x4_t value; 
-	kinc_internal_float32x4_converter_t acvt;
-	kinc_internal_float32x4_converter_t bcvt;
+	uint32_t acvt[4];
+	uint32_t bcvt[4];
 	memcpy(&acvt, &a, sizeof(a));
 	memcpy(&bcvt, &b, sizeof(b));
 
-	acvt.as_ints[0] |= bcvt.as_ints[0];
-	acvt.as_ints[1] |= bcvt.as_ints[1];
-	acvt.as_ints[2] |= bcvt.as_ints[2];
-	acvt.as_ints[3] |= bcvt.as_ints[3];
+	acvt[0] |= bcvt[0];
+	acvt[1] |= bcvt[1];
+	acvt[2] |= bcvt[2];
+	acvt[3] |= bcvt[3];
 
+	kinc_float32x4_t value; 
 	memcpy(&value, &acvt, sizeof(acvt));
 
 	return value;
 }
 
 static inline kinc_float32x4_t kinc_float32x4_and(kinc_float32x4_t a, kinc_float32x4_t b) {
-	kinc_float32x4_t value; 
-	kinc_internal_float32x4_converter_t acvt;
-	kinc_internal_float32x4_converter_t bcvt;
+	uint32_t acvt[4];
+	uint32_t bcvt[4];
 	memcpy(&acvt, &a, sizeof(a));
 	memcpy(&bcvt, &b, sizeof(b));
 
-	acvt.as_ints[0] &= bcvt.as_ints[0];
-	acvt.as_ints[1] &= bcvt.as_ints[1];
-	acvt.as_ints[2] &= bcvt.as_ints[2];
-	acvt.as_ints[3] &= bcvt.as_ints[3];
+	acvt[0] &= bcvt[0];
+	acvt[1] &= bcvt[1];
+	acvt[2] &= bcvt[2];
+	acvt[3] &= bcvt[3];
 
+	kinc_float32x4_t value; 
 	memcpy(&value, &acvt, sizeof(acvt));
 
 	return value;
 }
 
 static inline kinc_float32x4_t kinc_float32x4_xor(kinc_float32x4_t a, kinc_float32x4_t b) {
-	kinc_float32x4_t value; 
-	kinc_internal_float32x4_converter_t acvt;
-	kinc_internal_float32x4_converter_t bcvt;
+	uint32_t acvt[4];
+	uint32_t bcvt[4];
 	memcpy(&acvt, &a, sizeof(a));
 	memcpy(&bcvt, &b, sizeof(b));
 
-	acvt.as_ints[0] ^= bcvt.as_ints[0];
-	acvt.as_ints[1] ^= bcvt.as_ints[1];
-	acvt.as_ints[2] ^= bcvt.as_ints[2];
-	acvt.as_ints[3] ^= bcvt.as_ints[3];
+	acvt[0] ^= bcvt[0];
+	acvt[1] ^= bcvt[1];
+	acvt[2] ^= bcvt[2];
+	acvt[3] ^= bcvt[3];
 
+	kinc_float32x4_t value; 
 	memcpy(&value, &acvt, sizeof(acvt));
 
 	return value;
 }
 
 static inline kinc_float32x4_t kinc_float32x4_not(kinc_float32x4_t t) {
-	kinc_float32x4_t value; 
-	kinc_internal_float32x4_converter_t tcvt;
+	uint32_t tcvt[4];
 	memcpy(&tcvt, &t, sizeof(t));
 
-	tcvt.as_ints[0] = ~tcvt.as_ints[0];
-	tcvt.as_ints[1] = ~tcvt.as_ints[1];
-	tcvt.as_ints[2] = ~tcvt.as_ints[2];
-	tcvt.as_ints[3] = ~tcvt.as_ints[3];
+	tcvt[0] = ~tcvt[0];
+	tcvt[1] = ~tcvt[1];
+	tcvt[2] = ~tcvt[2];
+	tcvt[3] = ~tcvt[3];
 
+	kinc_float32x4_t value; 
 	memcpy(&value, &tcvt, sizeof(tcvt));
 
 	return value;

--- a/Sources/kinc/simd/float32x4.h
+++ b/Sources/kinc/simd/float32x4.h
@@ -294,9 +294,11 @@ static inline kinc_float32x4_t kinc_float32x4_not(kinc_float32x4_t t) {
 	}
 
 static inline kinc_float32x4_t kinc_float32x4_shuffle_aebf(kinc_float32x4_t abcd, kinc_float32x4_t efgh) {
-	// #if defined(__aarch64__)
-	// return vzip1q_f32(abcd, efgh);
-	// #endif
+	#if defined(__aarch64__)
+
+	return vzip1q_f32(abcd, efgh);
+
+	#else
 
 	float a = vgetq_lane_f32(abcd, 0);
 	float b = vgetq_lane_f32(abcd, 1);
@@ -304,12 +306,16 @@ static inline kinc_float32x4_t kinc_float32x4_shuffle_aebf(kinc_float32x4_t abcd
 	float f = vgetq_lane_f32(efgh, 1);
 
 	return (kinc_float32x4_t){a, e, b, f};
+
+	#endif
 }
 
 static inline kinc_float32x4_t kinc_float32x4_shuffle_cgdh(kinc_float32x4_t abcd, kinc_float32x4_t efgh) {
-	// #if defined(__aarch64__)
-	// return vzip2q_f32(abcd, efgh);
-	// #endif
+	#if defined(__aarch64__)
+
+	return vzip2q_f32(abcd, efgh);
+
+	#else
 
 	float c = vgetq_lane_f32(abcd, 2);
 	float d = vgetq_lane_f32(abcd, 3);
@@ -317,6 +323,8 @@ static inline kinc_float32x4_t kinc_float32x4_shuffle_cgdh(kinc_float32x4_t abcd
 	float h = vgetq_lane_f32(efgh, 3);
 
 	return (kinc_float32x4_t){c, g, d, h};
+
+	#endif
 }
 
 static inline kinc_float32x4_t kinc_float32x4_shuffle_abef(kinc_float32x4_t abcd, kinc_float32x4_t efgh) {

--- a/Sources/kinc/simd/type_conversions.h
+++ b/Sources/kinc/simd/type_conversions.h
@@ -548,7 +548,7 @@ static inline kinc_float32x4_t kinc_uint8x16_cast_to_float32x4(kinc_uint8x16_t t
 
 
 //Shared signed and unsigned integer vectors for SSE and SIMD-fallback
-#if defined(KINC_SSE) || defined(KINC_NOSIMD)
+#if !defined(KINC_SSE2) && (defined(KINC_SSE) || defined(KINC_NOSIMD)) 
 
 //Int32x4 ----> Other
 static inline kinc_uint32x4_t kinc_int32x4_cast_to_uint32x4(kinc_int32x4_t t) {

--- a/Sources/kinc/simd/type_conversions.h
+++ b/Sources/kinc/simd/type_conversions.h
@@ -1,0 +1,760 @@
+#pragma once
+
+#include <kinc/global.h>
+#include "types.h"
+#include <string>
+
+/*! \file type_conversions.h
+	\brief Provides type casts and type conversions between all 128bit SIMD types
+*/
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+#if defined(KINC_SSE2)
+
+
+//Float32x4 ----> Other
+static inline kinc_int32x4_t kinc_float32x4_cast_to_int32x4(kinc_float32x4_t t) {
+	return _mm_castps_si128(t);
+}
+static inline kinc_uint32x4_t kinc_float32x4_cast_to_uint32x4(kinc_float32x4_t t) {
+	return _mm_castps_si128(t);
+}
+static inline kinc_int16x8_t kinc_float32x4_cast_to_int16x8(kinc_float32x4_t t) {
+	return _mm_castps_si128(t);
+}
+static inline kinc_uint16x8_t kinc_float32x4_cast_to_uint16x8(kinc_float32x4_t t) {
+	return _mm_castps_si128(t);
+}
+static inline kinc_int8x16_t kinc_float32x4_cast_to_int8x16(kinc_float32x4_t t) {
+	return _mm_castps_si128(t);
+}
+static inline kinc_uint8x16_t kinc_float32x4_cast_to_uint8x16(kinc_float32x4_t t) {
+	return _mm_castps_si128(t);
+}
+
+
+
+//Int32x4 ----> Other
+static inline kinc_float32x4_t kinc_int32x4_cast_to_float32x4(kinc_int32x4_t t) {
+	return _mm_castsi128_ps(t);
+}
+static inline kinc_uint32x4_t kinc_int32x4_cast_to_uint32x4(kinc_int32x4_t t) {
+	//SSE2's m128i is every int type, so we can just return any inbound int type parameter
+	return t;
+}
+static inline kinc_int16x8_t kinc_int32x4_cast_to_int16x8(kinc_int32x4_t t) {
+	return t;
+}
+static inline kinc_uint16x8_t kinc_int32x4_cast_to_uint16x8(kinc_int32x4_t t) {
+	return t;
+}
+static inline kinc_int8x16_t kinc_int32x4_cast_to_int8x16(kinc_int32x4_t t) {
+	return t;
+}
+static inline kinc_uint8x16_t kinc_int32x4_cast_to_uint8x16(kinc_int32x4_t t) {
+	return t;
+}
+
+
+
+//Unsigned Int32x4 ----> Other
+static inline kinc_float32x4_t kinc_uint32x4_cast_to_float32x4(kinc_uint32x4_t t) {
+	return _mm_castsi128_ps(t);
+}
+static inline kinc_int32x4_t kinc_uint32x4_cast_to_int32x4(kinc_uint32x4_t t) {
+	return t;
+}
+static inline kinc_int16x8_t kinc_uint32x4_cast_to_int16x8(kinc_uint32x4_t t) {
+	return t;
+}
+static inline kinc_uint16x8_t kinc_uint32x4_cast_to_uint16x8(kinc_uint32x4_t t) {
+	return t;
+}
+static inline kinc_int8x16_t kinc_uint32x4_cast_to_int8x16(kinc_uint32x4_t t) {
+	return t;
+}
+static inline kinc_uint8x16_t kinc_uint32x4_cast_to_uint8x16(kinc_uint32x4_t t) {
+	return t;
+}
+
+
+
+//Int16x8 ----> Other
+static inline kinc_float32x4_t kinc_int16x8_cast_to_float32x4(kinc_int16x8_t t) {
+	return _mm_castsi128_ps(t);
+}
+static inline kinc_int32x4_t kinc_int16x8_cast_to_int32x4(kinc_int16x8_t t) {
+	return t;
+}
+static inline kinc_uint32x4_t kinc_int16x8_cast_to_uint32x4(kinc_int16x8_t t) {
+	return t;
+}
+static inline kinc_uint16x8_t kinc_int16x8_cast_to_uint16x8(kinc_int16x8_t t) {
+	return t;
+}
+static inline kinc_int8x16_t kinc_int16x8_cast_to_int8x16(kinc_int16x8_t t) {
+	return t;
+}
+static inline kinc_uint8x16_t kinc_int16x8_cast_to_uint8x16(kinc_int16x8_t t) {
+	return t;
+}
+
+
+
+//Unsigned Int16x8 ----> Other
+static inline kinc_float32x4_t kinc_uint16x8_cast_to_float32x4(kinc_uint16x8_t t) {
+	return _mm_castsi128_ps(t);
+}
+static inline kinc_int32x4_t kinc_uint16x8_cast_to_int32x4(kinc_uint16x8_t t) {
+	return t;
+}
+static inline kinc_uint32x4_t kinc_uint16x8_cast_to_uint32x4(kinc_uint16x8_t t) {
+	return t;
+}
+static inline kinc_int16x8_t kinc_uint16x8_cast_to_int16x8(kinc_uint16x8_t t) {
+	return t;
+}
+static inline kinc_int8x16_t kinc_uint16x8_cast_to_int8x16(kinc_uint16x8_t t) {
+	return t;
+}
+static inline kinc_uint8x16_t kinc_uint16x8_cast_to_uint8x16(kinc_uint16x8_t t) {
+	return t;
+}
+
+
+//Int8x16 ----> Other
+static inline kinc_float32x4_t kinc_int8x16_cast_to_float32x4(kinc_int8x16_t t) {
+	return _mm_castsi128_ps(t);
+}
+static inline kinc_int32x4_t kinc_int8x16_cast_to_int32x4(kinc_int8x16_t t) {
+	return t;
+}
+static inline kinc_uint32x4_t kinc_int8x16_cast_to_uint32x4(kinc_int8x16_t t) {
+	return t;
+}
+static inline kinc_int16x8_t kinc_int8x16_cast_to_int16x8(kinc_int8x16_t t) {
+	return t;
+}
+static inline kinc_uint16x8_t kinc_int8x16_cast_to_uint16x8(kinc_int8x16_t t) {
+	return t;
+}
+static inline kinc_uint8x16_t kinc_int8x16_cast_to_uint8x16(kinc_int8x16_t t) {
+	return t;
+}
+
+
+
+//Unsigned Int8x16 ----> Other
+static inline kinc_float32x4_t kinc_uint8x16_cast_to_float32x4(kinc_uint8x16_t t) {
+	return _mm_castsi128_ps(t);
+}
+static inline kinc_int32x4_t kinc_uint8x16_cast_to_int32x4(kinc_uint8x16_t t) {
+	return t;
+}
+static inline kinc_uint32x4_t kinc_uint8x16_cast_to_uint32x4(kinc_uint8x16_t t) {
+	return t;
+}
+static inline kinc_int16x8_t kinc_uint8x16_cast_to_int16x8(kinc_uint8x16_t t) {
+	return t;
+}
+static inline kinc_uint16x8_t kinc_uint8x16_cast_to_uint16x8(kinc_uint8x16_t t) {
+	return t;
+}
+static inline kinc_int8x16_t kinc_uint8x16_cast_to_int8x16(kinc_uint8x16_t t) {
+	return t;
+}
+
+
+
+#elif defined(KINC_SSE)
+
+
+//Float32x4 ----> Other
+static inline kinc_int32x4_t kinc_float32x4_cast_to_int32x4(kinc_float32x4_t t) {
+	float extracted[4];
+	_mm_storeu_ps(&extracted, t);
+
+	kinc_int32x4_t cvt;
+	memcpy(&cvt, &extracted, sizeof(extracted));
+
+	return cvt;
+}
+static inline kinc_uint32x4_t kinc_float32x4_cast_to_uint32x4(kinc_float32x4_t t) {
+	float extracted[4];
+	_mm_storeu_ps(&extracted, t);
+
+	kinc_uint32x4_t cvt;
+	memcpy(&cvt, &extracted, sizeof(extracted));
+
+	return cvt;
+}
+static inline kinc_int16x8_t kinc_float32x4_cast_to_int16x8(kinc_float32x4_t t) {
+	float extracted[4];
+	_mm_storeu_ps(&extracted, t);
+
+	kinc_int16x8_t cvt;
+	memcpy(&cvt, &extracted, sizeof(extracted));
+
+	return cvt;
+}
+static inline kinc_uint16x8_t kinc_float32x4_cast_to_uint16x8(kinc_float32x4_t t) {
+	float extracted[4];
+	_mm_storeu_ps(&extracted, t);
+
+	kinc_uint16x8_t cvt;
+	memcpy(&cvt, &extracted, sizeof(extracted));
+
+	return cvt;
+}
+static inline kinc_int8x16_t kinc_float32x4_cast_to_int8x16(kinc_float32x4_t t) {
+	float extracted[4];
+	_mm_storeu_ps(&extracted, t);
+
+	kinc_int8x16_t cvt;
+	memcpy(&cvt, &extracted, sizeof(extracted));
+
+	return cvt;
+}
+static inline kinc_uint8x16_t kinc_float32x4_cast_to_uint8x16(kinc_float32x4_t t) {
+	float extracted[4];
+	_mm_storeu_ps(&extracted, t);
+
+	kinc_uint8x16_t cvt;
+	memcpy(&cvt, &extracted, sizeof(extracted));
+
+	return cvt;
+}
+
+
+
+//Int32x4 ----> Other
+static inline kinc_float32x4_t kinc_int32x4_cast_to_float32x4(kinc_int32x4_t t) {
+	float cvt[4];
+	memcpy(&cvt, &t.values[0], sizeof(t));
+
+	return _mm_loadu_ps(cvt);
+}
+
+
+//Unsigned Int32x4 ----> Other
+static inline kinc_float32x4_t kinc_uint32x4_cast_to_float32x4(kinc_uint32x4_t t) {
+	float cvt[4];
+	memcpy(&cvt, &t.values[0], sizeof(t));
+
+	return _mm_loadu_ps(cvt);
+}
+
+
+
+//Int16x8 ----> Other
+static inline kinc_float32x4_t kinc_int16x8_cast_to_float32x4(kinc_int16x8_t t) {
+	float cvt[4];
+	memcpy(&cvt, &t.values[0], sizeof(t));
+
+	return _mm_loadu_ps(cvt);
+}
+
+
+
+//Unsigned Int16x8 ----> Other
+static inline kinc_float32x4_t kinc_uint16x8_cast_to_float32x4(kinc_uint16x8_t t) {
+	float cvt[4];
+	memcpy(&cvt, &t.values[0], sizeof(t));
+
+	return _mm_loadu_ps(cvt);
+}
+
+
+
+//Int8x16 ----> Other
+static inline kinc_float32x4_t kinc_int8x16_cast_to_float32x4(kinc_int8x16_t t) {
+	float cvt[4];
+	memcpy(&cvt, &t.values[0], sizeof(t));
+
+	return _mm_loadu_ps(cvt);
+}
+
+
+
+//Unsigned Int8x16 ----> Other
+static inline kinc_float32x4_t kinc_uint8x16_cast_to_float32x4(kinc_uint8x16_t t) {
+	float cvt[4];
+	memcpy(&cvt, &t.values[0], sizeof(t));
+
+	return _mm_loadu_ps(cvt);
+}
+
+
+#elif defined(KINC_NEON)
+
+
+//Float32x4 ----> Other
+static inline kinc_int32x4_t kinc_float32x4_cast_to_int32x4(kinc_float32x4_t t) {
+	return vreinterpretq_s32_f32(t);
+}
+static inline kinc_uint32x4_t kinc_float32x4_cast_to_uint32x4(kinc_float32x4_t t) {
+	return vreinterpretq_u32_f32(t);
+}
+static inline kinc_int16x8_t kinc_float32x4_cast_to_int16x8(kinc_float32x4_t t) {
+	return vreinterpretq_s16_f32(t);
+}
+static inline kinc_uint16x8_t kinc_float32x4_cast_to_uint16x8(kinc_float32x4_t t) {
+	return vreinterpretq_u16_f32(t);
+}
+static inline kinc_int8x16_t kinc_float32x4_cast_to_int8x16(kinc_float32x4_t t) {
+	return vreinterpretq_s8_f32(t);
+}
+static inline kinc_uint8x16_t kinc_float32x4_cast_to_uint8x16(kinc_float32x4_t t) {
+	return vreinterpretq_u8_f32(t);
+}
+
+
+
+//Int32x4 ----> Other
+static inline kinc_float32x4_t kinc_int32x4_cast_to_float32x4(kinc_int32x4_t t) {
+	return vreinterpretq_f32_s32(t);
+}
+static inline kinc_uint32x4_t kinc_int32x4_cast_to_uint32x4(kinc_int32x4_t t) {
+	return vreinterpretq_u32_s32(t);
+}
+static inline kinc_int16x8_t kinc_int32x4_cast_to_int16x8(kinc_int32x4_t t) {
+	return vreinterpretq_s16_s32(t);
+}
+static inline kinc_uint16x8_t kinc_int32x4_cast_to_uint16x8(kinc_int32x4_t t) {
+	return vreinterpretq_u16_s32(t);
+}
+static inline kinc_int8x16_t kinc_int32x4_cast_to_int8x16(kinc_int32x4_t t) {
+	return vreinterpretq_s8_s32(t);
+}
+static inline kinc_uint8x16_t kinc_int32x4_cast_to_uint8x16(kinc_int32x4_t t) {
+	return vreinterpretq_u8_s32(t);
+}
+
+
+
+//Unsigned Int32x4 ----> Other
+static inline kinc_float32x4_t kinc_uint32x4_cast_to_float32x4(kinc_uint32x4_t t) {
+	return vreinterpretq_f32_u32(t);
+}
+static inline kinc_int32x4_t kinc_uint32x4_cast_to_int32x4(kinc_uint32x4_t t) {
+	return vreinterpretq_s32_u32(t);
+}
+static inline kinc_int16x8_t kinc_uint32x4_cast_to_int16x8(kinc_uint32x4_t t) {
+	return vreinterpretq_s16_u32(t);
+}
+static inline kinc_uint16x8_t kinc_uint32x4_cast_to_uint16x8(kinc_uint32x4_t t) {
+	return vreinterpretq_u16_u32(t);
+}
+static inline kinc_int8x16_t kinc_uint32x4_cast_to_int8x16(kinc_uint32x4_t t) {
+	return vreinterpretq_s8_u32(t);
+}
+static inline kinc_uint8x16_t kinc_uint32x4_cast_to_uint8x16(kinc_uint32x4_t t) {
+	return vreinterpretq_u8_u32(t);
+}
+
+
+
+//Int16x8 ----> Other
+static inline kinc_float32x4_t kinc_int16x8_cast_to_float32x4(kinc_int16x8_t t) {
+	return vreinterpretq_f32_s16(t);
+}
+static inline kinc_int32x4_t kinc_int16x8_cast_to_int32x4(kinc_int16x8_t t) {
+	return vreinterpretq_s32_s16(t);
+}
+static inline kinc_uint32x4_t kinc_int16x8_cast_to_uint32x4(kinc_int16x8_t t) {
+	return vreinterpretq_u32_s16(t);
+}
+static inline kinc_uint16x8_t kinc_int16x8_cast_to_uint16x8(kinc_int16x8_t t) {
+	return vreinterpretq_u16_s16(t);
+}
+static inline kinc_int8x16_t kinc_int16x8_cast_to_int8x16(kinc_int16x8_t t) {
+	return vreinterpretq_s8_s16(t);
+}
+static inline kinc_uint8x16_t kinc_int16x8_cast_to_uint8x16(kinc_int16x8_t t) {
+	return vreinterpretq_u8_s16(t);
+}
+
+
+
+//Unsigned Int16x8 ----> Other
+static inline kinc_float32x4_t kinc_uint16x8_cast_to_float32x4(kinc_uint16x8_t t) {
+	return vreinterpretq_f32_u16(t);
+}
+static inline kinc_int32x4_t kinc_uint16x8_cast_to_int32x4(kinc_uint16x8_t t) {
+	return vreinterpretq_s32_u16(t);
+}
+static inline kinc_uint32x4_t kinc_uint16x8_cast_to_uint32x4(kinc_uint16x8_t t) {
+	return vreinterpretq_u32_u16(t);
+}
+static inline kinc_int16x8_t kinc_uint16x8_cast_to_int16x8(kinc_uint16x8_t t) {
+	return vreinterpretq_s16_u16(t);
+}
+static inline kinc_int8x16_t kinc_uint16x8_cast_to_int8x16(kinc_uint16x8_t t) {
+	return vreinterpretq_s8_u16(t);
+}
+static inline kinc_uint8x16_t kinc_uint16x8_cast_to_uint8x16(kinc_uint16x8_t t) {
+	return vreinterpretq_u8_u16(t);
+}
+
+
+//Int8x16 ----> Other
+static inline kinc_float32x4_t kinc_int8x16_cast_to_float32x4(kinc_int8x16_t t) {
+	return vreinterpretq_f32_s8(t);
+}
+static inline kinc_int32x4_t kinc_int8x16_cast_to_int32x4(kinc_int8x16_t t) {
+	return vreinterpretq_s32_s8(t);
+}
+static inline kinc_uint32x4_t kinc_int8x16_cast_to_uint32x4(kinc_int8x16_t t) {
+	return vreinterpretq_u32_s8(t);
+}
+static inline kinc_int16x8_t kinc_int8x16_cast_to_int16x8(kinc_int8x16_t t) {
+	return vreinterpretq_s16_s8(t);
+}
+static inline kinc_uint16x8_t kinc_int8x16_cast_to_uint16x8(kinc_int8x16_t t) {
+	return vreinterpretq_u16_s8(t);
+}
+static inline kinc_uint8x16_t kinc_int8x16_cast_to_uint8x16(kinc_int8x16_t t) {
+	return vreinterpretq_u8_s8(t);
+}
+
+
+
+//Unsigned Int8x16 ----> Other
+static inline kinc_float32x4_t kinc_uint8x16_cast_to_float32x4(kinc_uint8x16_t t) {
+	return vreinterpretq_f32_u8(t);
+}
+static inline kinc_int32x4_t kinc_uint8x16_cast_to_int32x4(kinc_uint8x16_t t) {
+	return vreinterpretq_s32_u8(t);
+}
+static inline kinc_uint32x4_t kinc_uint8x16_cast_to_uint32x4(kinc_uint8x16_t t) {
+	return vreinterpretq_u32_u8(t);
+}
+static inline kinc_int16x8_t kinc_uint8x16_cast_to_int16x8(kinc_uint8x16_t t) {
+	return vreinterpretq_s16_u8(t);
+}
+static inline kinc_uint16x8_t kinc_uint8x16_cast_to_uint16x8(kinc_uint8x16_t t) {
+	return vreinterpretq_u16_u8(t);
+}
+static inline kinc_int8x16_t kinc_uint8x16_cast_to_int8x16(kinc_uint8x16_t t) {
+	return vreinterpretq_s8_u8(t);
+}
+
+
+//KINC_NOSIMD float fallbacks casts
+#else
+
+
+
+//Float32x4 ----> Other
+static inline kinc_int32x4_t kinc_float32x4_cast_to_int32x4(kinc_float32x4_t t) {
+	kinc_int32x4_t cvt;
+	memcpy(&cvt.values[0], &t.values[0], sizeof(t));
+
+	return cvt;
+}
+static inline kinc_uint32x4_t kinc_float32x4_cast_to_uint32x4(kinc_float32x4_t t) {
+	kinc_uint32x4_t cvt;
+	memcpy(&cvt.values[0], &t.values[0], sizeof(t));
+
+	return cvt;
+}
+static inline kinc_int16x8_t kinc_float32x4_cast_to_int16x8(kinc_float32x4_t t) {
+	kinc_int16x8_t cvt;
+	memcpy(&cvt.values[0], &t.values[0], sizeof(t));
+
+	return cvt;
+}
+static inline kinc_uint16x8_t kinc_float32x4_cast_to_uint16x8(kinc_float32x4_t t) {
+	kinc_uint16x8_t cvt;
+	memcpy(&cvt.values[0], &t.values[0], sizeof(t));
+
+	return cvt;
+}
+static inline kinc_int8x16_t kinc_float32x4_cast_to_int8x16(kinc_float32x4_t t) {
+	kinc_int8x16_t cvt;
+	memcpy(&cvt.values[0], &t.values[0], sizeof(t));
+
+	return cvt;
+}
+static inline kinc_uint8x16_t kinc_float32x4_cast_to_uint8x16(kinc_float32x4_t t) {
+	kinc_uint8x16_t cvt;
+	memcpy(&cvt.values[0], &t.values[0], sizeof(t));
+
+	return cvt;
+}
+
+
+
+//Int32x4 ----> Float32x4
+static inline kinc_float32x4_t kinc_int32x4_cast_to_float32x4(kinc_int32x4_t t) {
+	kinc_float32x4_t cvt;
+	memcpy(&cvt.values[0], &t.values[0], sizeof(t));
+
+	return cvt;
+}
+
+
+//Unsigned Int32x4 ----> Float32x4
+static inline kinc_float32x4_t kinc_uint32x4_cast_to_float32x4(kinc_uint32x4_t t) {
+	kinc_float32x4_t cvt;
+	memcpy(&cvt.values[0], &t.values[0], sizeof(t));
+
+	return cvt;
+}
+
+
+//Int16x8 ----> Float32x4
+static inline kinc_float32x4_t kinc_int16x8_cast_to_float32x4(kinc_int16x8_t t) {
+	kinc_float32x4_t cvt;
+	memcpy(&cvt.values[0], &t.values[0], sizeof(t));
+
+	return cvt;
+}
+
+
+//Unsigned Int16x8 ----> Float32x4
+static inline kinc_float32x4_t kinc_uint16x8_cast_to_float32x4(kinc_uint16x8_t t) {
+	kinc_float32x4_t cvt;
+	memcpy(&cvt.values[0], &t.values[0], sizeof(t));
+
+	return cvt;
+}
+
+
+//Int8x16 ----> Float32x4
+static inline kinc_float32x4_t kinc_int8x16_cast_to_float32x4(kinc_int8x16_t t) {
+	kinc_float32x4_t cvt;
+	memcpy(&cvt.values[0], &t.values[0], sizeof(t));
+
+	return cvt;
+}
+
+
+//Unsigned Int8x16 ----> Float32x4
+static inline kinc_float32x4_t kinc_uint8x16_cast_to_float32x4(kinc_uint8x16_t t) {
+	kinc_float32x4_t cvt;
+	memcpy(&cvt.values[0], &t.values[0], sizeof(t));
+
+	return cvt;
+}
+
+#endif //KINC_NOSIMD floats
+
+
+
+
+//Shared signed and unsigned integer vectors for SSE and SIMD-fallback
+#if defined(KINC_SSE) || defined(KINC_NOSIMD)
+
+//Int32x4 ----> Other
+static inline kinc_uint32x4_t kinc_int32x4_cast_to_uint32x4(kinc_int32x4_t t) {
+	kinc_uint32x4_t cvt;
+	memcpy(&cvt.values[0], &t.values[0], sizeof(t));
+
+	return cvt;
+}
+static inline kinc_int16x8_t kinc_int32x4_cast_to_int16x8(kinc_int32x4_t t) {
+	kinc_int16x8_t cvt;
+	memcpy(&cvt.values[0], &t.values[0], sizeof(t));
+
+	return cvt;
+}
+static inline kinc_uint16x8_t kinc_int32x4_cast_to_uint16x8(kinc_int32x4_t t) {
+	kinc_uint16x8_t cvt;
+	memcpy(&cvt.values[0], &t.values[0], sizeof(t));
+
+	return cvt;
+}
+static inline kinc_int8x16_t kinc_int32x4_cast_to_int8x16(kinc_int32x4_t t) {
+	kinc_int8x16_t cvt;
+	memcpy(&cvt.values[0], &t.values[0], sizeof(t));
+
+	return cvt;
+}
+static inline kinc_uint8x16_t kinc_int32x4_cast_to_uint8x16(kinc_int32x4_t t) {
+	kinc_uint8x16_t cvt;
+	memcpy(&cvt.values[0], &t.values[0], sizeof(t));
+
+	return cvt;
+}
+
+
+
+//Unsigned Int32x4 ----> Other
+static inline kinc_int32x4_t kinc_uint32x4_cast_to_int32x4(kinc_uint32x4_t t) {
+	kinc_int32x4_t cvt;
+	memcpy(&cvt.values[0], &t.values[0], sizeof(t));
+
+	return cvt;
+}
+static inline kinc_int16x8_t kinc_uint32x4_cast_to_int16x8(kinc_uint32x4_t t) {
+	kinc_int16x8_t cvt;
+	memcpy(&cvt.values[0], &t.values[0], sizeof(t));
+
+	return cvt;
+}
+static inline kinc_uint16x8_t kinc_uint32x4_cast_to_uint16x8(kinc_uint32x4_t t) {
+	kinc_uint16x8_t cvt;
+	memcpy(&cvt.values[0], &t.values[0], sizeof(t));
+
+	return cvt;
+}
+static inline kinc_int8x16_t kinc_uint32x4_cast_to_int8x16(kinc_uint32x4_t t) {
+	kinc_int8x16_t cvt;
+	memcpy(&cvt.values[0], &t.values[0], sizeof(t));
+
+	return cvt;
+}
+static inline kinc_uint8x16_t kinc_uint32x4_cast_to_uint8x16(kinc_uint32x4_t t) {
+	kinc_uint8x16_t cvt;
+	memcpy(&cvt.values[0], &t.values[0], sizeof(t));
+
+	return cvt;
+}
+
+
+
+//Int16x8 ----> Other
+static inline kinc_int32x4_t kinc_int16x8_cast_to_int32x4(kinc_int16x8_t t) {
+	kinc_int32x4_t cvt;
+	memcpy(&cvt.values[0], &t.values[0], sizeof(t));
+
+	return cvt;
+}
+static inline kinc_uint32x4_t kinc_int16x8_cast_to_uint32x4(kinc_int16x8_t t) {
+	kinc_uint32x4_t cvt;
+	memcpy(&cvt.values[0], &t.values[0], sizeof(t));
+
+	return cvt;
+}
+static inline kinc_uint16x8_t kinc_int16x8_cast_to_uint16x8(kinc_int16x8_t t) {
+	kinc_uint16x8_t cvt;
+	memcpy(&cvt.values[0], &t.values[0], sizeof(t));
+
+	return cvt;
+}
+static inline kinc_int8x16_t kinc_int16x8_cast_to_int8x16(kinc_int16x8_t t) {
+	kinc_int8x16_t cvt;
+	memcpy(&cvt.values[0], &t.values[0], sizeof(t));
+
+	return cvt;
+}
+static inline kinc_uint8x16_t kinc_int16x8_cast_to_uint8x16(kinc_int16x8_t t) {
+	kinc_uint8x16_t cvt;
+	memcpy(&cvt.values[0], &t.values[0], sizeof(t));
+
+	return cvt;
+}
+
+
+
+//Unsigned Int16x8 ----> Other
+static inline kinc_int32x4_t kinc_uint16x8_cast_to_int32x4(kinc_uint16x8_t t) {
+	kinc_int32x4_t cvt;
+	memcpy(&cvt.values[0], &t.values[0], sizeof(t));
+
+	return cvt;
+}
+static inline kinc_uint32x4_t kinc_uint16x8_cast_to_uint32x4(kinc_uint16x8_t t) {
+	kinc_uint32x4_t cvt;
+	memcpy(&cvt.values[0], &t.values[0], sizeof(t));
+
+	return cvt;
+}
+static inline kinc_int16x8_t kinc_uint16x8_cast_to_int16x8(kinc_uint16x8_t t) {
+	kinc_int16x8_t cvt;
+	memcpy(&cvt.values[0], &t.values[0], sizeof(t));
+
+	return cvt;
+}
+static inline kinc_int8x16_t kinc_uint16x8_cast_to_int8x16(kinc_uint16x8_t t) {
+	kinc_int8x16_t cvt;
+	memcpy(&cvt.values[0], &t.values[0], sizeof(t));
+
+	return cvt;
+}
+static inline kinc_uint8x16_t kinc_uint16x8_cast_to_uint8x16(kinc_uint16x8_t t) {
+	kinc_uint8x16_t cvt;
+	memcpy(&cvt.values[0], &t.values[0], sizeof(t));
+
+	return cvt;
+}
+
+
+//Int8x16 ----> Other
+static inline kinc_int32x4_t kinc_int8x16_cast_to_int32x4(kinc_int8x16_t t) {
+	kinc_int32x4_t cvt;
+	memcpy(&cvt.values[0], &t.values[0], sizeof(t));
+
+	return cvt;
+}
+static inline kinc_uint32x4_t kinc_int8x16_cast_to_uint32x4(kinc_int8x16_t t) {
+	kinc_uint32x4_t cvt;
+	memcpy(&cvt.values[0], &t.values[0], sizeof(t));
+
+	return cvt;
+}
+static inline kinc_int16x8_t kinc_int8x16_cast_to_int16x8(kinc_int8x16_t t) {
+	kinc_int16x8_t cvt;
+	memcpy(&cvt.values[0], &t.values[0], sizeof(t));
+
+	return cvt;
+}
+static inline kinc_uint16x8_t kinc_int8x16_cast_to_uint16x8(kinc_int8x16_t t) {
+	kinc_uint16x8_t cvt;
+	memcpy(&cvt.values[0], &t.values[0], sizeof(t));
+
+	return cvt;
+}
+static inline kinc_uint8x16_t kinc_int8x16_cast_to_uint8x16(kinc_int8x16_t t) {
+	kinc_uint8x16_t cvt;
+	memcpy(&cvt.values[0], &t.values[0], sizeof(t));
+
+	return cvt;
+}
+
+
+
+//Unsigned Int8x16 ----> Other
+static inline kinc_int32x4_t kinc_uint8x16_cast_to_int32x4(kinc_uint8x16_t t) {
+	kinc_int32x4_t cvt;
+	memcpy(&cvt.values[0], &t.values[0], sizeof(t));
+
+	return cvt;
+}
+static inline kinc_uint32x4_t kinc_uint8x16_cast_to_uint32x4(kinc_uint8x16_t t) {
+	kinc_uint32x4_t cvt;
+	memcpy(&cvt.values[0], &t.values[0], sizeof(t));
+
+	return cvt;
+}
+static inline kinc_int16x8_t kinc_uint8x16_cast_to_int16x8(kinc_uint8x16_t t) {
+	kinc_int16x8_t cvt;
+	memcpy(&cvt.values[0], &t.values[0], sizeof(t));
+
+	return cvt;
+}
+static inline kinc_uint16x8_t kinc_uint8x16_cast_to_uint16x8(kinc_uint8x16_t t) {
+	kinc_uint16x8_t cvt;
+	memcpy(&cvt.values[0], &t.values[0], sizeof(t));
+
+	return cvt;
+}
+static inline kinc_int8x16_t kinc_uint8x16_cast_to_int8x16(kinc_uint8x16_t t) {
+	kinc_int8x16_t cvt;
+	memcpy(&cvt.values[0], &t.values[0], sizeof(t));
+
+	return cvt;
+}
+
+#endif //KINC_SSE || KINC_NOSIMD
+
+
+
+#ifdef __cplusplus
+}
+#endif

--- a/Sources/kinc/simd/type_conversions.h
+++ b/Sources/kinc/simd/type_conversions.h
@@ -20,107 +20,128 @@ extern "C" {
 static inline kinc_int32x4_t kinc_float32x4_cast_to_int32x4(kinc_float32x4_t t) {
 	return _mm_castps_si128(t);
 }
+
 static inline kinc_uint32x4_t kinc_float32x4_cast_to_uint32x4(kinc_float32x4_t t) {
 	return _mm_castps_si128(t);
 }
+
 static inline kinc_int16x8_t kinc_float32x4_cast_to_int16x8(kinc_float32x4_t t) {
 	return _mm_castps_si128(t);
 }
+
 static inline kinc_uint16x8_t kinc_float32x4_cast_to_uint16x8(kinc_float32x4_t t) {
 	return _mm_castps_si128(t);
 }
+
 static inline kinc_int8x16_t kinc_float32x4_cast_to_int8x16(kinc_float32x4_t t) {
 	return _mm_castps_si128(t);
 }
+
 static inline kinc_uint8x16_t kinc_float32x4_cast_to_uint8x16(kinc_float32x4_t t) {
 	return _mm_castps_si128(t);
 }
-
 
 
 //Int32x4 ----> Other
 static inline kinc_float32x4_t kinc_int32x4_cast_to_float32x4(kinc_int32x4_t t) {
 	return _mm_castsi128_ps(t);
 }
+
 static inline kinc_uint32x4_t kinc_int32x4_cast_to_uint32x4(kinc_int32x4_t t) {
 	//SSE2's m128i is every int type, so we can just return any inbound int type parameter
 	return t;
 }
+
 static inline kinc_int16x8_t kinc_int32x4_cast_to_int16x8(kinc_int32x4_t t) {
 	return t;
 }
+
 static inline kinc_uint16x8_t kinc_int32x4_cast_to_uint16x8(kinc_int32x4_t t) {
 	return t;
 }
+
 static inline kinc_int8x16_t kinc_int32x4_cast_to_int8x16(kinc_int32x4_t t) {
 	return t;
 }
+
 static inline kinc_uint8x16_t kinc_int32x4_cast_to_uint8x16(kinc_int32x4_t t) {
 	return t;
 }
-
 
 
 //Unsigned Int32x4 ----> Other
 static inline kinc_float32x4_t kinc_uint32x4_cast_to_float32x4(kinc_uint32x4_t t) {
 	return _mm_castsi128_ps(t);
 }
+
 static inline kinc_int32x4_t kinc_uint32x4_cast_to_int32x4(kinc_uint32x4_t t) {
 	return t;
 }
+
 static inline kinc_int16x8_t kinc_uint32x4_cast_to_int16x8(kinc_uint32x4_t t) {
 	return t;
 }
+
 static inline kinc_uint16x8_t kinc_uint32x4_cast_to_uint16x8(kinc_uint32x4_t t) {
 	return t;
 }
+
 static inline kinc_int8x16_t kinc_uint32x4_cast_to_int8x16(kinc_uint32x4_t t) {
 	return t;
 }
+
 static inline kinc_uint8x16_t kinc_uint32x4_cast_to_uint8x16(kinc_uint32x4_t t) {
 	return t;
 }
-
 
 
 //Int16x8 ----> Other
 static inline kinc_float32x4_t kinc_int16x8_cast_to_float32x4(kinc_int16x8_t t) {
 	return _mm_castsi128_ps(t);
 }
+
 static inline kinc_int32x4_t kinc_int16x8_cast_to_int32x4(kinc_int16x8_t t) {
 	return t;
 }
+
 static inline kinc_uint32x4_t kinc_int16x8_cast_to_uint32x4(kinc_int16x8_t t) {
 	return t;
 }
+
 static inline kinc_uint16x8_t kinc_int16x8_cast_to_uint16x8(kinc_int16x8_t t) {
 	return t;
 }
+
 static inline kinc_int8x16_t kinc_int16x8_cast_to_int8x16(kinc_int16x8_t t) {
 	return t;
 }
+
 static inline kinc_uint8x16_t kinc_int16x8_cast_to_uint8x16(kinc_int16x8_t t) {
 	return t;
 }
-
 
 
 //Unsigned Int16x8 ----> Other
 static inline kinc_float32x4_t kinc_uint16x8_cast_to_float32x4(kinc_uint16x8_t t) {
 	return _mm_castsi128_ps(t);
 }
+
 static inline kinc_int32x4_t kinc_uint16x8_cast_to_int32x4(kinc_uint16x8_t t) {
 	return t;
 }
+
 static inline kinc_uint32x4_t kinc_uint16x8_cast_to_uint32x4(kinc_uint16x8_t t) {
 	return t;
 }
+
 static inline kinc_int16x8_t kinc_uint16x8_cast_to_int16x8(kinc_uint16x8_t t) {
 	return t;
 }
+
 static inline kinc_int8x16_t kinc_uint16x8_cast_to_int8x16(kinc_uint16x8_t t) {
 	return t;
 }
+
 static inline kinc_uint8x16_t kinc_uint16x8_cast_to_uint8x16(kinc_uint16x8_t t) {
 	return t;
 }
@@ -130,40 +151,49 @@ static inline kinc_uint8x16_t kinc_uint16x8_cast_to_uint8x16(kinc_uint16x8_t t) 
 static inline kinc_float32x4_t kinc_int8x16_cast_to_float32x4(kinc_int8x16_t t) {
 	return _mm_castsi128_ps(t);
 }
+
 static inline kinc_int32x4_t kinc_int8x16_cast_to_int32x4(kinc_int8x16_t t) {
 	return t;
 }
+
 static inline kinc_uint32x4_t kinc_int8x16_cast_to_uint32x4(kinc_int8x16_t t) {
 	return t;
 }
+
 static inline kinc_int16x8_t kinc_int8x16_cast_to_int16x8(kinc_int8x16_t t) {
 	return t;
 }
+
 static inline kinc_uint16x8_t kinc_int8x16_cast_to_uint16x8(kinc_int8x16_t t) {
 	return t;
 }
+
 static inline kinc_uint8x16_t kinc_int8x16_cast_to_uint8x16(kinc_int8x16_t t) {
 	return t;
 }
-
 
 
 //Unsigned Int8x16 ----> Other
 static inline kinc_float32x4_t kinc_uint8x16_cast_to_float32x4(kinc_uint8x16_t t) {
 	return _mm_castsi128_ps(t);
 }
+
 static inline kinc_int32x4_t kinc_uint8x16_cast_to_int32x4(kinc_uint8x16_t t) {
 	return t;
 }
+
 static inline kinc_uint32x4_t kinc_uint8x16_cast_to_uint32x4(kinc_uint8x16_t t) {
 	return t;
 }
+
 static inline kinc_int16x8_t kinc_uint8x16_cast_to_int16x8(kinc_uint8x16_t t) {
 	return t;
 }
+
 static inline kinc_uint16x8_t kinc_uint8x16_cast_to_uint16x8(kinc_uint8x16_t t) {
 	return t;
 }
+
 static inline kinc_int8x16_t kinc_uint8x16_cast_to_int8x16(kinc_uint8x16_t t) {
 	return t;
 }
@@ -183,6 +213,7 @@ static inline kinc_int32x4_t kinc_float32x4_cast_to_int32x4(kinc_float32x4_t t) 
 
 	return cvt;
 }
+
 static inline kinc_uint32x4_t kinc_float32x4_cast_to_uint32x4(kinc_float32x4_t t) {
 	float extracted[4];
 	_mm_storeu_ps(&extracted[0], t);
@@ -192,6 +223,7 @@ static inline kinc_uint32x4_t kinc_float32x4_cast_to_uint32x4(kinc_float32x4_t t
 
 	return cvt;
 }
+
 static inline kinc_int16x8_t kinc_float32x4_cast_to_int16x8(kinc_float32x4_t t) {
 	float extracted[4];
 	_mm_storeu_ps(&extracted[0], t);
@@ -201,6 +233,7 @@ static inline kinc_int16x8_t kinc_float32x4_cast_to_int16x8(kinc_float32x4_t t) 
 
 	return cvt;
 }
+
 static inline kinc_uint16x8_t kinc_float32x4_cast_to_uint16x8(kinc_float32x4_t t) {
 	float extracted[4];
 	_mm_storeu_ps(&extracted[0], t);
@@ -210,6 +243,7 @@ static inline kinc_uint16x8_t kinc_float32x4_cast_to_uint16x8(kinc_float32x4_t t
 
 	return cvt;
 }
+
 static inline kinc_int8x16_t kinc_float32x4_cast_to_int8x16(kinc_float32x4_t t) {
 	float extracted[4];
 	_mm_storeu_ps(&extracted[0], t);
@@ -219,6 +253,7 @@ static inline kinc_int8x16_t kinc_float32x4_cast_to_int8x16(kinc_float32x4_t t) 
 
 	return cvt;
 }
+
 static inline kinc_uint8x16_t kinc_float32x4_cast_to_uint8x16(kinc_float32x4_t t) {
 	float extracted[4];
 	_mm_storeu_ps(&extracted[0], t);
@@ -228,7 +263,6 @@ static inline kinc_uint8x16_t kinc_float32x4_cast_to_uint8x16(kinc_float32x4_t t
 
 	return cvt;
 }
-
 
 
 //Int32x4 ----> Other
@@ -249,7 +283,6 @@ static inline kinc_float32x4_t kinc_uint32x4_cast_to_float32x4(kinc_uint32x4_t t
 }
 
 
-
 //Int16x8 ----> Other
 static inline kinc_float32x4_t kinc_int16x8_cast_to_float32x4(kinc_int16x8_t t) {
 	float cvt[4];
@@ -257,7 +290,6 @@ static inline kinc_float32x4_t kinc_int16x8_cast_to_float32x4(kinc_int16x8_t t) 
 
 	return _mm_loadu_ps(&cvt[0]);
 }
-
 
 
 //Unsigned Int16x8 ----> Other
@@ -269,7 +301,6 @@ static inline kinc_float32x4_t kinc_uint16x8_cast_to_float32x4(kinc_uint16x8_t t
 }
 
 
-
 //Int8x16 ----> Other
 static inline kinc_float32x4_t kinc_int8x16_cast_to_float32x4(kinc_int8x16_t t) {
 	float cvt[4];
@@ -277,7 +308,6 @@ static inline kinc_float32x4_t kinc_int8x16_cast_to_float32x4(kinc_int8x16_t t) 
 
 	return _mm_loadu_ps(&cvt[0]);
 }
-
 
 
 //Unsigned Int8x16 ----> Other
@@ -296,106 +326,127 @@ static inline kinc_float32x4_t kinc_uint8x16_cast_to_float32x4(kinc_uint8x16_t t
 static inline kinc_int32x4_t kinc_float32x4_cast_to_int32x4(kinc_float32x4_t t) {
 	return vreinterpretq_s32_f32(t);
 }
+
 static inline kinc_uint32x4_t kinc_float32x4_cast_to_uint32x4(kinc_float32x4_t t) {
 	return vreinterpretq_u32_f32(t);
 }
+
 static inline kinc_int16x8_t kinc_float32x4_cast_to_int16x8(kinc_float32x4_t t) {
 	return vreinterpretq_s16_f32(t);
 }
+
 static inline kinc_uint16x8_t kinc_float32x4_cast_to_uint16x8(kinc_float32x4_t t) {
 	return vreinterpretq_u16_f32(t);
 }
+
 static inline kinc_int8x16_t kinc_float32x4_cast_to_int8x16(kinc_float32x4_t t) {
 	return vreinterpretq_s8_f32(t);
 }
+
 static inline kinc_uint8x16_t kinc_float32x4_cast_to_uint8x16(kinc_float32x4_t t) {
 	return vreinterpretq_u8_f32(t);
 }
-
 
 
 //Int32x4 ----> Other
 static inline kinc_float32x4_t kinc_int32x4_cast_to_float32x4(kinc_int32x4_t t) {
 	return vreinterpretq_f32_s32(t);
 }
+
 static inline kinc_uint32x4_t kinc_int32x4_cast_to_uint32x4(kinc_int32x4_t t) {
 	return vreinterpretq_u32_s32(t);
 }
+
 static inline kinc_int16x8_t kinc_int32x4_cast_to_int16x8(kinc_int32x4_t t) {
 	return vreinterpretq_s16_s32(t);
 }
+
 static inline kinc_uint16x8_t kinc_int32x4_cast_to_uint16x8(kinc_int32x4_t t) {
 	return vreinterpretq_u16_s32(t);
 }
+
 static inline kinc_int8x16_t kinc_int32x4_cast_to_int8x16(kinc_int32x4_t t) {
 	return vreinterpretq_s8_s32(t);
 }
+
 static inline kinc_uint8x16_t kinc_int32x4_cast_to_uint8x16(kinc_int32x4_t t) {
 	return vreinterpretq_u8_s32(t);
 }
-
 
 
 //Unsigned Int32x4 ----> Other
 static inline kinc_float32x4_t kinc_uint32x4_cast_to_float32x4(kinc_uint32x4_t t) {
 	return vreinterpretq_f32_u32(t);
 }
+
 static inline kinc_int32x4_t kinc_uint32x4_cast_to_int32x4(kinc_uint32x4_t t) {
 	return vreinterpretq_s32_u32(t);
 }
+
 static inline kinc_int16x8_t kinc_uint32x4_cast_to_int16x8(kinc_uint32x4_t t) {
 	return vreinterpretq_s16_u32(t);
 }
+
 static inline kinc_uint16x8_t kinc_uint32x4_cast_to_uint16x8(kinc_uint32x4_t t) {
 	return vreinterpretq_u16_u32(t);
 }
+
 static inline kinc_int8x16_t kinc_uint32x4_cast_to_int8x16(kinc_uint32x4_t t) {
 	return vreinterpretq_s8_u32(t);
 }
+
 static inline kinc_uint8x16_t kinc_uint32x4_cast_to_uint8x16(kinc_uint32x4_t t) {
 	return vreinterpretq_u8_u32(t);
 }
-
 
 
 //Int16x8 ----> Other
 static inline kinc_float32x4_t kinc_int16x8_cast_to_float32x4(kinc_int16x8_t t) {
 	return vreinterpretq_f32_s16(t);
 }
+
 static inline kinc_int32x4_t kinc_int16x8_cast_to_int32x4(kinc_int16x8_t t) {
 	return vreinterpretq_s32_s16(t);
 }
+
 static inline kinc_uint32x4_t kinc_int16x8_cast_to_uint32x4(kinc_int16x8_t t) {
 	return vreinterpretq_u32_s16(t);
 }
+
 static inline kinc_uint16x8_t kinc_int16x8_cast_to_uint16x8(kinc_int16x8_t t) {
 	return vreinterpretq_u16_s16(t);
 }
+
 static inline kinc_int8x16_t kinc_int16x8_cast_to_int8x16(kinc_int16x8_t t) {
 	return vreinterpretq_s8_s16(t);
 }
+
 static inline kinc_uint8x16_t kinc_int16x8_cast_to_uint8x16(kinc_int16x8_t t) {
 	return vreinterpretq_u8_s16(t);
 }
-
 
 
 //Unsigned Int16x8 ----> Other
 static inline kinc_float32x4_t kinc_uint16x8_cast_to_float32x4(kinc_uint16x8_t t) {
 	return vreinterpretq_f32_u16(t);
 }
+
 static inline kinc_int32x4_t kinc_uint16x8_cast_to_int32x4(kinc_uint16x8_t t) {
 	return vreinterpretq_s32_u16(t);
 }
+
 static inline kinc_uint32x4_t kinc_uint16x8_cast_to_uint32x4(kinc_uint16x8_t t) {
 	return vreinterpretq_u32_u16(t);
 }
+
 static inline kinc_int16x8_t kinc_uint16x8_cast_to_int16x8(kinc_uint16x8_t t) {
 	return vreinterpretq_s16_u16(t);
 }
+
 static inline kinc_int8x16_t kinc_uint16x8_cast_to_int8x16(kinc_uint16x8_t t) {
 	return vreinterpretq_s8_u16(t);
 }
+
 static inline kinc_uint8x16_t kinc_uint16x8_cast_to_uint8x16(kinc_uint16x8_t t) {
 	return vreinterpretq_u8_u16(t);
 }
@@ -405,40 +456,49 @@ static inline kinc_uint8x16_t kinc_uint16x8_cast_to_uint8x16(kinc_uint16x8_t t) 
 static inline kinc_float32x4_t kinc_int8x16_cast_to_float32x4(kinc_int8x16_t t) {
 	return vreinterpretq_f32_s8(t);
 }
+
 static inline kinc_int32x4_t kinc_int8x16_cast_to_int32x4(kinc_int8x16_t t) {
 	return vreinterpretq_s32_s8(t);
 }
+
 static inline kinc_uint32x4_t kinc_int8x16_cast_to_uint32x4(kinc_int8x16_t t) {
 	return vreinterpretq_u32_s8(t);
 }
+
 static inline kinc_int16x8_t kinc_int8x16_cast_to_int16x8(kinc_int8x16_t t) {
 	return vreinterpretq_s16_s8(t);
 }
+
 static inline kinc_uint16x8_t kinc_int8x16_cast_to_uint16x8(kinc_int8x16_t t) {
 	return vreinterpretq_u16_s8(t);
 }
+
 static inline kinc_uint8x16_t kinc_int8x16_cast_to_uint8x16(kinc_int8x16_t t) {
 	return vreinterpretq_u8_s8(t);
 }
-
 
 
 //Unsigned Int8x16 ----> Other
 static inline kinc_float32x4_t kinc_uint8x16_cast_to_float32x4(kinc_uint8x16_t t) {
 	return vreinterpretq_f32_u8(t);
 }
+
 static inline kinc_int32x4_t kinc_uint8x16_cast_to_int32x4(kinc_uint8x16_t t) {
 	return vreinterpretq_s32_u8(t);
 }
+
 static inline kinc_uint32x4_t kinc_uint8x16_cast_to_uint32x4(kinc_uint8x16_t t) {
 	return vreinterpretq_u32_u8(t);
 }
+
 static inline kinc_int16x8_t kinc_uint8x16_cast_to_int16x8(kinc_uint8x16_t t) {
 	return vreinterpretq_s16_u8(t);
 }
+
 static inline kinc_uint16x8_t kinc_uint8x16_cast_to_uint16x8(kinc_uint8x16_t t) {
 	return vreinterpretq_u16_u8(t);
 }
+
 static inline kinc_int8x16_t kinc_uint8x16_cast_to_int8x16(kinc_uint8x16_t t) {
 	return vreinterpretq_s8_u8(t);
 }
@@ -456,37 +516,41 @@ static inline kinc_int32x4_t kinc_float32x4_cast_to_int32x4(kinc_float32x4_t t) 
 
 	return cvt;
 }
+
 static inline kinc_uint32x4_t kinc_float32x4_cast_to_uint32x4(kinc_float32x4_t t) {
 	kinc_uint32x4_t cvt;
 	memcpy(&cvt.values[0], &t.values[0], sizeof(t));
 
 	return cvt;
 }
+
 static inline kinc_int16x8_t kinc_float32x4_cast_to_int16x8(kinc_float32x4_t t) {
 	kinc_int16x8_t cvt;
 	memcpy(&cvt.values[0], &t.values[0], sizeof(t));
 
 	return cvt;
 }
+
 static inline kinc_uint16x8_t kinc_float32x4_cast_to_uint16x8(kinc_float32x4_t t) {
 	kinc_uint16x8_t cvt;
 	memcpy(&cvt.values[0], &t.values[0], sizeof(t));
 
 	return cvt;
 }
+
 static inline kinc_int8x16_t kinc_float32x4_cast_to_int8x16(kinc_float32x4_t t) {
 	kinc_int8x16_t cvt;
 	memcpy(&cvt.values[0], &t.values[0], sizeof(t));
 
 	return cvt;
 }
+
 static inline kinc_uint8x16_t kinc_float32x4_cast_to_uint8x16(kinc_float32x4_t t) {
 	kinc_uint8x16_t cvt;
 	memcpy(&cvt.values[0], &t.values[0], sizeof(t));
 
 	return cvt;
 }
-
 
 
 //Int32x4 ----> Float32x4
@@ -557,31 +621,34 @@ static inline kinc_uint32x4_t kinc_int32x4_cast_to_uint32x4(kinc_int32x4_t t) {
 
 	return cvt;
 }
+
 static inline kinc_int16x8_t kinc_int32x4_cast_to_int16x8(kinc_int32x4_t t) {
 	kinc_int16x8_t cvt;
 	memcpy(&cvt.values[0], &t.values[0], sizeof(t));
 
 	return cvt;
 }
+
 static inline kinc_uint16x8_t kinc_int32x4_cast_to_uint16x8(kinc_int32x4_t t) {
 	kinc_uint16x8_t cvt;
 	memcpy(&cvt.values[0], &t.values[0], sizeof(t));
 
 	return cvt;
 }
+
 static inline kinc_int8x16_t kinc_int32x4_cast_to_int8x16(kinc_int32x4_t t) {
 	kinc_int8x16_t cvt;
 	memcpy(&cvt.values[0], &t.values[0], sizeof(t));
 
 	return cvt;
 }
+
 static inline kinc_uint8x16_t kinc_int32x4_cast_to_uint8x16(kinc_int32x4_t t) {
 	kinc_uint8x16_t cvt;
 	memcpy(&cvt.values[0], &t.values[0], sizeof(t));
 
 	return cvt;
 }
-
 
 
 //Unsigned Int32x4 ----> Other
@@ -591,31 +658,34 @@ static inline kinc_int32x4_t kinc_uint32x4_cast_to_int32x4(kinc_uint32x4_t t) {
 
 	return cvt;
 }
+
 static inline kinc_int16x8_t kinc_uint32x4_cast_to_int16x8(kinc_uint32x4_t t) {
 	kinc_int16x8_t cvt;
 	memcpy(&cvt.values[0], &t.values[0], sizeof(t));
 
 	return cvt;
 }
+
 static inline kinc_uint16x8_t kinc_uint32x4_cast_to_uint16x8(kinc_uint32x4_t t) {
 	kinc_uint16x8_t cvt;
 	memcpy(&cvt.values[0], &t.values[0], sizeof(t));
 
 	return cvt;
 }
+
 static inline kinc_int8x16_t kinc_uint32x4_cast_to_int8x16(kinc_uint32x4_t t) {
 	kinc_int8x16_t cvt;
 	memcpy(&cvt.values[0], &t.values[0], sizeof(t));
 
 	return cvt;
 }
+
 static inline kinc_uint8x16_t kinc_uint32x4_cast_to_uint8x16(kinc_uint32x4_t t) {
 	kinc_uint8x16_t cvt;
 	memcpy(&cvt.values[0], &t.values[0], sizeof(t));
 
 	return cvt;
 }
-
 
 
 //Int16x8 ----> Other
@@ -625,31 +695,34 @@ static inline kinc_int32x4_t kinc_int16x8_cast_to_int32x4(kinc_int16x8_t t) {
 
 	return cvt;
 }
+
 static inline kinc_uint32x4_t kinc_int16x8_cast_to_uint32x4(kinc_int16x8_t t) {
 	kinc_uint32x4_t cvt;
 	memcpy(&cvt.values[0], &t.values[0], sizeof(t));
 
 	return cvt;
 }
+
 static inline kinc_uint16x8_t kinc_int16x8_cast_to_uint16x8(kinc_int16x8_t t) {
 	kinc_uint16x8_t cvt;
 	memcpy(&cvt.values[0], &t.values[0], sizeof(t));
 
 	return cvt;
 }
+
 static inline kinc_int8x16_t kinc_int16x8_cast_to_int8x16(kinc_int16x8_t t) {
 	kinc_int8x16_t cvt;
 	memcpy(&cvt.values[0], &t.values[0], sizeof(t));
 
 	return cvt;
 }
+
 static inline kinc_uint8x16_t kinc_int16x8_cast_to_uint8x16(kinc_int16x8_t t) {
 	kinc_uint8x16_t cvt;
 	memcpy(&cvt.values[0], &t.values[0], sizeof(t));
 
 	return cvt;
 }
-
 
 
 //Unsigned Int16x8 ----> Other
@@ -659,24 +732,28 @@ static inline kinc_int32x4_t kinc_uint16x8_cast_to_int32x4(kinc_uint16x8_t t) {
 
 	return cvt;
 }
+
 static inline kinc_uint32x4_t kinc_uint16x8_cast_to_uint32x4(kinc_uint16x8_t t) {
 	kinc_uint32x4_t cvt;
 	memcpy(&cvt.values[0], &t.values[0], sizeof(t));
 
 	return cvt;
 }
+
 static inline kinc_int16x8_t kinc_uint16x8_cast_to_int16x8(kinc_uint16x8_t t) {
 	kinc_int16x8_t cvt;
 	memcpy(&cvt.values[0], &t.values[0], sizeof(t));
 
 	return cvt;
 }
+
 static inline kinc_int8x16_t kinc_uint16x8_cast_to_int8x16(kinc_uint16x8_t t) {
 	kinc_int8x16_t cvt;
 	memcpy(&cvt.values[0], &t.values[0], sizeof(t));
 
 	return cvt;
 }
+
 static inline kinc_uint8x16_t kinc_uint16x8_cast_to_uint8x16(kinc_uint16x8_t t) {
 	kinc_uint8x16_t cvt;
 	memcpy(&cvt.values[0], &t.values[0], sizeof(t));
@@ -692,31 +769,34 @@ static inline kinc_int32x4_t kinc_int8x16_cast_to_int32x4(kinc_int8x16_t t) {
 
 	return cvt;
 }
+
 static inline kinc_uint32x4_t kinc_int8x16_cast_to_uint32x4(kinc_int8x16_t t) {
 	kinc_uint32x4_t cvt;
 	memcpy(&cvt.values[0], &t.values[0], sizeof(t));
 
 	return cvt;
 }
+
 static inline kinc_int16x8_t kinc_int8x16_cast_to_int16x8(kinc_int8x16_t t) {
 	kinc_int16x8_t cvt;
 	memcpy(&cvt.values[0], &t.values[0], sizeof(t));
 
 	return cvt;
 }
+
 static inline kinc_uint16x8_t kinc_int8x16_cast_to_uint16x8(kinc_int8x16_t t) {
 	kinc_uint16x8_t cvt;
 	memcpy(&cvt.values[0], &t.values[0], sizeof(t));
 
 	return cvt;
 }
+
 static inline kinc_uint8x16_t kinc_int8x16_cast_to_uint8x16(kinc_int8x16_t t) {
 	kinc_uint8x16_t cvt;
 	memcpy(&cvt.values[0], &t.values[0], sizeof(t));
 
 	return cvt;
 }
-
 
 
 //Unsigned Int8x16 ----> Other
@@ -726,24 +806,28 @@ static inline kinc_int32x4_t kinc_uint8x16_cast_to_int32x4(kinc_uint8x16_t t) {
 
 	return cvt;
 }
+
 static inline kinc_uint32x4_t kinc_uint8x16_cast_to_uint32x4(kinc_uint8x16_t t) {
 	kinc_uint32x4_t cvt;
 	memcpy(&cvt.values[0], &t.values[0], sizeof(t));
 
 	return cvt;
 }
+
 static inline kinc_int16x8_t kinc_uint8x16_cast_to_int16x8(kinc_uint8x16_t t) {
 	kinc_int16x8_t cvt;
 	memcpy(&cvt.values[0], &t.values[0], sizeof(t));
 
 	return cvt;
 }
+
 static inline kinc_uint16x8_t kinc_uint8x16_cast_to_uint16x8(kinc_uint8x16_t t) {
 	kinc_uint16x8_t cvt;
 	memcpy(&cvt.values[0], &t.values[0], sizeof(t));
 
 	return cvt;
 }
+
 static inline kinc_int8x16_t kinc_uint8x16_cast_to_int8x16(kinc_uint8x16_t t) {
 	kinc_int8x16_t cvt;
 	memcpy(&cvt.values[0], &t.values[0], sizeof(t));

--- a/Sources/kinc/simd/type_conversions.h
+++ b/Sources/kinc/simd/type_conversions.h
@@ -176,55 +176,55 @@ static inline kinc_int8x16_t kinc_uint8x16_cast_to_int8x16(kinc_uint8x16_t t) {
 //Float32x4 ----> Other
 static inline kinc_int32x4_t kinc_float32x4_cast_to_int32x4(kinc_float32x4_t t) {
 	float extracted[4];
-	_mm_storeu_ps(&extracted, t);
+	_mm_storeu_ps(&extracted[0], t);
 
 	kinc_int32x4_t cvt;
-	memcpy(&cvt, &extracted, sizeof(extracted));
+	memcpy(&cvt.values[0], &extracted[0], sizeof(extracted));
 
 	return cvt;
 }
 static inline kinc_uint32x4_t kinc_float32x4_cast_to_uint32x4(kinc_float32x4_t t) {
 	float extracted[4];
-	_mm_storeu_ps(&extracted, t);
+	_mm_storeu_ps(&extracted[0], t);
 
 	kinc_uint32x4_t cvt;
-	memcpy(&cvt, &extracted, sizeof(extracted));
+	memcpy(&cvt.values[0], &extracted[0], sizeof(extracted));
 
 	return cvt;
 }
 static inline kinc_int16x8_t kinc_float32x4_cast_to_int16x8(kinc_float32x4_t t) {
 	float extracted[4];
-	_mm_storeu_ps(&extracted, t);
+	_mm_storeu_ps(&extracted[0], t);
 
 	kinc_int16x8_t cvt;
-	memcpy(&cvt, &extracted, sizeof(extracted));
+	memcpy(&cvt.values[0], &extracted[0], sizeof(extracted));
 
 	return cvt;
 }
 static inline kinc_uint16x8_t kinc_float32x4_cast_to_uint16x8(kinc_float32x4_t t) {
 	float extracted[4];
-	_mm_storeu_ps(&extracted, t);
+	_mm_storeu_ps(&extracted[0], t);
 
 	kinc_uint16x8_t cvt;
-	memcpy(&cvt, &extracted, sizeof(extracted));
+	memcpy(&cvt.values[0], &extracted[0], sizeof(extracted));
 
 	return cvt;
 }
 static inline kinc_int8x16_t kinc_float32x4_cast_to_int8x16(kinc_float32x4_t t) {
 	float extracted[4];
-	_mm_storeu_ps(&extracted, t);
+	_mm_storeu_ps(&extracted[0], t);
 
 	kinc_int8x16_t cvt;
-	memcpy(&cvt, &extracted, sizeof(extracted));
+	memcpy(&cvt.values[0], &extracted[0], sizeof(extracted));
 
 	return cvt;
 }
 static inline kinc_uint8x16_t kinc_float32x4_cast_to_uint8x16(kinc_float32x4_t t) {
 	float extracted[4];
-	_mm_storeu_ps(&extracted, t);
+	_mm_storeu_ps(&extracted[0], t);
 
 	kinc_uint8x16_t cvt;
-	memcpy(&cvt, &extracted, sizeof(extracted));
+	memcpy(&cvt.values[0], &extracted[0], sizeof(extracted));
 
 	return cvt;
 }
@@ -234,18 +234,18 @@ static inline kinc_uint8x16_t kinc_float32x4_cast_to_uint8x16(kinc_float32x4_t t
 //Int32x4 ----> Other
 static inline kinc_float32x4_t kinc_int32x4_cast_to_float32x4(kinc_int32x4_t t) {
 	float cvt[4];
-	memcpy(&cvt, &t.values[0], sizeof(t));
+	memcpy(&cvt[0], &t.values[0], sizeof(t));
 
-	return _mm_loadu_ps(cvt);
+	return _mm_loadu_ps(&cvt[0]);
 }
 
 
 //Unsigned Int32x4 ----> Other
 static inline kinc_float32x4_t kinc_uint32x4_cast_to_float32x4(kinc_uint32x4_t t) {
 	float cvt[4];
-	memcpy(&cvt, &t.values[0], sizeof(t));
+	memcpy(&cvt[0], &t.values[0], sizeof(t));
 
-	return _mm_loadu_ps(cvt);
+	return _mm_loadu_ps(&cvt[0]);
 }
 
 
@@ -253,9 +253,9 @@ static inline kinc_float32x4_t kinc_uint32x4_cast_to_float32x4(kinc_uint32x4_t t
 //Int16x8 ----> Other
 static inline kinc_float32x4_t kinc_int16x8_cast_to_float32x4(kinc_int16x8_t t) {
 	float cvt[4];
-	memcpy(&cvt, &t.values[0], sizeof(t));
+	memcpy(&cvt[0], &t.values[0], sizeof(t));
 
-	return _mm_loadu_ps(cvt);
+	return _mm_loadu_ps(&cvt[0]);
 }
 
 
@@ -263,9 +263,9 @@ static inline kinc_float32x4_t kinc_int16x8_cast_to_float32x4(kinc_int16x8_t t) 
 //Unsigned Int16x8 ----> Other
 static inline kinc_float32x4_t kinc_uint16x8_cast_to_float32x4(kinc_uint16x8_t t) {
 	float cvt[4];
-	memcpy(&cvt, &t.values[0], sizeof(t));
+	memcpy(&cvt[0], &t.values[0], sizeof(t));
 
-	return _mm_loadu_ps(cvt);
+	return _mm_loadu_ps(&cvt[0]);
 }
 
 
@@ -273,9 +273,9 @@ static inline kinc_float32x4_t kinc_uint16x8_cast_to_float32x4(kinc_uint16x8_t t
 //Int8x16 ----> Other
 static inline kinc_float32x4_t kinc_int8x16_cast_to_float32x4(kinc_int8x16_t t) {
 	float cvt[4];
-	memcpy(&cvt, &t.values[0], sizeof(t));
+	memcpy(&cvt[0], &t.values[0], sizeof(t));
 
-	return _mm_loadu_ps(cvt);
+	return _mm_loadu_ps(&cvt[0]);
 }
 
 
@@ -283,9 +283,9 @@ static inline kinc_float32x4_t kinc_int8x16_cast_to_float32x4(kinc_int8x16_t t) 
 //Unsigned Int8x16 ----> Other
 static inline kinc_float32x4_t kinc_uint8x16_cast_to_float32x4(kinc_uint8x16_t t) {
 	float cvt[4];
-	memcpy(&cvt, &t.values[0], sizeof(t));
+	memcpy(&cvt[0], &t.values[0], sizeof(t));
 
-	return _mm_loadu_ps(cvt);
+	return _mm_loadu_ps(&cvt[0]);
 }
 
 

--- a/Sources/kinc/simd/types.h
+++ b/Sources/kinc/simd/types.h
@@ -49,6 +49,9 @@ extern "C" {
 #define KINC_NOSIMD
 #endif
 
+#define KINC_SHUFFLE_TABLE(LANE_A1, LANE_A2, LANE_B1, LANE_B2)\
+	 ((((LANE_B2) & 0x3) << 6) | (((LANE_B1) & 0x3) << 4) | (((LANE_A2) & 0x3) << 2) | (((LANE_A1) & 0x3) << 0))
+
 #if defined(KINC_SSE2)
 
 // SSE_## related headers include earlier revisions, IE

--- a/Sources/kinc/simd/types.h
+++ b/Sources/kinc/simd/types.h
@@ -139,9 +139,6 @@ typedef struct kinc_float32x4 {
 
 typedef kinc_float32x4_t kinc_float32x4_mask_t;
 
-typedef struct kinc_internal_float32x4_converter {
-	uint32_t as_ints[4];
-} kinc_internal_float32x4_converter_t;
 
 
 

--- a/Sources/kinc/simd/types.h
+++ b/Sources/kinc/simd/types.h
@@ -140,7 +140,7 @@ typedef struct kinc_float32x4 {
 typedef kinc_float32x4_t kinc_float32x4_mask_t;
 
 typedef struct kinc_internal_float32x4_converter {
-	int as_ints[4];
+	uint32_t as_ints[4];
 } kinc_internal_float32x4_converter_t;
 
 

--- a/Sources/kinc/simd/types.h
+++ b/Sources/kinc/simd/types.h
@@ -137,12 +137,13 @@ typedef struct kinc_float32x4 {
 	float values[4];
 } kinc_float32x4_t;
 
-// Note: Float mask operates a bit differently than int masks
-// Int/UInt masks are intended to mixed with SIMD base type functions like and/or/xor etc.
-// so they're basically just the underlying type in the first place
-typedef struct kinc_float32x4_mask {
-	int values[4];
-} kinc_float32x4_mask_t;
+typedef kinc_float32x4_t kinc_float32x4_mask_t;
+
+typedef struct kinc_internal_float32x4_converter {
+	int as_ints[4];
+} kinc_internal_float32x4_converter_t;
+
+
 
 typedef struct kinc_int8x16 {
 	int8_t values[16];


### PR DESCRIPTION
Changes and additions:

* Completely removed the "mask" concept other than as a naming convention and usage hint, masks aren't different than normal vectors in the first place. kinc_float32x4_mask_t's fallback was the last violation of this, now it's a weak typedef over its base type
* Added 9999999 type casts between all the different vector types
* float32x4 has its bitwise operations now like the other vector types
* Adds SSE-branded float32x4 shuffle operations for SSE/2, NEON, and the fallback (unpacklo, unpackhi, movelh, movehl, and _mm_shuffle_ps equivalents)

Aside from the bit operations, everything else was done to enable vector shuffling. All the cool kids use the float shuffles (in SSE/2 anyway) so you have to be able to cast to and from float32x4 all the time.

Notes:
* NEON intrinsic shuffle options are kind of weak without \_\_aarch64__, so I went with the easiest solutions for these. NEON has "vext" and "vtbl" instructions which can move elements around without that define set, but I didn't want to play Tetris at this time, sorry. There might be other better options available too that I don't know about. Suffice to say these could probably be improved further.
* Shuffle operation names are different between SSE and NEON so I just named them whatever the shuffle's end result in the vector is. If you'd prefer them to use one of the actual intrinsic names or something else, let me know.
* The _mm_shuffle_ps operation is implemented as a macro for SSE and NEON because the vector lane selections for them have to be a constant expression