### PR TITLE
Prevent D3D12 crash if no debug layer support

### DIFF
--- a/Backends/Graphics5/Direct3D12/Sources/kinc/backend/graphics5/Direct3D12.c.h
+++ b/Backends/Graphics5/Direct3D12/Sources/kinc/backend/graphics5/Direct3D12.c.h
@@ -437,10 +437,11 @@ void kinc_g5_internal_init() {
 #ifdef KORE_WINDOWS
 #ifdef _DEBUG
 	ID3D12Debug *debugController = NULL;
-	D3D12GetDebugInterface(IID_PPV_ARGS(&debugController));
-	debugController->EnableDebugLayer();
+	if (D3D12GetDebugInterface(IID_PPV_ARGS(&debugController)) == S_OK) {
+		debugController->EnableDebugLayer();
+	}
 #endif
-	D3D12CreateDevice(NULL, D3D_FEATURE_LEVEL_11_0, IID_PPV_ARGS(&device));
+	kinc_microsoft_affirm(D3D12CreateDevice(NULL, D3D_FEATURE_LEVEL_11_0, IID_PPV_ARGS(&device)));
 
 	createRootSignature();
 	createComputeRootSignature();


### PR DESCRIPTION
On PCs without debug layer support `D3D12GetDebugInterface` fails and leaves `debugController` a null-pointer, causing crashes. In this case simply avoiding attempting to enable debug layers seems simplest

Also adds a check that device creation succeeds to improve error messages