### PR TITLE
Fix socket send flag

### DIFF
--- a/Sources/kinc/network/socket.h
+++ b/Sources/kinc/network/socket.h
@@ -557,7 +557,7 @@ int kinc_socket_send(kinc_socket_t *sock, const uint8_t *data, int size) {
 			return -1;
 		}
 
-		size_t sent = send(sock->handle, (const char *)data, size, MSG_WAITALL);
+		size_t sent = send(sock->handle, (const char *)data, size, 0);
 		if (sent != size) {
 			kinc_log(KINC_LOG_LEVEL_ERROR, "Could not send packet.");
 		}


### PR DESCRIPTION
On linux we can use the MSG_WAITALL flag because linux doesn't care and just sends it disregarding our flag.

On windows this gives a WSAEOPNOTSUPP error and doesn't send. This basically tells us the flag [isn't supported](https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-send) for send, look at the possible values for the flag parameter. It's still [not supported](https://linux.die.net/man/3/send) on linux, it just doesn't error out.