### PR TITLE
SIMD Improvements 4: Unsigned Integer Shifts, Unaligned Load/Store

### DIFF
--- a/Sources/kinc/simd/float32x4.h
+++ b/Sources/kinc/simd/float32x4.h
@@ -17,6 +17,10 @@ static inline kinc_float32x4_t kinc_float32x4_intrin_load(const float *values) {
 	return _mm_load_ps(values);
 }
 
+static inline kinc_float32x4_t kinc_float32x4_intrin_load_unaligned(const float *values) {
+	return _mm_loadu_ps(values);
+}
+
 static inline kinc_float32x4_t kinc_float32x4_load(float a, float b, float c, float d) {
 	return _mm_set_ps(d, c, b, a);
 }
@@ -27,6 +31,10 @@ static inline kinc_float32x4_t kinc_float32x4_load_all(float t) {
 
 static inline void kinc_float32x4_store(float *destination, kinc_float32x4_t value) {
 	_mm_store_ps(destination, value);
+}
+
+static inline void kinc_float32x4_store_unaligned(float *destination, kinc_float32x4_t value) {
+	_mm_storeu_ps(destination, value);
 }
 
 static inline float kinc_float32x4_get(kinc_float32x4_t t, int index) {
@@ -159,6 +167,10 @@ static inline kinc_float32x4_t kinc_float32x4_intrin_load(const float *values) {
 	return vld1q_f32(values);
 }
 
+static inline kinc_float32x4_t kinc_float32x4_intrin_load_unaligned(const float *values) {
+	return kinc_float32x4_intrin_load(values);
+}
+
 static inline kinc_float32x4_t kinc_float32x4_load(float a, float b, float c, float d) {
 	return (kinc_float32x4_t){a, b, c, d};
 }
@@ -169,6 +181,10 @@ static inline kinc_float32x4_t kinc_float32x4_load_all(float t) {
 
 static inline void kinc_float32x4_store(float *destination, kinc_float32x4_t value) {
 	vst1q_f32(destination, value);
+}
+
+static inline void kinc_float32x4_store_unaligned(float *destination, kinc_float32x4_t value) {
+	kinc_float32x4_store(destination, value);
 }
 
 static inline float kinc_float32x4_get(kinc_float32x4_t t, int index) {
@@ -355,6 +371,10 @@ static inline kinc_float32x4_t kinc_float32x4_intrin_load(const float *values) {
 	return value;
 }
 
+static inline kinc_float32x4_t kinc_float32x4_intrin_load_unaligned(const float *values) {
+	return kinc_float32x4_intrin_load(values);
+}
+
 static inline kinc_float32x4_t kinc_float32x4_load(float a, float b, float c, float d) {
 	kinc_float32x4_t value;
 	value.values[0] = a;
@@ -378,6 +398,10 @@ static inline void kinc_float32x4_store(float *destination, kinc_float32x4_t val
 	destination[1] = value.values[1];
 	destination[2] = value.values[2];
 	destination[3] = value.values[3];
+}
+
+static inline void kinc_float32x4_store_unaligned(float *destination, kinc_float32x4_t value) {
+	kinc_float32x4_store(destination, value);
 }
 
 static inline float kinc_float32x4_get(kinc_float32x4_t t, int index) {

--- a/Sources/kinc/simd/int16x8.h
+++ b/Sources/kinc/simd/int16x8.h
@@ -99,6 +99,13 @@ static inline kinc_int16x8_t kinc_int16x8_not(kinc_int16x8_t t) {
 	return _mm_xor_si128(t, _mm_set1_epi32(0xffffffff));
 }
 
+#define kinc_int16x8_shift_left(t, shift)\
+	return _mm_slli_epi16((t), (shift))
+
+#define kinc_int16x8_shift_right(t, shift)\
+	return _mm_srli_epi16((t), (shift))
+
+
 #elif defined(KINC_NEON)
 
 static inline kinc_int16x8_t kinc_int16x8_intrin_load(const int16_t *values) {
@@ -180,6 +187,12 @@ static inline kinc_int16x8_t kinc_int16x8_xor(kinc_int16x8_t a, kinc_int16x8_t b
 static inline kinc_int16x8_t kinc_int16x8_not(kinc_int16x8_t t) {
 	return vmvnq_s16(t);
 }
+
+#define kinc_int16x8_shift_left(t, shift)\
+	return vshlq_n_s16((t), (shift))
+
+#define kinc_int16x8_shift_right(t, shift)\
+	return vshrq_n_s16((t), (shift))
 
 #else
 
@@ -431,6 +444,35 @@ static inline kinc_int16x8_t kinc_int16x8_not(kinc_int16x8_t t) {
 	value.values[7] = ~t.values[7];
 	return value;
 }
+
+static inline kinc_int16x8_t kinc_int16x8_shift_left(kinc_int16x8_t t, const int shift) {
+	kinc_int16x8_t value;
+	value.values[0] = t.values[0] << shift;
+	value.values[1] = t.values[1] << shift;
+	value.values[2] = t.values[2] << shift;
+	value.values[3] = t.values[3] << shift;
+	value.values[4] = t.values[4] << shift;
+	value.values[5] = t.values[5] << shift;
+	value.values[6] = t.values[6] << shift;
+	value.values[7] = t.values[7] << shift;
+
+	return value;
+}
+
+static inline kinc_int16x8_t kinc_int16x8_shift_right(kinc_int16x8_t t, const int shift) {
+	kinc_int16x8_t value;
+	value.values[0] = t.values[0] >> shift;
+	value.values[1] = t.values[1] >> shift;
+	value.values[2] = t.values[2] >> shift;
+	value.values[3] = t.values[3] >> shift;
+	value.values[4] = t.values[4] >> shift;
+	value.values[5] = t.values[5] >> shift;
+	value.values[6] = t.values[6] >> shift;
+	value.values[7] = t.values[7] >> shift;
+
+	return value;
+}
+
 
 #endif
 

--- a/Sources/kinc/simd/int16x8.h
+++ b/Sources/kinc/simd/int16x8.h
@@ -107,12 +107,6 @@ static inline kinc_int16x8_t kinc_int16x8_not(kinc_int16x8_t t) {
 	return _mm_xor_si128(t, _mm_set1_epi32(0xffffffff));
 }
 
-#define kinc_int16x8_shift_left(t, shift)\
-	return _mm_slli_epi16((t), (shift))
-
-#define kinc_int16x8_shift_right(t, shift)\
-	return _mm_srli_epi16((t), (shift))
-
 
 #elif defined(KINC_NEON)
 
@@ -203,12 +197,6 @@ static inline kinc_int16x8_t kinc_int16x8_xor(kinc_int16x8_t a, kinc_int16x8_t b
 static inline kinc_int16x8_t kinc_int16x8_not(kinc_int16x8_t t) {
 	return vmvnq_s16(t);
 }
-
-#define kinc_int16x8_shift_left(t, shift)\
-	return vshlq_n_s16((t), (shift))
-
-#define kinc_int16x8_shift_right(t, shift)\
-	return vshrq_n_s16((t), (shift))
 
 #else
 
@@ -466,34 +454,6 @@ static inline kinc_int16x8_t kinc_int16x8_not(kinc_int16x8_t t) {
 	value.values[5] = ~t.values[5];
 	value.values[6] = ~t.values[6];
 	value.values[7] = ~t.values[7];
-	return value;
-}
-
-static inline kinc_int16x8_t kinc_int16x8_shift_left(kinc_int16x8_t t, const int shift) {
-	kinc_int16x8_t value;
-	value.values[0] = t.values[0] << shift;
-	value.values[1] = t.values[1] << shift;
-	value.values[2] = t.values[2] << shift;
-	value.values[3] = t.values[3] << shift;
-	value.values[4] = t.values[4] << shift;
-	value.values[5] = t.values[5] << shift;
-	value.values[6] = t.values[6] << shift;
-	value.values[7] = t.values[7] << shift;
-
-	return value;
-}
-
-static inline kinc_int16x8_t kinc_int16x8_shift_right(kinc_int16x8_t t, const int shift) {
-	kinc_int16x8_t value;
-	value.values[0] = t.values[0] >> shift;
-	value.values[1] = t.values[1] >> shift;
-	value.values[2] = t.values[2] >> shift;
-	value.values[3] = t.values[3] >> shift;
-	value.values[4] = t.values[4] >> shift;
-	value.values[5] = t.values[5] >> shift;
-	value.values[6] = t.values[6] >> shift;
-	value.values[7] = t.values[7] >> shift;
-
 	return value;
 }
 

--- a/Sources/kinc/simd/int16x8.h
+++ b/Sources/kinc/simd/int16x8.h
@@ -16,6 +16,10 @@ static inline kinc_int16x8_t kinc_int16x8_intrin_load(const int16_t *values) {
 	return _mm_load_si128((const kinc_int16x8_t *)values);
 }
 
+static inline kinc_int16x8_t kinc_int16x8_intrin_load_unaligned(const int16_t *values) {
+	return _mm_loadu_si128((const kinc_int16x8_t *)values);
+}
+
 static inline kinc_int16x8_t kinc_int16x8_load(const int16_t values[8]) {
 	return _mm_set_epi16(values[7], values[6], values[5], values[4], values[3], values[2], values[1], values[0]);
 }
@@ -26,6 +30,10 @@ static inline kinc_int16x8_t kinc_int16x8_load_all(int16_t t) {
 
 static inline void kinc_int16x8_store(int16_t *destination, kinc_int16x8_t value) {
 	_mm_store_si128((kinc_int16x8_t *)destination, value);
+}
+
+static inline void kinc_int16x8_store_unaligned(int16_t *destination, kinc_int16x8_t value) {
+	_mm_storeu_si128((kinc_int16x8_t *)destination, value);
 }
 
 static inline int16_t kinc_int16x8_get(kinc_int16x8_t t, int index) {
@@ -112,6 +120,10 @@ static inline kinc_int16x8_t kinc_int16x8_intrin_load(const int16_t *values) {
 	return vld1q_s16(values);
 }
 
+static inline kinc_int16x8_t kinc_int16x8_intrin_load_unaligned(const int16_t *values) {
+	return kinc_int16x8_intrin_load(values);
+}
+
 static inline kinc_int16x8_t kinc_int16x8_load(const int16_t values[8]) {
 	return (kinc_int16x8_t){values[0], values[1], values[2], values[3], values[4], values[5], values[6], values[7]};
 }
@@ -122,6 +134,10 @@ static inline kinc_int16x8_t kinc_int16x8_load_all(int16_t t) {
 
 static inline void kinc_int16x8_store(int16_t *destination, kinc_int16x8_t value) {
 	vst1q_s16(destination, value);
+}
+
+static inline void kinc_int16x8_store_unaligned(int16_t *destination, kinc_int16x8_t value) {
+	kinc_int16x8_store(destination, value);
 }
 
 static inline int16_t kinc_int16x8_get(kinc_int16x8_t t, int index) {
@@ -209,6 +225,10 @@ static inline kinc_int16x8_t kinc_int16x8_intrin_load(const int16_t *values) {
 	return value;
 }
 
+static inline kinc_int16x8_t kinc_int16x8_intrin_load_unaligned(const int16_t *values) {
+	return kinc_int16x8_intrin_load(values);
+}
+
 static inline kinc_int16x8_t kinc_int16x8_load(const int16_t values[8]) {
 	kinc_int16x8_t value;
 	value.values[0] = values[0];
@@ -244,6 +264,10 @@ static inline void kinc_int16x8_store(int16_t *destination, kinc_int16x8_t value
 	destination[5] = value.values[5];
 	destination[6] = value.values[6];
 	destination[7] = value.values[7];
+}
+
+static inline void kinc_int16x8_store_unaligned(int16_t *destination, kinc_int16x8_t value) {
+	return kinc_int16x8_store(destination, value);
 }
 
 static inline int16_t kinc_int16x8_get(kinc_int16x8_t t, int index) {

--- a/Sources/kinc/simd/int32x4.h
+++ b/Sources/kinc/simd/int32x4.h
@@ -16,6 +16,10 @@ static inline kinc_int32x4_t kinc_int32x4_intrin_load(const int32_t *values) {
 	return _mm_load_si128((const kinc_int32x4_t *)values);
 }
 
+static inline kinc_int32x4_t kinc_int32x4_intrin_load_unaligned(const int32_t *values) {
+	return _mm_loadu_si128((const kinc_int32x4_t *)values);
+}
+
 static inline kinc_int32x4_t kinc_int32x4_load(const int32_t values[4]) {
 	return _mm_set_epi32(values[3], values[2], values[1], values[0]);
 }
@@ -26,6 +30,10 @@ static inline kinc_int32x4_t kinc_int32x4_load_all(int32_t t) {
 
 static inline void kinc_int32x4_store(int32_t *destination, kinc_int32x4_t value) {
 	_mm_store_si128((kinc_int32x4_t *)destination, value);
+}
+
+static inline void kinc_int32x4_store_unaligned(int32_t *destination, kinc_int32x4_t value) {
+	_mm_storeu_si128((kinc_int32x4_t *)destination, value);
 }
 
 static inline int32_t kinc_int32x4_get(kinc_int32x4_t t, int index) {
@@ -113,6 +121,10 @@ static inline kinc_int32x4_t kinc_int32x4_intrin_load(const int32_t *values) {
 	return vld1q_s32(values);
 }
 
+static inline kinc_int32x4_t kinc_int32x4_intrin_load_unaligned(const int32_t *values) {
+	return kinc_int32x4_intrin_load(values);
+}
+
 static inline kinc_int32x4_t kinc_int32x4_load(const int32_t values[4]) {
 	return (kinc_int32x4_t){values[0], values[1], values[2], values[3]};
 }
@@ -123,6 +135,10 @@ static inline kinc_int32x4_t kinc_int32x4_load_all(int32_t t) {
 
 static inline void kinc_int32x4_store(int32_t *destination, kinc_int32x4_t value) {
 	vst1q_s32(destination, value);
+}
+
+static inline void kinc_int32x4_store_unaligned(int32_t *destination, kinc_int32x4_t value) {
+	kinc_int32x4_store(destination, value);
 }
 
 static inline int32_t kinc_int32x4_get(kinc_int32x4_t t, int index) {
@@ -207,6 +223,10 @@ static inline kinc_int32x4_t kinc_int32x4_intrin_load(const int32_t *values) {
 	return value;
 }
 
+static inline kinc_int32x4_t kinc_int32x4_intrin_load_unaligned(const int32_t *values) {
+	return kinc_int32x4_intrin_load(values);
+}
+
 static inline kinc_int32x4_t kinc_int32x4_load(const int32_t values[4]) {
 	kinc_int32x4_t value;
 	value.values[0] = values[0];
@@ -230,6 +250,10 @@ static inline void kinc_int32x4_store(int32_t *destination, kinc_int32x4_t value
 	destination[1] = value.values[1];
 	destination[2] = value.values[2];
 	destination[3] = value.values[3];
+}
+
+static inline void kinc_int32x4_store_unaligned(int32_t *destination, kinc_int32x4_t value) {
+	kinc_int32x4_store(destination, value);
 }
 
 static inline int32_t kinc_int32x4_get(kinc_int32x4_t t, int index) {

--- a/Sources/kinc/simd/int32x4.h
+++ b/Sources/kinc/simd/int32x4.h
@@ -99,7 +99,15 @@ static inline kinc_int32x4_t kinc_int32x4_not(kinc_int32x4_t t) {
 	return _mm_xor_si128(t, _mm_set1_epi32(0xffffffff));
 }
 
+#define kinc_int32x4_shift_left(t, shift)\
+	return _mm_slli_epi32((t), (shift))
+
+#define kinc_int32x4_shift_right(t, shift)\
+	return _mm_srli_epi32((t), (shift))
+
+
 #elif defined(KINC_NEON)
+
 
 static inline kinc_int32x4_t kinc_int32x4_intrin_load(const int32_t *values) {
 	return vld1q_s32(values);
@@ -180,6 +188,13 @@ static inline kinc_int32x4_t kinc_int32x4_xor(kinc_int32x4_t a, kinc_int32x4_t b
 static inline kinc_int32x4_t kinc_int32x4_not(kinc_int32x4_t t) {
 	return vmvnq_s32(t);
 }
+
+#define kinc_int32x4_shift_left(t, shift)\
+	return vshlq_n_s32((t), (shift))
+
+#define kinc_int32x4_shift_right(t, shift)\
+	return vshrq_n_s32((t), (shift))
+
 
 #else
 
@@ -355,6 +370,27 @@ static inline kinc_int32x4_t kinc_int32x4_not(kinc_int32x4_t t) {
 	value.values[3] = ~t.values[3];
 	return value;
 }
+
+static inline kinc_int32x4_t kinc_int32x4_shift_left(kinc_int32x4_t t, const int shift) {
+	kinc_int32x4_t value;
+	value.values[0] = t.values[0] << shift;
+	value.values[1] = t.values[1] << shift;
+	value.values[2] = t.values[2] << shift;
+	value.values[3] = t.values[3] << shift;
+
+	return value;
+}
+
+static inline kinc_int32x4_t kinc_int32x4_shift_right(kinc_int32x4_t t, const int shift) {
+	kinc_int32x4_t value;
+	value.values[0] = t.values[0] >> shift;
+	value.values[1] = t.values[1] >> shift;
+	value.values[2] = t.values[2] >> shift;
+	value.values[3] = t.values[3] >> shift;
+
+	return value;
+}
+
 
 #endif
 

--- a/Sources/kinc/simd/int32x4.h
+++ b/Sources/kinc/simd/int32x4.h
@@ -107,12 +107,6 @@ static inline kinc_int32x4_t kinc_int32x4_not(kinc_int32x4_t t) {
 	return _mm_xor_si128(t, _mm_set1_epi32(0xffffffff));
 }
 
-#define kinc_int32x4_shift_left(t, shift)\
-	return _mm_slli_epi32((t), (shift))
-
-#define kinc_int32x4_shift_right(t, shift)\
-	return _mm_srli_epi32((t), (shift))
-
 
 #elif defined(KINC_NEON)
 
@@ -204,12 +198,6 @@ static inline kinc_int32x4_t kinc_int32x4_xor(kinc_int32x4_t a, kinc_int32x4_t b
 static inline kinc_int32x4_t kinc_int32x4_not(kinc_int32x4_t t) {
 	return vmvnq_s32(t);
 }
-
-#define kinc_int32x4_shift_left(t, shift)\
-	return vshlq_n_s32((t), (shift))
-
-#define kinc_int32x4_shift_right(t, shift)\
-	return vshrq_n_s32((t), (shift))
 
 
 #else
@@ -392,26 +380,6 @@ static inline kinc_int32x4_t kinc_int32x4_not(kinc_int32x4_t t) {
 	value.values[1] = ~t.values[1];
 	value.values[2] = ~t.values[2];
 	value.values[3] = ~t.values[3];
-	return value;
-}
-
-static inline kinc_int32x4_t kinc_int32x4_shift_left(kinc_int32x4_t t, const int shift) {
-	kinc_int32x4_t value;
-	value.values[0] = t.values[0] << shift;
-	value.values[1] = t.values[1] << shift;
-	value.values[2] = t.values[2] << shift;
-	value.values[3] = t.values[3] << shift;
-
-	return value;
-}
-
-static inline kinc_int32x4_t kinc_int32x4_shift_right(kinc_int32x4_t t, const int shift) {
-	kinc_int32x4_t value;
-	value.values[0] = t.values[0] >> shift;
-	value.values[1] = t.values[1] >> shift;
-	value.values[2] = t.values[2] >> shift;
-	value.values[3] = t.values[3] >> shift;
-
 	return value;
 }
 

--- a/Sources/kinc/simd/int8x16.h
+++ b/Sources/kinc/simd/int8x16.h
@@ -16,6 +16,10 @@ static inline kinc_int8x16_t kinc_int8x16_intrin_load(const int8_t *values) {
 	return _mm_load_si128((const kinc_int8x16_t *)values);
 }
 
+static inline kinc_int8x16_t kinc_int8x16_intrin_load_unaligned(const int8_t *values) {
+	return _mm_loadu_si128((const kinc_int8x16_t *)values);
+}
+
 static inline kinc_int8x16_t kinc_int8x16_load(const int8_t values[16]) {
 	return _mm_set_epi8(values[15], values[14], values[13], values[12], values[11], values[10], values[9], values[8], values[7], values[6], values[5],
 	                    values[4], values[3], values[2], values[1], values[0]);
@@ -27,6 +31,10 @@ static inline kinc_int8x16_t kinc_int8x16_load_all(int8_t t) {
 
 static inline void kinc_int8x16_store(int8_t *destination, kinc_int8x16_t value) {
 	_mm_store_si128((kinc_int8x16_t *)destination, value);
+}
+
+static inline void kinc_int8x16_store_unaligned(int8_t *destination, kinc_int8x16_t value) {
+	_mm_storeu_si128((kinc_int8x16_t *)destination, value);
 }
 
 static inline int8_t kinc_int8x16_get(kinc_int8x16_t t, int index) {
@@ -109,6 +117,10 @@ static inline kinc_int8x16_t kinc_int8x16_intrin_load(const int8_t *values) {
 	return vld1q_s8(values);
 }
 
+static inline kinc_int8x16_t kinc_int8x16_intrin_load_unaligned(const int8_t *values) {
+	return kinc_int8x16_intrin_load(values);
+}
+
 static inline kinc_int8x16_t kinc_int8x16_load(const int8_t values[16]) {
 	return (kinc_int8x16_t){values[0], values[1], values[2],  values[3],  values[4],  values[5],  values[6],  values[7],
 	                        values[8], values[9], values[10], values[11], values[12], values[13], values[14], values[15]};
@@ -120,6 +132,10 @@ static inline kinc_int8x16_t kinc_int8x16_load_all(int8_t t) {
 
 static inline void kinc_int8x16_store(int8_t *destination, kinc_int8x16_t value) {
 	vst1q_s8(destination, value);
+}
+
+static inline void kinc_int8x16_store_unaligned(int8_t *destination, kinc_int8x16_t value) {
+	kinc_int8x16_store(destination, value);
 }
 
 static inline int8_t kinc_int8x16_get(kinc_int8x16_t t, int index) {
@@ -209,6 +225,10 @@ static inline kinc_int8x16_t kinc_int8x16_intrin_load(const int8_t *values) {
 	return value;
 }
 
+static inline kinc_int8x16_t kinc_int8x16_intrin_load_unaligned(const int8_t *values) {
+	return kinc_int8x16_intrin_load(values);
+}
+
 static inline kinc_int8x16_t kinc_int8x16_load(const int8_t values[16]) {
 	kinc_int8x16_t value;
 	value.values[0] = values[0];
@@ -268,6 +288,10 @@ static inline void kinc_int8x16_store(int8_t *destination, kinc_int8x16_t value)
 	destination[13] = value.values[13];
 	destination[14] = value.values[14];
 	destination[15] = value.values[15];
+}
+
+static inline void kinc_int8x16_store_unaligned(int8_t *destination, kinc_int8x16_t value) {
+	return kinc_int8x16_store(destination, value);
 }
 
 static inline int8_t kinc_int8x16_get(kinc_int8x16_t t, int index) {

--- a/Sources/kinc/simd/uint16x8.h
+++ b/Sources/kinc/simd/uint16x8.h
@@ -110,10 +110,10 @@ static inline kinc_uint16x8_t kinc_uint16x8_not(kinc_uint16x8_t t) {
 }
 
 #define kinc_uint16x8_shift_left(t, shift)\
-	return _mm_slli_epi16((t), (shift))
+	_mm_slli_epi16((t), (shift))
 
 #define kinc_uint16x8_shift_right(t, shift)\
-	return _mm_srli_epi16((t), (shift))
+	_mm_srli_epi16((t), (shift))
 
 
 #elif defined(KINC_NEON)
@@ -207,10 +207,10 @@ static inline kinc_uint16x8_t kinc_uint16x8_not(kinc_uint16x8_t t) {
 }
 
 #define kinc_uint16x8_shift_left(t, shift)\
-	return vshlq_n_u16((t), (shift))
+	vshlq_n_u16((t), (shift))
 
 #define kinc_uint16x8_shift_right(t, shift)\
-	return vshrq_n_u16((t), (shift))
+	vshrq_n_u16((t), (shift))
 
 
 #else

--- a/Sources/kinc/simd/uint16x8.h
+++ b/Sources/kinc/simd/uint16x8.h
@@ -16,6 +16,10 @@ static inline kinc_uint16x8_t kinc_uint16x8_intrin_load(const uint16_t *values) 
 	return _mm_load_si128((const kinc_uint16x8_t *)values);
 }
 
+static inline kinc_uint16x8_t kinc_uint16x8_intrin_load_unaligned(const uint16_t *values) {
+	return _mm_loadu_si128((const kinc_uint16x8_t *)values);
+}
+
 static inline kinc_uint16x8_t kinc_uint16x8_load(const uint16_t values[8]) {
 	return _mm_set_epi16(values[7], values[6], values[5], values[4], values[3], values[2], values[1], values[0]);
 }
@@ -26,6 +30,10 @@ static inline kinc_uint16x8_t kinc_uint16x8_load_all(uint16_t t) {
 
 static inline void kinc_uint16x8_store(uint16_t *destination, kinc_uint16x8_t value) {
 	_mm_store_si128((kinc_uint16x8_t *)destination, value);
+}
+
+static inline void kinc_uint16x8_store_unaligned(uint16_t *destination, kinc_uint16x8_t value) {
+	_mm_storeu_si128((kinc_uint16x8_t *)destination, value);
 }
 
 static inline uint16_t kinc_uint16x8_get(kinc_uint16x8_t t, int index) {
@@ -114,6 +122,10 @@ static inline kinc_uint16x8_t kinc_uint16x8_intrin_load(const uint16_t *values) 
 	return vld1q_u16(values);
 }
 
+static inline kinc_uint16x8_t kinc_uint16x8_intrin_load_unaligned(const uint16_t *values) {
+	return kinc_uint16x8_intrin_load(values);
+}
+
 static inline kinc_uint16x8_t kinc_uint16x8_load(const uint16_t values[8]) {
 	return (kinc_uint16x8_t){values[0], values[1], values[2], values[3], values[4], values[5], values[6], values[7]};
 }
@@ -124,6 +136,10 @@ static inline kinc_uint16x8_t kinc_uint16x8_load_all(uint16_t t) {
 
 static inline void kinc_uint16x8_store(uint16_t *destination, kinc_uint16x8_t value) {
 	vst1q_u16(destination, value);
+}
+
+static inline void kinc_uint16x8_store_unaligned(uint16_t *destination, kinc_uint16x8_t value) {
+	kinc_uint16x8_store(destination, value);
 }
 
 static inline uint16_t kinc_uint16x8_get(kinc_uint16x8_t t, int index) {
@@ -212,6 +228,10 @@ static inline kinc_uint16x8_t kinc_uint16x8_intrin_load(const uint16_t *values) 
 	return value;
 }
 
+static inline kinc_uint16x8_t kinc_uint16x8_intrin_load_unaligned(const uint16_t *values) {
+	return kinc_uint16x8_intrin_load(values);
+}
+
 static inline kinc_uint16x8_t kinc_uint16x8_load(const uint16_t values[8]) {
 	kinc_uint16x8_t value;
 	value.values[0] = values[0];
@@ -247,6 +267,10 @@ static inline void kinc_uint16x8_store(uint16_t *destination, kinc_uint16x8_t va
 	destination[5] = value.values[5];
 	destination[6] = value.values[6];
 	destination[7] = value.values[7];
+}
+
+static inline void kinc_uint16x8_store_unaligned(uint16_t *destination, kinc_uint16x8_t value) {
+	kinc_uint16x8_store(destination, value);
 }
 
 static inline uint16_t kinc_uint16x8_get(kinc_uint16x8_t t, int index) {

--- a/Sources/kinc/simd/uint16x8.h
+++ b/Sources/kinc/simd/uint16x8.h
@@ -101,6 +101,13 @@ static inline kinc_uint16x8_t kinc_uint16x8_not(kinc_uint16x8_t t) {
 	return _mm_xor_si128(t, _mm_set1_epi32(0xffffffff));
 }
 
+#define kinc_uint16x8_shift_left(t, shift)\
+	return _mm_slli_epi16((t), (shift))
+
+#define kinc_uint16x8_shift_right(t, shift)\
+	return _mm_srli_epi16((t), (shift))
+
+
 #elif defined(KINC_NEON)
 
 static inline kinc_uint16x8_t kinc_uint16x8_intrin_load(const uint16_t *values) {
@@ -182,6 +189,13 @@ static inline kinc_uint16x8_t kinc_uint16x8_xor(kinc_uint16x8_t a, kinc_uint16x8
 static inline kinc_uint16x8_t kinc_uint16x8_not(kinc_uint16x8_t t) {
 	return vmvnq_u16(t);
 }
+
+#define kinc_uint16x8_shift_left(t, shift)\
+	return vshlq_n_u16((t), (shift))
+
+#define kinc_uint16x8_shift_right(t, shift)\
+	return vshrq_n_u16((t), (shift))
+
 
 #else
 
@@ -433,6 +447,35 @@ static inline kinc_uint16x8_t kinc_uint16x8_not(kinc_uint16x8_t t) {
 	value.values[7] = ~t.values[7];
 	return value;
 }
+
+static inline kinc_uint16x8_t kinc_uint16x8_shift_left(kinc_uint16x8_t t, const int shift) {
+	kinc_uint16x8_t value;
+	value.values[0] = t.values[0] << shift;
+	value.values[1] = t.values[1] << shift;
+	value.values[2] = t.values[2] << shift;
+	value.values[3] = t.values[3] << shift;
+	value.values[4] = t.values[4] << shift;
+	value.values[5] = t.values[5] << shift;
+	value.values[6] = t.values[6] << shift;
+	value.values[7] = t.values[7] << shift;
+
+	return value;
+}
+
+static inline kinc_uint16x8_t kinc_uint16x8_shift_right(kinc_uint16x8_t t, const int shift) {
+	kinc_uint16x8_t value;
+	value.values[0] = t.values[0] >> shift;
+	value.values[1] = t.values[1] >> shift;
+	value.values[2] = t.values[2] >> shift;
+	value.values[3] = t.values[3] >> shift;
+	value.values[4] = t.values[4] >> shift;
+	value.values[5] = t.values[5] >> shift;
+	value.values[6] = t.values[6] >> shift;
+	value.values[7] = t.values[7] >> shift;
+
+	return value;
+}
+
 
 #endif
 

--- a/Sources/kinc/simd/uint32x4.h
+++ b/Sources/kinc/simd/uint32x4.h
@@ -101,6 +101,13 @@ static inline kinc_uint32x4_t kinc_uint32x4_not(kinc_uint32x4_t t) {
 	return _mm_xor_si128(t, _mm_set1_epi32(0xffffffff));
 }
 
+#define kinc_uint32x4_shift_left(t, shift)\
+	return _mm_slli_epi32((t), (shift))
+
+#define kinc_uint32x4_shift_right(t, shift)\
+	return _mm_srli_epi32((t), (shift))
+
+
 #elif defined(KINC_NEON)
 
 static inline kinc_uint32x4_t kinc_uint32x4_intrin_load(const uint32_t *values) {
@@ -182,6 +189,13 @@ static inline kinc_uint32x4_t kinc_uint32x4_xor(kinc_uint32x4_t a, kinc_uint32x4
 static inline kinc_uint32x4_t kinc_uint32x4_not(kinc_uint32x4_t t) {
 	return vmvnq_u32(t);
 }
+
+#define kinc_uint32x4_shift_left(t, shift)\
+	return vshlq_n_u32((t), (shift))
+
+#define kinc_uint32x4_shift_right(t, shift)\
+	return vshrq_n_u32((t), (shift))
+
 
 #else
 
@@ -355,6 +369,26 @@ static inline kinc_uint32x4_t kinc_uint32x4_not(kinc_uint32x4_t t) {
 	value.values[1] = ~t.values[1];
 	value.values[2] = ~t.values[2];
 	value.values[3] = ~t.values[3];
+	return value;
+}
+
+static inline kinc_uint32x4_t kinc_uint32x4_shift_left(kinc_uint32x4_t t, const int shift) {
+	kinc_uint32x4_t value;
+	value.values[0] = t.values[0] << shift;
+	value.values[1] = t.values[1] << shift;
+	value.values[2] = t.values[2] << shift;
+	value.values[3] = t.values[3] << shift;
+
+	return value;
+}
+
+static inline kinc_uint32x4_t kinc_uint32x4_shift_right(kinc_uint32x4_t t, const int shift) {
+	kinc_uint32x4_t value;
+	value.values[0] = t.values[0] >> shift;
+	value.values[1] = t.values[1] >> shift;
+	value.values[2] = t.values[2] >> shift;
+	value.values[3] = t.values[3] >> shift;
+
 	return value;
 }
 

--- a/Sources/kinc/simd/uint32x4.h
+++ b/Sources/kinc/simd/uint32x4.h
@@ -110,10 +110,10 @@ static inline kinc_uint32x4_t kinc_uint32x4_not(kinc_uint32x4_t t) {
 }
 
 #define kinc_uint32x4_shift_left(t, shift)\
-	return _mm_slli_epi32((t), (shift))
+	_mm_slli_epi32((t), (shift))
 
 #define kinc_uint32x4_shift_right(t, shift)\
-	return _mm_srli_epi32((t), (shift))
+	_mm_srli_epi32((t), (shift))
 
 
 #elif defined(KINC_NEON)
@@ -207,10 +207,10 @@ static inline kinc_uint32x4_t kinc_uint32x4_not(kinc_uint32x4_t t) {
 }
 
 #define kinc_uint32x4_shift_left(t, shift)\
-	return vshlq_n_u32((t), (shift))
+	vshlq_n_u32((t), (shift))
 
 #define kinc_uint32x4_shift_right(t, shift)\
-	return vshrq_n_u32((t), (shift))
+	vshrq_n_u32((t), (shift))
 
 
 #else

--- a/Sources/kinc/simd/uint32x4.h
+++ b/Sources/kinc/simd/uint32x4.h
@@ -16,6 +16,10 @@ static inline kinc_uint32x4_t kinc_uint32x4_intrin_load(const uint32_t *values) 
 	return _mm_load_si128((const kinc_uint32x4_t *)values);
 }
 
+static inline kinc_uint32x4_t kinc_uint32x4_intrin_load_unaligned(const uint32_t *values) {
+	return _mm_loadu_si128((const kinc_uint32x4_t *)values);
+}
+
 static inline kinc_uint32x4_t kinc_uint32x4_load(const uint32_t values[4]) {
 	return _mm_set_epi32(values[3], values[2], values[1], values[0]);
 }
@@ -26,6 +30,10 @@ static inline kinc_uint32x4_t kinc_uint32x4_load_all(uint32_t t) {
 
 static inline void kinc_uint32x4_store(uint32_t *destination, kinc_uint32x4_t value) {
 	_mm_store_si128((kinc_uint32x4_t *)destination, value);
+}
+
+static inline void kinc_uint32x4_store_unaligned(uint32_t *destination, kinc_uint32x4_t value) {
+	_mm_storeu_si128((kinc_uint32x4_t *)destination, value);
 }
 
 static inline uint32_t kinc_uint32x4_get(kinc_uint32x4_t t, int index) {
@@ -114,6 +122,10 @@ static inline kinc_uint32x4_t kinc_uint32x4_intrin_load(const uint32_t *values) 
 	return vld1q_u32(values);
 }
 
+static inline kinc_uint32x4_t kinc_uint32x4_intrin_load_unaligned(const uint32_t *values) {
+	return kinc_uint32x4_intrin_load(values);
+}
+
 static inline kinc_uint32x4_t kinc_uint32x4_load(const uint32_t values[4]) {
 	return (kinc_uint32x4_t){values[0], values[1], values[2], values[3]};
 }
@@ -124,6 +136,10 @@ static inline kinc_uint32x4_t kinc_uint32x4_load_all(uint32_t t) {
 
 static inline void kinc_uint32x4_store(uint32_t *destination, kinc_uint32x4_t value) {
 	vst1q_u32(destination, value);
+}
+
+static inline void kinc_uint32x4_store_unaligned(uint32_t *destination, kinc_uint32x4_t value) {
+	kinc_uint32x4_store(destination, value);
 }
 
 static inline uint32_t kinc_uint32x4_get(kinc_uint32x4_t t, int index) {
@@ -208,6 +224,10 @@ static inline kinc_uint32x4_t kinc_uint32x4_intrin_load(const uint32_t *values) 
 	return value;
 }
 
+static inline kinc_uint32x4_t kinc_uint32x4_intrin_load_unaligned(const uint32_t *values) {
+	return kinc_uint32x4_intrin_load(values);
+}
+
 static inline kinc_uint32x4_t kinc_uint32x4_load(const uint32_t values[4]) {
 	kinc_uint32x4_t value;
 	value.values[0] = values[0];
@@ -231,6 +251,10 @@ static inline void kinc_uint32x4_store(uint32_t *destination, kinc_uint32x4_t va
 	destination[1] = value.values[1];
 	destination[2] = value.values[2];
 	destination[3] = value.values[3];
+}
+
+static inline void kinc_uint32x4_store_unaligned(uint32_t *destination, kinc_uint32x4_t value) {
+	kinc_uint32x4_store(destination, value);
 }
 
 static inline uint32_t kinc_uint32x4_get(kinc_uint32x4_t t, int index) {

--- a/Sources/kinc/simd/uint8x16.h
+++ b/Sources/kinc/simd/uint8x16.h
@@ -16,6 +16,10 @@ static inline kinc_uint8x16_t kinc_uint8x16_intrin_load(const uint8_t *values) {
 	return _mm_load_si128((const kinc_uint8x16_t *)values);
 }
 
+static inline kinc_uint8x16_t kinc_uint8x16_intrin_load_unaligned(const uint8_t *values) {
+	return _mm_loadu_si128((const kinc_uint8x16_t *)values);
+}
+
 static inline kinc_uint8x16_t kinc_uint8x16_load(const uint8_t values[16]) {
 	return _mm_set_epi8(values[15], values[14], values[13], values[12], values[11], values[10], values[9], values[8], values[7], values[6], values[5],
 	                    values[4], values[3], values[2], values[1], values[0]);
@@ -27,6 +31,10 @@ static inline kinc_uint8x16_t kinc_uint8x16_load_all(uint8_t t) {
 
 static inline void kinc_uint8x16_store(uint8_t *destination, kinc_uint8x16_t value) {
 	_mm_store_si128((kinc_uint8x16_t *)destination, value);
+}
+
+static inline void kinc_uint8x16_store_unaligned(uint8_t *destination, kinc_uint8x16_t value) {
+	_mm_storeu_si128((kinc_uint8x16_t *)destination, value);
 }
 
 static inline uint8_t kinc_uint8x16_get(kinc_uint8x16_t t, int index) {
@@ -104,6 +112,10 @@ static inline kinc_uint8x16_t kinc_uint8x16_intrin_load(const uint8_t *values) {
 	return vld1q_u8(values);
 }
 
+static inline kinc_uint8x16_t kinc_uint8x16_intrin_load_unaligned(const uint8_t *values) {
+	return kinc_uint8x16_intrin_load(values);
+}
+
 static inline kinc_uint8x16_t kinc_uint8x16_load(const uint8_t values[16]) {
 	return (kinc_uint8x16_t){values[0], values[1], values[2],  values[3],  values[4],  values[5],  values[6],  values[7],
 	                         values[8], values[9], values[10], values[11], values[12], values[13], values[14], values[15]};
@@ -115,6 +127,10 @@ static inline kinc_uint8x16_t kinc_uint8x16_load_all(uint8_t t) {
 
 static inline void kinc_uint8x16_store(uint8_t *destination, kinc_uint8x16_t value) {
 	vst1q_u8(destination, value);
+}
+
+static inline void kinc_uint8x16_store_unaligned(uint8_t *destination, kinc_uint8x16_t value) {
+	kinc_uint8x16_store(destination, value);
 }
 
 static inline uint8_t kinc_uint8x16_get(kinc_uint8x16_t t, int index) {
@@ -204,6 +220,10 @@ static inline kinc_uint8x16_t kinc_uint8x16_intrin_load(const uint8_t *values) {
 	return value;
 }
 
+static inline kinc_uint8x16_t kinc_uint8x16_intrin_load_unaligned(const uint8_t *values) {
+	return kinc_uint8x16_intrin_load(values);
+}
+
 static inline kinc_uint8x16_t kinc_uint8x16_load(const uint8_t values[16]) {
 	kinc_uint8x16_t value;
 	value.values[0] = values[0];
@@ -263,6 +283,10 @@ static inline void kinc_uint8x16_store(uint8_t *destination, kinc_uint8x16_t val
 	destination[13] = value.values[13];
 	destination[14] = value.values[14];
 	destination[15] = value.values[15];
+}
+
+static inline void kinc_uint8x16_store_unaligned(uint8_t *destination, kinc_uint8x16_t value) {
+	return kinc_uint8x16_store(destination, value);
 }
 
 static inline uint8_t kinc_uint8x16_get(kinc_uint8x16_t t, int index) {


### PR DESCRIPTION
Notes:
* Left/Right shift are constexpr for NEON and SSE2, macros again :(
* Hopefully no more PR spam as I think this is most of the portable useful stuff, my eyes are glazing over at this point after reading uint1337xSpork variations a million times.