### PR TITLE
Minor keyboard input fixes

### DIFF
--- a/Backends/System/Windows/Sources/kinc/backend/system.c.h
+++ b/Backends/System/Windows/Sources/kinc/backend/system.c.h
@@ -655,18 +655,7 @@ LRESULT WINAPI KoreWindowsMessageProcedure(HWND hWnd, UINT msg, WPARAM wParam, L
 		break;
 	case WM_CHAR:
 		switch (wParam) {
-		case 0x08: // backspace
-			break;
-		case 0x0A: // linefeed
-			kinc_internal_keyboard_trigger_key_press(L'\n');
-			break;
 		case 0x1B: // escape
-			break;
-		case 0x09: // tab
-			kinc_internal_keyboard_trigger_key_press(L'\t');
-			break;
-		case 0x0D: // carriage return
-			kinc_internal_keyboard_trigger_key_press(L'\r');
 			break;
 		default:
 			kinc_internal_keyboard_trigger_key_press((unsigned)wParam);

--- a/Backends/System/Windows/Sources/kinc/backend/system.c.h
+++ b/Backends/System/Windows/Sources/kinc/backend/system.c.h
@@ -635,9 +635,8 @@ LRESULT WINAPI KoreWindowsMessageProcedure(HWND hWnd, UINT msg, WPARAM wParam, L
 				}
 #endif
 			}
-
-			kinc_internal_keyboard_trigger_key_down(keyTranslated[wParam]);
 		}
+		kinc_internal_keyboard_trigger_key_down(keyTranslated[wParam]);
 		break;
 	case WM_KEYUP:
 	case WM_SYSKEYUP:

--- a/Backends/System/macOS/Sources/kinc/backend/BasicOpenGLView.m.h
+++ b/Backends/System/macOS/Sources/kinc/backend/BasicOpenGLView.m.h
@@ -144,12 +144,15 @@ static bool cmd = false;
 		case NSNewlineCharacter:
 		case NSCarriageReturnCharacter:
 			kinc_internal_keyboard_trigger_key_down(KINC_KEY_RETURN);
+			kinc_internal_keyboard_trigger_key_press('\n');
 			break;
 		case 0x7f:
 			kinc_internal_keyboard_trigger_key_down(KINC_KEY_BACKSPACE);
+			kinc_internal_keyboard_trigger_key_press('\x08');
 			break;
 		case 9:
 			kinc_internal_keyboard_trigger_key_down(KINC_KEY_TAB);
+			kinc_internal_keyboard_trigger_key_press('\t');
 			break;
 		default:
 			if (ch == 'x' && [theEvent modifierFlags] & NSCommandKeyMask) {


### PR DESCRIPTION
This PR tries to improve consistency across desktop platforms:
 - autorepeated keys on Windows (already works on Linux and OS X).
 - backspace triggers `kinc_internal_keyboard_trigger_key_press()` on Windows.
 - backspace, return, and tab trigger `kinc_internal_keyboard_trigger_key_press()` on OS X.