### PR TITLE
Fix obsolete C++ syntax in DirectShow library

### DIFF
--- a/Backends/System/Windows/Libraries/DirectShow/BaseClasses/amvideo.cpp
+++ b/Backends/System/Windows/Libraries/DirectShow/BaseClasses/amvideo.cpp
@@ -23,8 +23,8 @@ const DWORD bits888[] = {0xFF0000,0x00FF00,0x0000FF};
 const struct {
     const GUID *pSubtype;
     WORD BitCount;
-    CHAR *pName;
-    WCHAR *wszName;
+    const CHAR *pName;
+    const WCHAR *wszName;
 } BitCountMap[] =  { &MEDIASUBTYPE_RGB1,        1,   "RGB Monochrome",     L"RGB Monochrome",   
                      &MEDIASUBTYPE_RGB4,        4,   "RGB VGA",            L"RGB VGA",          
                      &MEDIASUBTYPE_RGB8,        8,   "RGB 8",              L"RGB 8",            
@@ -173,12 +173,12 @@ int LocateSubtype(const GUID *pSubtype)
 
 
 
-STDAPI_(WCHAR *) GetSubtypeNameW(const GUID *pSubtype)
+STDAPI_(const WCHAR *) GetSubtypeNameW(const GUID *pSubtype)
 {
     return BitCountMap[LocateSubtype(pSubtype)].wszName;
 }
 
-STDAPI_(CHAR *) GetSubtypeNameA(const GUID *pSubtype)
+STDAPI_(const CHAR *) GetSubtypeNameA(const GUID *pSubtype)
 {
     return BitCountMap[LocateSubtype(pSubtype)].pName;
 }
@@ -190,7 +190,7 @@ STDAPI_(CHAR *) GetSubtypeNameA(const GUID *pSubtype)
 
 // this is here for people that linked to it directly; most people
 // would use the header file that picks the A or W version.
-STDAPI_(CHAR *) GetSubtypeName(const GUID *pSubtype)
+STDAPI_(const CHAR *) GetSubtypeName(const GUID *pSubtype)
 {
     return GetSubtypeNameA(pSubtype);
 }

--- a/Backends/System/Windows/Libraries/DirectShow/BaseClasses/transip.h
+++ b/Backends/System/Windows/Libraries/DirectShow/BaseClasses/transip.h
@@ -211,7 +211,7 @@ public:
 
 protected:
 
-    __out_opt IMediaSample * CTransInPlaceFilter::Copy(IMediaSample *pSource);
+    __out_opt IMediaSample * Copy(IMediaSample *pSource);
 
 #ifdef PERF
     int m_idTransInPlace;                 // performance measuring id

--- a/Backends/System/Windows/Libraries/DirectShow/BaseClasses/videoctl.cpp
+++ b/Backends/System/Windows/Libraries/DirectShow/BaseClasses/videoctl.cpp
@@ -15,7 +15,7 @@
 // buffer in the property page class and use it for all string loading. It
 // cannot be static as multiple property pages may be active simultaneously
 
-LPTSTR WINAPI StringFromResource(__out_ecount(STR_MAX_LENGTH) LPTSTR pBuffer, int iResourceID)
+LPCTSTR WINAPI StringFromResource(__out_ecount(STR_MAX_LENGTH) LPTSTR pBuffer, int iResourceID)
 {
     if (LoadString(g_hInst,iResourceID,pBuffer,STR_MAX_LENGTH) == 0) {
         return TEXT("");

--- a/Backends/System/Windows/Libraries/DirectShow/BaseClasses/videoctl.h
+++ b/Backends/System/Windows/Libraries/DirectShow/BaseClasses/videoctl.h
@@ -51,7 +51,7 @@ public:
         CUnknown(pName,pUnk),
         m_pDirectDraw(NULL) { };
 
-    virtual CAggDirectDraw::~CAggDirectDraw() { };
+    virtual ~CAggDirectDraw() { };
 
     // Set the object we should be aggregating
     void SetDirectDraw(__inout LPDIRECTDRAW pDirectDraw) {

--- a/Backends/System/Windows/Libraries/DirectShow/BaseClasses/videoctl.h
+++ b/Backends/System/Windows/Libraries/DirectShow/BaseClasses/videoctl.h
@@ -17,7 +17,7 @@
 // resource ID of a dialog box and returns the size of it in screen pixels
 
 #define STR_MAX_LENGTH 256
-LPTSTR WINAPI StringFromResource(__out_ecount(STR_MAX_LENGTH) LPTSTR pBuffer, int iResourceID);
+LPCTSTR WINAPI StringFromResource(__out_ecount(STR_MAX_LENGTH) LPTSTR pBuffer, int iResourceID);
 
 #ifdef UNICODE
 #define WideStringFromResource StringFromResource

--- a/Backends/System/Windows/Libraries/DirectShow/BaseClasses/wxdebug.cpp
+++ b/Backends/System/Windows/Libraries/DirectShow/BaseClasses/wxdebug.cpp
@@ -86,7 +86,7 @@ bool g_fAutoRefreshLevels = false;
 
 LPCTSTR pBaseKey = TEXT("SOFTWARE\\Microsoft\\DirectShow\\Debug");
 LPCTSTR pGlobalKey = TEXT("GLOBAL");
-static CHAR *pUnknownName = "UNKNOWN";
+static const CHAR *pUnknownName = "UNKNOWN";
 
 LPCTSTR TimeoutName = TEXT("TIMEOUT");
 
@@ -1086,7 +1086,7 @@ void WINAPI DbgSetWaitTimeout(DWORD dwTimeout)
     CGuidNameList GuidNames;
     int g_cGuidNames = sizeof(g_GuidNames) / sizeof(g_GuidNames[0]);
 
-    char *CGuidNameList::operator [] (const GUID &guid)
+    const char *CGuidNameList::operator [] (const GUID &guid)
     {
         for (int i = 0; i < g_cGuidNames; i++) {
             if (g_GuidNames[i].guid == guid) {

--- a/Backends/System/Windows/Libraries/DirectShow/BaseClasses/wxdebug.h
+++ b/Backends/System/Windows/Libraries/DirectShow/BaseClasses/wxdebug.h
@@ -254,13 +254,13 @@ typedef struct tag_ObjectDesc {
     //  Returns the name defined in uuids.h as a string
 
     typedef struct {
-        CHAR   *szName;
+        const CHAR   *szName;
         GUID    guid;
     } GUID_STRING_ENTRY;
 
     class CGuidNameList {
     public:
-        CHAR *operator [] (const GUID& guid);
+        const CHAR *operator [] (const GUID& guid);
     };
 
     extern CGuidNameList GuidNames;

--- a/Backends/System/Windows/Libraries/DirectShow/BaseClasses/wxutil.h
+++ b/Backends/System/Windows/Libraries/DirectShow/BaseClasses/wxutil.h
@@ -408,8 +408,8 @@ STDAPI_(WORD) GetBitCount(const GUID *pSubtype);
 //
 // STDAPI_(/* T */ CHAR *) GetSubtypeName(const GUID *pSubtype);
 
-STDAPI_(CHAR *) GetSubtypeNameA(const GUID *pSubtype);
-STDAPI_(WCHAR *) GetSubtypeNameW(const GUID *pSubtype);
+STDAPI_(const CHAR *) GetSubtypeNameA(const GUID *pSubtype);
+STDAPI_(const WCHAR *) GetSubtypeNameW(const GUID *pSubtype);
 
 #ifdef UNICODE
 #define GetSubtypeName GetSubtypeNameW


### PR DESCRIPTION
Compiling using a recent version of the C++ standard (`/std:c++latest`) will fail to build these two files:

    2>kinc\Backends\System\Windows\Libraries\DirectShow\BaseClasses\transip.h(214,55): error C4596: 'Copy': illegal qualified name in member declaration
    2>(compiling source file '../../../kinc/Backends/System/Windows/Sources/kinc/backend/windowscppunit.cpp')
    2>kinc\Backends\System\Windows\Libraries\DirectShow\BaseClasses\videoctl.h(54,30): error C2385: ambiguous access of '{dtor}'
    2>(compiling source file '../../../kinc/Backends/System/Windows/Sources/kinc/backend/windowscppunit.cpp')
    2>kinc\Backends\System\Windows\Libraries\DirectShow\BaseClasses\videoctl.h(54,30):
    2>could be the '{dtor}' in base 'IDirectDraw'
    2>kinc\Backends\System\Windows\Libraries\DirectShow\BaseClasses\videoctl.h(54,30):
    2>or could be the '{dtor}' in base 'CUnknown'
    2>kinc\Backends\System\Windows\Libraries\DirectShow\BaseClasses\videoctl.h(54,30): error C3254: 'CAggDirectDraw': class contains explicit override '{dtor}' but does not derive from an interface that contains the function declaration
    2>(compiling source file '../../../kinc/Backends/System/Windows/Sources/kinc/backend/windowscppunit.cpp')
    2>kinc\Backends\System\Windows\Libraries\DirectShow\BaseClasses\videoctl.h(54,30): error C3244: 'CAggDirectDraw::~CAggDirectDraw(void)': this method was introduced by '<Unknown>' not by 'IDirectDraw'
    2>(compiling source file '../../../kinc/Backends/System/Windows/Sources/kinc/backend/windowscppunit.cpp')