### PR TITLE
Fix Windows MultiByte builds

### DIFF
--- a/Backends/System/Windows/Libraries/DirectShow/BaseClasses/videoctl.cpp
+++ b/Backends/System/Windows/Libraries/DirectShow/BaseClasses/videoctl.cpp
@@ -24,7 +24,7 @@ LPTSTR WINAPI StringFromResource(__out_ecount(STR_MAX_LENGTH) LPTSTR pBuffer, in
 }
 
 #ifdef UNICODE
-LPSTR WINAPI StringFromResource(__out_ecount(STR_MAX_LENGTH) LPSTR pBuffer, int iResourceID)
+LPCSTR WINAPI StringFromResource(__out_ecount(STR_MAX_LENGTH) LPSTR pBuffer, int iResourceID)
 {
     if (LoadStringA(g_hInst,iResourceID,pBuffer,STR_MAX_LENGTH) == 0) {
         return "";

--- a/Backends/System/Windows/Libraries/DirectShow/BaseClasses/videoctl.h
+++ b/Backends/System/Windows/Libraries/DirectShow/BaseClasses/videoctl.h
@@ -21,7 +21,7 @@ LPTSTR WINAPI StringFromResource(__out_ecount(STR_MAX_LENGTH) LPTSTR pBuffer, in
 
 #ifdef UNICODE
 #define WideStringFromResource StringFromResource
-LPSTR WINAPI StringFromResource(__out_ecount(STR_MAX_LENGTH) LPSTR pBuffer, int iResourceID);
+LPCSTR WINAPI StringFromResource(__out_ecount(STR_MAX_LENGTH) LPSTR pBuffer, int iResourceID);
 #else
 LPWSTR WINAPI WideStringFromResource(__out_ecount(STR_MAX_LENGTH) LPWSTR pBuffer, int iResourceID);
 #endif

--- a/Backends/System/Windows/Sources/kinc/backend/system.c.h
+++ b/Backends/System/Windows/Sources/kinc/backend/system.c.h
@@ -545,7 +545,7 @@ LRESULT WINAPI KoreWindowsMessageProcedure(HWND hWnd, UINT msg, WPARAM wParam, L
 		if (bHandled)
 			CloseTouchInputHandle((HTOUCHINPUT)lParam);
 		else
-			DefWindowProc(hWnd, WM_TOUCH, wParam, lParam);
+			DefWindowProcW(hWnd, WM_TOUCH, wParam, lParam);
 
 		InvalidateRect(hWnd, NULL, FALSE);
 	} break;
@@ -700,7 +700,7 @@ LRESULT WINAPI KoreWindowsMessageProcedure(HWND hWnd, UINT msg, WPARAM wParam, L
 		DragFinish(hDrop);
 		break;
 	}
-	return DefWindowProc(hWnd, msg, wParam, lParam);
+	return DefWindowProcW(hWnd, msg, wParam, lParam);
 }
 
 static float axes[12 * 6];
@@ -712,12 +712,12 @@ static XInputGetStateType InputGetState = NULL;
 static XInputSetStateType InputSetState = NULL;
 
 void loadXInput() {
-	HMODULE lib = LoadLibrary(L"xinput1_4.dll");
+	HMODULE lib = LoadLibraryA("xinput1_4.dll");
 	if (lib == NULL) {
-		lib = LoadLibrary(L"xinput1_3.dll");
+		lib = LoadLibraryA("xinput1_3.dll");
 	}
 	if (lib == NULL) {
-		lib = LoadLibrary(L"xinput9_1_0.dll");
+		lib = LoadLibraryA("xinput9_1_0.dll");
 	}
 
 	if (lib != NULL) {
@@ -726,8 +726,8 @@ void loadXInput() {
 	}
 }
 
-static IDirectInput8 *di_instance = NULL;
-static IDirectInputDevice8 *di_pads[KINC_DINPUT_MAX_COUNT];
+static IDirectInput8W *di_instance = NULL;
+static IDirectInputDevice8W *di_pads[KINC_DINPUT_MAX_COUNT];
 static DIJOYSTATE2 di_padState[KINC_DINPUT_MAX_COUNT];
 static DIJOYSTATE2 di_lastPadState[KINC_DINPUT_MAX_COUNT];
 static DIDEVCAPS di_deviceCaps[KINC_DINPUT_MAX_COUNT];
@@ -966,14 +966,14 @@ static BOOL CALLBACK enumerateJoysticksCallback(LPCDIDEVICEINSTANCEW ddi, LPVOID
 }
 
 static void initializeDirectInput() {
-	HINSTANCE hinstance = GetModuleHandle(NULL);
+	HINSTANCE hinstance = GetModuleHandleW(NULL);
 
 	memset(&di_pads, 0, sizeof(IDirectInputDevice8) * KINC_DINPUT_MAX_COUNT);
 	memset(&di_padState, 0, sizeof(DIJOYSTATE2) * KINC_DINPUT_MAX_COUNT);
 	memset(&di_lastPadState, 0, sizeof(DIJOYSTATE2) * KINC_DINPUT_MAX_COUNT);
 	memset(&di_deviceCaps, 0, sizeof(DIDEVCAPS) * KINC_DINPUT_MAX_COUNT);
 
-	HRESULT hr = DirectInput8Create(hinstance, DIRECTINPUT_VERSION, &IID_IDirectInput8, (void **)&di_instance, NULL);
+	HRESULT hr = DirectInput8Create(hinstance, DIRECTINPUT_VERSION, &IID_IDirectInput8W, (void **)&di_instance, NULL);
 
 	if (SUCCEEDED(hr)) {
 		hr = di_instance->lpVtbl->EnumDevices(di_instance, DI8DEVCLASS_GAMECTRL, enumerateJoysticksCallback, NULL, DIEDFL_ATTACHEDONLY);
@@ -1114,9 +1114,9 @@ const char *kinc_gamepad_product_name(int gamepad) {
 bool kinc_internal_handle_messages() {
 	MSG message;
 
-	while (PeekMessage(&message, 0, 0, 0, PM_REMOVE)) {
+	while (PeekMessageW(&message, 0, 0, 0, PM_REMOVE)) {
 		TranslateMessage(&message);
-		DispatchMessage(&message);
+		DispatchMessageW(&message);
 	}
 
 	if (InputGetState != NULL && (detectGamepad || gamepadFound)) {
@@ -1260,7 +1260,7 @@ static void findSavePath() {
 	wcscat(savePathw, name);
 	wcscat(savePathw, L"\\");
 
-	SHCreateDirectoryEx(NULL, savePathw, NULL);
+	SHCreateDirectoryExW(NULL, savePathw, NULL);
 	WideCharToMultiByte(CP_UTF8, 0, savePathw, -1, savePath, 1024, NULL, NULL);
 
 	CoTaskMemFree(path);

--- a/Backends/System/Windows/Sources/kinc/backend/window.c.h
+++ b/Backends/System/Windows/Sources/kinc/backend/window.c.h
@@ -73,13 +73,13 @@ static void RegisterWindowClass(HINSTANCE hInstance, const wchar_t *className) {
 	                  0L,
 	                  0L,
 	                  hInstance,
-	                  LoadIcon(hInstance, MAKEINTRESOURCE(107)),
+	                  LoadIconW(hInstance, MAKEINTRESOURCEW(107)),
 	                  LoadCursor(NULL, IDC_ARROW),
 	                  0,
 	                  0,
 	                  className,
 	                  0};
-	RegisterClassEx(&wc);
+	RegisterClassExW(&wc);
 }
 
 static DWORD getStyle(int features) {
@@ -185,7 +185,7 @@ static DWORD getDwExStyle(kinc_window_mode_t mode, int features) {
 
 static int createWindow(const wchar_t *title, int x, int y, int width, int height, int bpp, int frequency, int features, kinc_window_mode_t windowMode,
                         int target_display_index) {
-	HINSTANCE inst = GetModuleHandle(NULL);
+	HINSTANCE inst = GetModuleHandleW(NULL);
 
 	if (window_counter == 0) {
 		RegisterWindowClass(inst, windowClassName);
@@ -238,11 +238,11 @@ static int createWindow(const wchar_t *title, int x, int y, int width, int heigh
 		break;
 	}
 
-	HWND hwnd = CreateWindowEx(getDwExStyle(windowMode, features), windowClassName, title, getDwStyle(windowMode, features), dstx, dsty, dstw, dsth, NULL, NULL,
-	                           inst, NULL);
+	HWND hwnd = CreateWindowExW(getDwExStyle(windowMode, features), windowClassName, title, getDwStyle(windowMode, features), dstx, dsty, dstw, dsth, NULL, NULL,
+	                            inst, NULL);
 #endif
 
-	SetCursor(LoadCursor(0, IDC_ARROW));
+	SetCursor(LoadCursor(NULL, IDC_ARROW));
 	DragAcceptFiles(hwnd, true);
 
 	windows[window_counter].handle = hwnd;
@@ -314,8 +314,8 @@ void kinc_window_change_framebuffer(int window, kinc_framebuffer_options_t *fram
 void kinc_window_change_features(int window_index, int features) {
 	WindowData *win = &windows[window_index];
 	win->features = features;
-	SetWindowLong(win->handle, GWL_STYLE, getStyle(features));
-	SetWindowLong(win->handle, GWL_EXSTYLE, getExStyle(features));
+	SetWindowLongW(win->handle, GWL_STYLE, getStyle(features));
+	SetWindowLongW(win->handle, GWL_EXSTYLE, getExStyle(features));
 
 	HWND on_top = (features & KINC_WINDOW_FEATURE_ON_TOP) ? HWND_TOPMOST : HWND_NOTOPMOST;
 	SetWindowPos(win->handle, on_top, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOSIZE | SWP_FRAMECHANGED);
@@ -335,16 +335,16 @@ void kinc_window_change_mode(int window_index, kinc_window_mode_t mode) {
 		break;
 	case KINC_WINDOW_MODE_FULLSCREEN: {
 		kinc_windows_restore_display(display_index);
-		SetWindowLong(win->handle, GWL_STYLE, WS_CLIPSIBLINGS | WS_CLIPCHILDREN | WS_POPUP);
-		SetWindowLong(win->handle, GWL_EXSTYLE, WS_EX_APPWINDOW);
+		SetWindowLongW(win->handle, GWL_STYLE, WS_CLIPSIBLINGS | WS_CLIPCHILDREN | WS_POPUP);
+		SetWindowLongW(win->handle, GWL_EXSTYLE, WS_EX_APPWINDOW);
 		SetWindowPos(win->handle, NULL, display_mode.x, display_mode.y, display_mode.width, display_mode.height, 0);
 		kinc_window_show(window_index);
 		break;
 	}
 	case KINC_WINDOW_MODE_EXCLUSIVE_FULLSCREEN:
 		kinc_windows_set_display_mode(display_index, win->manualWidth, win->manualHeight, win->bpp, win->frequency);
-		SetWindowLong(win->handle, GWL_STYLE, WS_CLIPSIBLINGS | WS_CLIPCHILDREN | WS_POPUP);
-		SetWindowLong(win->handle, GWL_EXSTYLE, WS_EX_APPWINDOW);
+		SetWindowLongW(win->handle, GWL_STYLE, WS_CLIPSIBLINGS | WS_CLIPCHILDREN | WS_POPUP);
+		SetWindowLongW(win->handle, GWL_EXSTYLE, WS_EX_APPWINDOW);
 		SetWindowPos(win->handle, NULL, display_mode.x, display_mode.y, display_mode.width, display_mode.height, 0);
 		kinc_window_show(window_index);
 		break;
@@ -379,7 +379,7 @@ void kinc_windows_destroy_windows(void) {
 	for (int i = 0; i < MAXIMUM_WINDOWS; ++i) {
 		kinc_window_destroy(i);
 	}
-	UnregisterClass(windowClassName, GetModuleHandle(NULL));
+	UnregisterClassW(windowClassName, GetModuleHandleW(NULL));
 }
 
 void kinc_window_show(int window_index) {


### PR DESCRIPTION
Use W-suffix functions explicitly instead of relying on the build character set to be Unicode. Keep the A-suffix functions when multibyte is not an issue.