### PR TITLE
Fix potential crash when resizing windows when using D3D12 graphics backend

### DIFF
--- a/Backends/Graphics4/G4onG5/Sources/kinc/backend/graphics4/G4.c.h
+++ b/Backends/Graphics4/G4onG5/Sources/kinc/backend/graphics4/G4.c.h
@@ -300,7 +300,6 @@ void kinc_g4_begin(int window) {
 		for (int i = 0; i < bufferCount; ++i) {
 			kinc_g5_render_target_destroy(&windows[current_window].framebuffers[i]);
 		}
-		windows[current_window].currentBuffer = 0;
 	}
 
 	kinc_g5_begin(&windows[current_window].framebuffers[windows[current_window].currentBuffer], window);


### PR DESCRIPTION
Fixed the crash described in  https://github.com/Kode/Kinc/issues/822

The issues basically boils down to this:
When the user resized the window at exactly the wrong time, the current commandbuffer that the GPU's processing is the commandbuffer that writes to the backbuffer at index 0.

When, at that time, the resize happens, the code sets `windows[current_window].currentBuffer = 0` inside `kinc_g4_begin()`. this results in the commandqueue trying to write to the wrong backbuffer for the next frame (basically it would then try to write to backbuffer 0 again even though it expects to write to backbuffer 1 - if that makes sense).

This requires further testing with an actual workload as I only tested this with the input test.

My testcode for this basically looked like this:
```c
static void update(void *data) {
	static int timer = 0;
	++timer;

	if ( timer == 3 ) {
		ShowWindow(hwnd, SW_MINIMIZE); //This was implemented inside Backends\System\Windows\Sources\kinc\backend\window.c.h
	}

	if (timer == 6) {
		ShowWindow(hwnd, SW_SHOWNORMAL);  //This was implemented inside Backends\System\Windows\Sources\kinc\backend\window.c.h
		timer = 0;
	}

	kinc_g4_begin(0);
	kinc_g4_clear(KINC_G4_CLEAR_COLOR, 0, 0.0f, 0);
	kinc_g4_end(0);
	kinc_g4_swap_buffers();
}

int kickstart(int argc, char **argv) {
        kinc_init("Shader", 1024, 768, NULL, NULL);
	kinc_set_update_callback(update, NULL);
	kinc_start();

        return 0;
}
```

Before my change the crash would happen at some point preceeded by logspam that read like this:
```
D3D12 ERROR: ID3D12CommandQueue::ExecuteCommandLists: A command list, which writes to a swapchain back buffer, may only be executed when that back buffer is the back buffer that will be presented during the next call to Present*. Such a back buffer is also referred to as the "current back buffer". Swap Chain: 0x000002793F1D5D40:'Unnamed Object' - Current Back Buffer Buffer: 0x000002793F22F1B0:'Backbuffer (index 0)' - Attempted Write Buffer: 0x000002793F230070:'Backbuffer (index 1)' [ STATE_SETTING ERROR #907: EXECUTECOMMANDLISTS_WRONGSWAPCHAINBUFFERREFERENCE]
```