### PR TITLE
[macos] Fix window size on retina display

### DIFF
--- a/Backends/System/macOS/Sources/kinc/backend/BasicOpenGLView.m.h
+++ b/Backends/System/macOS/Sources/kinc/backend/BasicOpenGLView.m.h
@@ -277,15 +277,13 @@ static bool cmd = false;
 static int getMouseX(NSEvent *event) {
 	// TODO (DK) map [theEvent window] to window id instead of 0
 	NSWindow *window = [[NSApplication sharedApplication] mainWindow];
-	float scale = [window backingScaleFactor];
-	return (int)([event locationInWindow].x * scale);
+	return (int)([event locationInWindow].x);
 }
 
 static int getMouseY(NSEvent *event) {
 	// TODO (DK) map [theEvent window] to window id instead of 0
 	NSWindow *window = [[NSApplication sharedApplication] mainWindow];
-	float scale = [window backingScaleFactor];
-	return (int)(kinc_height() - [event locationInWindow].y * scale);
+	return (int)(kinc_height() - [event locationInWindow].y);
 }
 
 static bool controlKeyMouseButton = false;

--- a/Backends/System/macOS/Sources/kinc/backend/system.m.h
+++ b/Backends/System/macOS/Sources/kinc/backend/system.m.h
@@ -100,12 +100,12 @@ void swapBuffersMac(int windowId) {
 static int createWindow(kinc_window_options_t *options) {
 	int width = options->width;
 	int height = options->height;
-	int styleMask = NSTitledWindowMask | NSClosableWindowMask;
+	int styleMask = NSWindowStyleMaskTitled | NSWindowStyleMaskClosable;
 	if ((options->window_features & KINC_WINDOW_FEATURE_RESIZEABLE) || (options->window_features & KINC_WINDOW_FEATURE_MAXIMIZABLE)) {
-		styleMask |= NSResizableWindowMask;
+		styleMask |= NSWindowStyleMaskResizable;
 	}
 	if (options->window_features & KINC_WINDOW_FEATURE_MINIMIZABLE) {
-		styleMask |= NSMiniaturizableWindowMask;
+		styleMask |= NSWindowStyleMaskMiniaturizable;
 	}
 
 	view = [[BasicOpenGLView alloc] initWithFrame:NSMakeRect(0, 0, width, height)];

--- a/Backends/System/macOS/Sources/kinc/backend/system.m.h
+++ b/Backends/System/macOS/Sources/kinc/backend/system.m.h
@@ -98,8 +98,8 @@ void swapBuffersMac(int windowId) {
 }
 
 static int createWindow(kinc_window_options_t *options) {
-	int width = options->width / [[NSScreen mainScreen] backingScaleFactor];
-	int height = options->height / [[NSScreen mainScreen] backingScaleFactor];
+	int width = options->width;
+	int height = options->height;
 	int styleMask = NSTitledWindowMask | NSClosableWindowMask;
 	if ((options->window_features & KINC_WINDOW_FEATURE_RESIZEABLE) || (options->window_features & KINC_WINDOW_FEATURE_MAXIMIZABLE)) {
 		styleMask |= NSResizableWindowMask;
@@ -213,14 +213,12 @@ int kinc_init(const char *name, int width, int height, kinc_window_options_t *wi
 
 int kinc_window_width(int window_index) {
 	NSWindow *window = windows[window_index].handle;
-	float scale = [window backingScaleFactor];
-	return [[window contentView] frame].size.width * scale;
+	return [[window contentView] frame].size.width;
 }
 
 int kinc_window_height(int window_index) {
 	NSWindow *window = windows[window_index].handle;
-	float scale = [window backingScaleFactor];
-	return [[window contentView] frame].size.height * scale;
+	return [[window contentView] frame].size.height;
 }
 
 NSWindow *kinc_get_mac_window_handle(int window_index) {


### PR DESCRIPTION
Hi ;)

Without this fix, Kha (and so Kinc) creates an incorrectly sized window (half of expected) on the retina display, so we probably should not divide the window `width` and `height` by `backingScaleFactor` whose value is `2` on the retina. 

With this fix it works as expected (at least on my project). But please, review it with attention, maybe I'm not seeing the whole picture.