### PR TITLE
[Windows] Make "borderless" and "on top" window styles function as expected

### DIFF
--- a/Backends/System/Windows/Sources/kinc/backend/window.c.h
+++ b/Backends/System/Windows/Sources/kinc/backend/window.c.h
@@ -316,6 +316,10 @@ void kinc_window_change_features(int window_index, int features) {
 	win->features = features;
 	SetWindowLong(win->handle, GWL_STYLE, getStyle(features));
 	SetWindowLong(win->handle, GWL_EXSTYLE, getExStyle(features));
+
+	HWND on_top = (features & KINC_WINDOW_FEATURE_ON_TOP) ? HWND_TOPMOST : HWND_NOTOPMOST;
+	SetWindowPos(win->handle, on_top, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_FRAMECHANGED);
+
 	kinc_window_show(window_index);
 }
 

--- a/Backends/System/Windows/Sources/kinc/backend/window.c.h
+++ b/Backends/System/Windows/Sources/kinc/backend/window.c.h
@@ -83,9 +83,9 @@ static void RegisterWindowClass(HINSTANCE hInstance, const wchar_t *className) {
 }
 
 static DWORD getStyle(int features) {
-	DWORD style = WS_CLIPSIBLINGS | WS_CLIPCHILDREN;
+	DWORD style = WS_CLIPSIBLINGS | WS_CLIPCHILDREN | WS_POPUP;
 
-	if (features & KINC_WINDOW_FEATURE_RESIZEABLE) {
+	if ((features & KINC_WINDOW_FEATURE_RESIZEABLE) && ((features & KINC_WINDOW_FEATURE_BORDERLESS) == 0)) {
 		style |= WS_SIZEBOX;
 	}
 
@@ -101,10 +101,6 @@ static DWORD getStyle(int features) {
 		style |= WS_CAPTION | WS_SYSMENU;
 	}
 
-	if (features & KINC_WINDOW_FEATURE_ON_TOP) {
-		style |= WS_POPUP;
-	}
-
 	return style;
 }
 
@@ -113,6 +109,10 @@ static DWORD getExStyle(int features) {
 
 	if ((features & KINC_WINDOW_FEATURE_BORDERLESS) == 0) {
 		exStyle |= WS_EX_WINDOWEDGE;
+	}
+
+	if (features & KINC_WINDOW_FEATURE_ON_TOP) {
+		exStyle |= WS_EX_TOPMOST;
 	}
 
 	return exStyle;


### PR DESCRIPTION
Previously, the borderless window mode was a bit janky and the on top window mode didn't function at all. This fix patches a couple of related problems up:

* Borderless window now works at window creation (WS_POPUP enables this)
* The borderless flag now supersedes the resizable flag (previously, both flags present would force the border to appear anyway). IMO borderless is the more "severe" setting so this seems right to me, although this does disable resizing with both flags enabled.
* The on top flag actually functions now. It's special cased because despite a dedicated WS_EX_* flag that works at window creation, SetWindowLong ignores it (I checked, doesn't work) and it must be updated with SetWindowPos.
* Fixed kinc_window_change_features not reliably working anyway because [changes to the window frame require a call to SetWindowPos.](https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-setwindowlonga#remarks)

Notes:
* Borderless mode previously wouldn't work at startup but worked with a call to kinc_window_change_features even without WS_POPUP anywhere and without a SetWindowPos call. I really wasn't able to figure out why this was the case.