### PR TITLE
[Vulkan] Fix handling of render target depth

### DIFF
--- a/Backends/Graphics5/Vulkan/Sources/kinc/backend/graphics5/Vulkan.c.h
+++ b/Backends/Graphics5/Vulkan/Sources/kinc/backend/graphics5/Vulkan.c.h
@@ -525,26 +525,9 @@ void create_render_target_render_pass(struct vk_window *window) {
 	attachments[0].finalLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
 	attachments[0].flags = 0;
 
-	// TODO
-	/*if (depthBufferBits > 0) {
-	    attachments[1].format = VK_FORMAT_D16_UNORM;
-	    attachments[1].samples = VK_SAMPLE_COUNT_1_BIT;
-	    attachments[1].loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
-	    attachments[1].storeOp = VK_ATTACHMENT_STORE_OP_STORE;
-	    attachments[1].stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
-	    attachments[1].stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
-	    attachments[1].initialLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
-	    attachments[1].finalLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
-	    attachments[1].flags = 0;
-	}*/
-
 	VkAttachmentReference color_reference = {0};
 	color_reference.attachment = 0;
 	color_reference.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
-
-	VkAttachmentReference depth_reference = {0};
-	depth_reference.attachment = 1;
-	depth_reference.layout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
 
 	VkSubpassDescription subpass = {0};
 	subpass.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
@@ -554,7 +537,7 @@ void create_render_target_render_pass(struct vk_window *window) {
 	subpass.colorAttachmentCount = 1;
 	subpass.pColorAttachments = &color_reference;
 	subpass.pResolveAttachments = NULL;
-	subpass.pDepthStencilAttachment = /*depthBufferBits > 0 ? &depth_reference :*/ NULL; // TODO
+	subpass.pDepthStencilAttachment = NULL;
 	subpass.preserveAttachmentCount = 0;
 	subpass.pPreserveAttachments = NULL;
 
@@ -581,7 +564,7 @@ void create_render_target_render_pass(struct vk_window *window) {
 	VkRenderPassCreateInfo rp_info = {0};
 	rp_info.sType = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO;
 	rp_info.pNext = NULL;
-	rp_info.attachmentCount = /*depthBufferBits > 0 ? 2 :*/ 1; // TODO
+	rp_info.attachmentCount = 1;
 	rp_info.pAttachments = attachments;
 	rp_info.subpassCount = 1;
 	rp_info.pSubpasses = &subpass;
@@ -589,6 +572,27 @@ void create_render_target_render_pass(struct vk_window *window) {
 	rp_info.pDependencies = dependencies;
 
 	VkResult err = vkCreateRenderPass(vk_ctx.device, &rp_info, NULL, &window->rendertarget_render_pass);
+	assert(!err);
+
+	// depthBufferBits > 0
+	attachments[1].format = VK_FORMAT_D16_UNORM;
+	attachments[1].samples = VK_SAMPLE_COUNT_1_BIT;
+	attachments[1].loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+	attachments[1].storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+	attachments[1].stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+	attachments[1].stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+	attachments[1].initialLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
+	attachments[1].finalLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
+	attachments[1].flags = 0;
+
+	VkAttachmentReference depth_reference = {0};
+	depth_reference.attachment = 1;
+	depth_reference.layout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
+	subpass.pDepthStencilAttachment = &depth_reference;
+
+	rp_info.attachmentCount = 2;
+
+	err = vkCreateRenderPass(vk_ctx.device, &rp_info, NULL, &window->rendertarget_render_pass_with_depth);
 	assert(!err);
 }
 

--- a/Backends/Graphics5/Vulkan/Sources/kinc/backend/graphics5/commandlist.c.h
+++ b/Backends/Graphics5/Vulkan/Sources/kinc/backend/graphics5/commandlist.c.h
@@ -568,7 +568,12 @@ void kinc_g5_command_list_set_render_targets(kinc_g5_command_list_t *list, struc
 	rp_begin.pClearValues = clear_values;
 
 	if (count == 1) {
-		rp_begin.renderPass = vk_ctx.windows[vk_ctx.current_window].rendertarget_render_pass;
+		if (targets[0]->impl.depthBufferBits > 0) {
+			rp_begin.renderPass = vk_ctx.windows[vk_ctx.current_window].rendertarget_render_pass_with_depth;
+		}
+		else {
+			rp_begin.renderPass = vk_ctx.windows[vk_ctx.current_window].rendertarget_render_pass;
+		}
 		rp_begin.framebuffer = targets[0]->impl.framebuffer;
 	}
 	else {

--- a/Backends/Graphics5/Vulkan/Sources/kinc/backend/graphics5/pipeline.c.h
+++ b/Backends/Graphics5/Vulkan/Sources/kinc/backend/graphics5/pipeline.c.h
@@ -672,7 +672,12 @@ void kinc_g5_pipeline_compile(kinc_g5_pipeline_t *pipeline) {
 	err = vkCreateGraphicsPipelines(vk_ctx.device, VK_NULL_HANDLE, 1, &pipeline_info, NULL, &pipeline->impl.framebuffer_pipeline);
 	assert(!err);
 
-	pipeline_info.renderPass = vk_ctx.windows[vk_ctx.current_window].rendertarget_render_pass;
+	if (pipeline->depthAttachmentBits > 0) {
+		pipeline_info.renderPass = vk_ctx.windows[vk_ctx.current_window].rendertarget_render_pass_with_depth;
+	}
+	else {
+		pipeline_info.renderPass = vk_ctx.windows[vk_ctx.current_window].rendertarget_render_pass;
+	}
 
 	err = vkCreateGraphicsPipelines(vk_ctx.device, VK_NULL_HANDLE, 1, &pipeline_info, NULL, &pipeline->impl.rendertarget_pipeline);
 	assert(!err);

--- a/Backends/Graphics5/Vulkan/Sources/kinc/backend/graphics5/rendertarget.c.h
+++ b/Backends/Graphics5/Vulkan/Sources/kinc/backend/graphics5/rendertarget.c.h
@@ -241,8 +241,15 @@ static void render_target_init(kinc_g5_render_target_t *target, int width, int h
 		VkFramebufferCreateInfo fbufCreateInfo = {0};
 		fbufCreateInfo.sType = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO;
 		fbufCreateInfo.pNext = NULL;
-		fbufCreateInfo.renderPass = framebuffer_index < 0 ? vk_ctx.windows[vk_ctx.current_window].rendertarget_render_pass
-		                                                  : vk_ctx.windows[vk_ctx.current_window].framebuffer_render_pass;
+		if (framebuffer_index >= 0) {
+			fbufCreateInfo.renderPass = vk_ctx.windows[vk_ctx.current_window].framebuffer_render_pass;
+		}
+		else if (depthBufferBits > 0) {
+			fbufCreateInfo.renderPass = vk_ctx.windows[vk_ctx.current_window].rendertarget_render_pass_with_depth;
+		}
+		else {
+			fbufCreateInfo.renderPass = vk_ctx.windows[vk_ctx.current_window].rendertarget_render_pass;
+		}
 		fbufCreateInfo.attachmentCount = depthBufferBits > 0 ? 2 : 1;
 		fbufCreateInfo.pAttachments = attachments;
 		fbufCreateInfo.width = width;
@@ -294,86 +301,6 @@ void kinc_g5_render_target_set_depth_stencil_from(kinc_g5_render_target_t *targe
 	target->impl.depthBufferBits = source->impl.depthBufferBits;
 
 	// vkDestroyFramebuffer(vk_ctx.device, target->impl.framebuffer, nullptr);
-	// vkDestroyRenderPass(vk_ctx.device, target->impl.renderPass, nullptr);
-
-	{
-		VkAttachmentDescription attachments[2];
-		attachments[0].format = target->impl.format;
-		attachments[0].samples = VK_SAMPLE_COUNT_1_BIT;
-		attachments[0].loadOp = VK_ATTACHMENT_LOAD_OP_LOAD;
-		attachments[0].storeOp = VK_ATTACHMENT_STORE_OP_STORE;
-		attachments[0].stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
-		attachments[0].stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
-		attachments[0].initialLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
-		attachments[0].finalLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
-		attachments[0].flags = 0;
-
-		if (target->impl.depthBufferBits > 0) {
-			attachments[1].format = VK_FORMAT_D16_UNORM;
-			attachments[1].samples = VK_SAMPLE_COUNT_1_BIT;
-			attachments[1].loadOp = VK_ATTACHMENT_LOAD_OP_LOAD;
-			attachments[1].storeOp = VK_ATTACHMENT_STORE_OP_STORE;
-			attachments[1].stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
-			attachments[1].stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
-			attachments[1].initialLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
-			attachments[1].finalLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
-			attachments[1].flags = 0;
-		}
-
-		VkAttachmentReference color_reference = {0};
-		color_reference.attachment = 0;
-		color_reference.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
-
-		VkAttachmentReference depth_reference = {0};
-		depth_reference.attachment = 1;
-		depth_reference.layout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
-
-		VkSubpassDescription subpass = {0};
-		subpass.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
-		subpass.flags = 0;
-		subpass.inputAttachmentCount = 0;
-		subpass.pInputAttachments = NULL;
-		subpass.colorAttachmentCount = 1;
-		subpass.pColorAttachments = &color_reference;
-		subpass.pResolveAttachments = NULL;
-		subpass.pDepthStencilAttachment = target->impl.depthBufferBits > 0 ? &depth_reference : NULL;
-		subpass.preserveAttachmentCount = 0;
-		subpass.pPreserveAttachments = NULL;
-
-		VkSubpassDependency dependencies[2];
-		memset(&dependencies, 0, sizeof(dependencies));
-
-		// TODO: depth-stencil-something
-		dependencies[0].srcSubpass = VK_SUBPASS_EXTERNAL;
-		dependencies[0].dstSubpass = 0;
-		dependencies[0].srcStageMask = VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
-		dependencies[0].dstStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
-		dependencies[0].srcAccessMask = VK_ACCESS_SHADER_READ_BIT;
-		dependencies[0].dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
-		dependencies[0].dependencyFlags = VK_DEPENDENCY_BY_REGION_BIT;
-
-		dependencies[1].srcSubpass = 0;
-		dependencies[1].dstSubpass = VK_SUBPASS_EXTERNAL;
-		dependencies[1].srcStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
-		dependencies[1].dstStageMask = VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
-		dependencies[1].srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
-		dependencies[1].dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
-		dependencies[1].dependencyFlags = VK_DEPENDENCY_BY_REGION_BIT;
-
-		VkRenderPassCreateInfo rp_info = {0};
-		rp_info.sType = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO;
-		rp_info.pNext = NULL;
-		rp_info.attachmentCount = target->impl.depthBufferBits > 0 ? 2 : 1;
-		rp_info.pAttachments = attachments;
-		rp_info.subpassCount = 1;
-		rp_info.pSubpasses = &subpass;
-		rp_info.dependencyCount = 2;
-		rp_info.pDependencies = dependencies;
-
-		// TODO
-		// VkResult err = vkCreateRenderPass(vk_ctx.device, &rp_info, NULL, &target->impl.renderPass);
-		// assert(!err);
-	}
 
 	{
 		VkImageView attachments[2];
@@ -386,7 +313,12 @@ void kinc_g5_render_target_set_depth_stencil_from(kinc_g5_render_target_t *targe
 		VkFramebufferCreateInfo fbufCreateInfo = {0};
 		fbufCreateInfo.sType = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO;
 		fbufCreateInfo.pNext = NULL;
-		fbufCreateInfo.renderPass = VK_NULL_HANDLE; // target->impl.renderPass; // TODO
+		if (target->impl.depthBufferBits > 0) {
+			fbufCreateInfo.renderPass = vk_ctx.windows[vk_ctx.current_window].rendertarget_render_pass_with_depth;
+		}
+		else {
+			fbufCreateInfo.renderPass = vk_ctx.windows[vk_ctx.current_window].rendertarget_render_pass;
+		}
 		fbufCreateInfo.attachmentCount = target->impl.depthBufferBits > 0 ? 2 : 1;
 		fbufCreateInfo.pAttachments = attachments;
 		fbufCreateInfo.width = target->width;

--- a/Backends/Graphics5/Vulkan/Sources/kinc/backend/graphics5/vulkan.h
+++ b/Backends/Graphics5/Vulkan/Sources/kinc/backend/graphics5/vulkan.h
@@ -52,6 +52,7 @@ struct vk_window {
 
 	VkRenderPass framebuffer_render_pass;
 	VkRenderPass rendertarget_render_pass;
+	VkRenderPass rendertarget_render_pass_with_depth;
 
 	struct vk_depth depth;
 };


### PR DESCRIPTION
This restores the functionality of using render targets with depth buffers in Vulkan.

Using multiple render targets is still broken, because the shared render pass is set to only 1 color attachment (and only `VK_FORMAT_B8G8R8A8_UNORM` format) .

https://github.com/Kode/Kinc/blob/main/Backends/Graphics5/Vulkan/Sources/kinc/backend/graphics5/vulkan.h#L54

Should more render pass combinations be created in advance or on demand? 