### PR TITLE
prevent crash in kinc_g4_set_matrix4()

### DIFF
--- a/Backends/Graphics5/Vulkan/Sources/kinc/backend/graphics5/pipeline.c.h
+++ b/Backends/Graphics5/Vulkan/Sources/kinc/backend/graphics5/pipeline.c.h
@@ -274,6 +274,7 @@ kinc_g5_constant_location_t kinc_g5_pipeline_get_constant_location(kinc_g5_pipel
 	kinc_g5_constant_location_t location;
 	location.impl.vertexOffset = -1;
 	location.impl.fragmentOffset = -1;
+	location.impl.computeOffset = -1;
 	if (has_number(pipeline->impl.vertexOffsets, name)) {
 		location.impl.vertexOffset = find_number(pipeline->impl.vertexOffsets, name);
 	}


### PR DESCRIPTION
Due to the uninitialized variable, any of the kinc_g4_set_xxx() would crash later

https://github.com/Kode/Kinc/blob/83af1a7421465c4d904ba31c8ba6433e2c35d65f/Backends/Graphics4/G4onG5/Sources/kinc/backend/graphics4/G4.c.h#L443-L450
