### PR TITLE
fix clang-cl errors on Windows D3D12 target

### DIFF
--- a/Backends/Audio2/WASAPI/Sources/kinc/backend/wasapi.c
+++ b/Backends/Audio2/WASAPI/Sources/kinc/backend/wasapi.c
@@ -63,7 +63,7 @@ DEFINE_GUID(IID_IMMDeviceEnumerator, 0xA95664D2, 0x9614, 0x4F35, 0xA7, 0x46, 0xD
 DEFINE_GUID(CLSID_MMDeviceEnumerator, 0xBCDE0395, 0xE52F, 0x467C, 0x8E, 0x3D, 0xC4, 0x57, 0x92, 0x91, 0x69, 0x2E);
 
 // based on the implementation in soloud and Microsoft sample code
-static volatile void (*a2_callback)(kinc_a2_buffer_t *buffer, uint32_t samples, void *userdata) = NULL;
+static void (*volatile a2_callback)(kinc_a2_buffer_t *buffer, uint32_t samples, void *userdata) = NULL;
 static void *a2_userdata = NULL;
 static kinc_a2_buffer_t a2_buffer;
 

--- a/Backends/Graphics5/Direct3D12/Sources/kinc/backend/graphics5/ShaderHash.c.h
+++ b/Backends/Graphics5/Direct3D12/Sources/kinc/backend/graphics5/ShaderHash.c.h
@@ -4,7 +4,7 @@
 uint32_t kinc_internal_hash_name(unsigned char *str) {
 	unsigned long hash = 5381;
 	int c;
-	while (c = *str++) {
+	while ((c = *str++)) {
 		hash = hash * 33 ^ c;
 	}
 	return hash;

--- a/Backends/Graphics5/Direct3D12/Sources/kinc/backend/graphics5/constantbuffer.c.h
+++ b/Backends/Graphics5/Direct3D12/Sources/kinc/backend/graphics5/constantbuffer.c.h
@@ -1,4 +1,4 @@
-#include <Kinc/Graphics5/ConstantBuffer.h>
+#include <kinc/graphics5/constantbuffer.h>
 
 #include <kinc/backend/SystemMicrosoft.h>
 

--- a/Backends/Graphics5/Direct3D12/Sources/kinc/backend/graphics5/pipeline.c.h
+++ b/Backends/Graphics5/Direct3D12/Sources/kinc/backend/graphics5/pipeline.c.h
@@ -451,6 +451,8 @@ void kinc_g5_pipeline_compile(kinc_g5_pipeline_t *pipe) {
 			case KINC_G4_VERTEX_DATA_U32_4X:
 				vertexDesc[curAttr].Format = DXGI_FORMAT_R32G32B32A32_UINT;
 				break;
+			default:
+				break;
 			}
 			curAttr++;
 		}

--- a/Backends/Graphics5/Direct3D12/Sources/kinc/backend/graphics5/pipeline.h
+++ b/Backends/Graphics5/Direct3D12/Sources/kinc/backend/graphics5/pipeline.h
@@ -68,6 +68,7 @@ typedef struct {
 } AttributeLocation5Impl;
 
 struct kinc_g5_pipeline;
+struct kinc_g5_command_list;
 
 void kinc_g5_internal_setConstants(struct kinc_g5_command_list *commandList, struct kinc_g5_pipeline *pipeline);
 

--- a/Backends/Graphics5/Direct3D12/Sources/kinc/backend/graphics5/raytrace.c.h
+++ b/Backends/Graphics5/Direct3D12/Sources/kinc/backend/graphics5/raytrace.c.h
@@ -26,7 +26,8 @@ void kinc_raytrace_pipeline_init(kinc_raytrace_pipeline_t *pipeline, kinc_g5_com
                                  kinc_g5_constant_buffer_t *constant_buffer) {
 	pipeline->_constant_buffer = constant_buffer;
 	// Descriptor heap
-	D3D12_DESCRIPTOR_HEAP_DESC descriptorHeapDesc = {0};
+	D3D12_DESCRIPTOR_HEAP_DESC descriptorHeapDesc;
+	ZeroMemory(&descriptorHeapDesc, sizeof(descriptorHeapDesc));
 	// Allocate a heap for 3 descriptors:
 	// 2 - bottom and top level acceleration structure
 	// 1 - raytracing output texture SRV
@@ -72,7 +73,8 @@ void kinc_raytrace_pipeline_init(kinc_raytrace_pipeline_t *pipeline, kinc_g5_com
 	device->CreateRootSignature(1, blob->GetBufferPointer(), blob->GetBufferSize(), IID_GRAPHICS_PPV_ARGS(&dxrRootSignature));
 
 	// Pipeline
-	D3D12_STATE_OBJECT_DESC raytracingPipeline = {0};
+	D3D12_STATE_OBJECT_DESC raytracingPipeline;
+	ZeroMemory(&raytracingPipeline, sizeof(raytracingPipeline));
 	raytracingPipeline.Type = D3D12_STATE_OBJECT_TYPE_RAYTRACING_PIPELINE;
 
 	D3D12_SHADER_BYTECODE shaderBytecode = {0};
@@ -130,7 +132,8 @@ void kinc_raytrace_pipeline_init(kinc_raytrace_pipeline_t *pipeline, kinc_g5_com
 	{
 		UINT size = shaderIdSize + constant_buffer->impl.mySize;
 		UINT shaderRecordSize = (size + (align - 1)) & ~(align - 1);
-		D3D12_RESOURCE_DESC bufferDesc = {0};
+		D3D12_RESOURCE_DESC bufferDesc;
+		ZeroMemory(&bufferDesc, sizeof(bufferDesc));
 		bufferDesc.Dimension = D3D12_RESOURCE_DIMENSION_BUFFER;
 		bufferDesc.Width = shaderRecordSize;
 		bufferDesc.Height = 1;
@@ -140,7 +143,8 @@ void kinc_raytrace_pipeline_init(kinc_raytrace_pipeline_t *pipeline, kinc_g5_com
 		bufferDesc.SampleDesc.Count = 1;
 		bufferDesc.SampleDesc.Quality = 0;
 		bufferDesc.Layout = D3D12_TEXTURE_LAYOUT_ROW_MAJOR;
-		D3D12_HEAP_PROPERTIES uploadHeapProperties = {0};
+		D3D12_HEAP_PROPERTIES uploadHeapProperties;
+		ZeroMemory(&uploadHeapProperties, sizeof(uploadHeapProperties));
 		uploadHeapProperties.Type = D3D12_HEAP_TYPE_UPLOAD;
 		uploadHeapProperties.CreationNodeMask = 1;
 		uploadHeapProperties.VisibleNodeMask = 1;
@@ -168,7 +172,8 @@ void kinc_raytrace_pipeline_init(kinc_raytrace_pipeline_t *pipeline, kinc_g5_com
 	{
 		UINT size = shaderIdSize;
 		UINT shaderRecordSize = (size + (align - 1)) & ~(align - 1);
-		D3D12_RESOURCE_DESC bufferDesc = {0};
+		D3D12_RESOURCE_DESC bufferDesc;
+		ZeroMemory(&bufferDesc, sizeof(bufferDesc));
 		bufferDesc.Dimension = D3D12_RESOURCE_DIMENSION_BUFFER;
 		bufferDesc.Width = shaderRecordSize;
 		bufferDesc.Height = 1;
@@ -178,7 +183,8 @@ void kinc_raytrace_pipeline_init(kinc_raytrace_pipeline_t *pipeline, kinc_g5_com
 		bufferDesc.SampleDesc.Count = 1;
 		bufferDesc.SampleDesc.Quality = 0;
 		bufferDesc.Layout = D3D12_TEXTURE_LAYOUT_ROW_MAJOR;
-		D3D12_HEAP_PROPERTIES uploadHeapProperties = {0};
+		D3D12_HEAP_PROPERTIES uploadHeapProperties;
+		ZeroMemory(&uploadHeapProperties, sizeof(uploadHeapProperties));
 		uploadHeapProperties.Type = D3D12_HEAP_TYPE_UPLOAD;
 		uploadHeapProperties.CreationNodeMask = 1;
 		uploadHeapProperties.VisibleNodeMask = 1;
@@ -199,7 +205,8 @@ void kinc_raytrace_pipeline_init(kinc_raytrace_pipeline_t *pipeline, kinc_g5_com
 	{
 		UINT size = shaderIdSize;
 		UINT shaderRecordSize = (size + (align - 1)) & ~(align - 1);
-		D3D12_RESOURCE_DESC bufferDesc = {0};
+		D3D12_RESOURCE_DESC bufferDesc;
+		ZeroMemory(&bufferDesc, sizeof(bufferDesc));
 		bufferDesc.Dimension = D3D12_RESOURCE_DIMENSION_BUFFER;
 		bufferDesc.Width = shaderRecordSize;
 		bufferDesc.Height = 1;
@@ -209,7 +216,8 @@ void kinc_raytrace_pipeline_init(kinc_raytrace_pipeline_t *pipeline, kinc_g5_com
 		bufferDesc.SampleDesc.Count = 1;
 		bufferDesc.SampleDesc.Quality = 0;
 		bufferDesc.Layout = D3D12_TEXTURE_LAYOUT_ROW_MAJOR;
-		D3D12_HEAP_PROPERTIES uploadHeapProperties = {0};
+		D3D12_HEAP_PROPERTIES uploadHeapProperties;
+		ZeroMemory(&uploadHeapProperties, sizeof(uploadHeapProperties));
 		uploadHeapProperties.Type = D3D12_HEAP_TYPE_UPLOAD;
 		uploadHeapProperties.CreationNodeMask = 1;
 		uploadHeapProperties.VisibleNodeMask = 1;
@@ -272,7 +280,8 @@ void kinc_raytrace_acceleration_structure_init(kinc_raytrace_acceleration_struct
 	{
 		UINT64 tlSize = topLevelPrebuildInfo.ScratchDataSizeInBytes;
 		UINT64 blSize = bottomLevelPrebuildInfo.ScratchDataSizeInBytes;
-		D3D12_RESOURCE_DESC bufferDesc = {0};
+		D3D12_RESOURCE_DESC bufferDesc;
+		ZeroMemory(&bufferDesc, sizeof(bufferDesc));
 		bufferDesc.Dimension = D3D12_RESOURCE_DIMENSION_BUFFER;
 		bufferDesc.Width = tlSize > blSize ? tlSize : blSize;
 		bufferDesc.Height = 1;
@@ -283,7 +292,8 @@ void kinc_raytrace_acceleration_structure_init(kinc_raytrace_acceleration_struct
 		bufferDesc.SampleDesc.Quality = 0;
 		bufferDesc.Layout = D3D12_TEXTURE_LAYOUT_ROW_MAJOR;
 		bufferDesc.Flags = D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS;
-		D3D12_HEAP_PROPERTIES uploadHeapProperties = {0};
+		D3D12_HEAP_PROPERTIES uploadHeapProperties;
+		ZeroMemory(&uploadHeapProperties, sizeof(uploadHeapProperties));
 		uploadHeapProperties.Type = D3D12_HEAP_TYPE_DEFAULT;
 		uploadHeapProperties.CreationNodeMask = 1;
 		uploadHeapProperties.VisibleNodeMask = 1;
@@ -343,7 +353,8 @@ void kinc_raytrace_acceleration_structure_init(kinc_raytrace_acceleration_struct
 	instanceDesc.InstanceMask = 1;
 	instanceDesc.AccelerationStructure = accel->impl.bottom_level_accel->GetGPUVirtualAddress();
 
-	D3D12_RESOURCE_DESC bufferDesc = {0};
+	D3D12_RESOURCE_DESC bufferDesc;
+	ZeroMemory(&bufferDesc, sizeof(bufferDesc));
 	bufferDesc.Dimension = D3D12_RESOURCE_DIMENSION_BUFFER;
 	bufferDesc.Width = sizeof(instanceDesc);
 	bufferDesc.Height = 1;

--- a/Backends/Graphics5/Direct3D12/Sources/kinc/backend/graphics5/rendertarget.c.h
+++ b/Backends/Graphics5/Direct3D12/Sources/kinc/backend/graphics5/rendertarget.c.h
@@ -1,7 +1,7 @@
 #include "rendertarget.h"
 
-#include <Kinc/Graphics5/RenderTarget.h>
-#include <Kinc/Graphics5/Texture.h>
+#include <kinc/graphics5/rendertarget.h>
+#include <kinc/graphics5/texture.h>
 #include <kinc/backend/SystemMicrosoft.h>
 
 #ifdef KORE_WINDOWS
@@ -145,7 +145,8 @@ static void render_target_init(kinc_g5_render_target_t *render_target, int width
 
 	device->CreateDescriptorHeap(&descriptorHeapDesc, IID_GRAPHICS_PPV_ARGS(&render_target->impl.srvDescriptorHeap));
 
-	D3D12_SHADER_RESOURCE_VIEW_DESC shaderResourceViewDesc = {0};
+	D3D12_SHADER_RESOURCE_VIEW_DESC shaderResourceViewDesc;
+	ZeroMemory(&shaderResourceViewDesc, sizeof(shaderResourceViewDesc));
 	shaderResourceViewDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
 	shaderResourceViewDesc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
 	shaderResourceViewDesc.Format = dxgiFormat;
@@ -212,7 +213,8 @@ static void render_target_init(kinc_g5_render_target_t *render_target, int width
 		srvDepthHeapDesc.Flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
 		device->CreateDescriptorHeap(&srvDepthHeapDesc, IID_GRAPHICS_PPV_ARGS(&render_target->impl.srvDepthDescriptorHeap));
 
-		D3D12_SHADER_RESOURCE_VIEW_DESC srvDepthViewDesc = {0};
+		D3D12_SHADER_RESOURCE_VIEW_DESC srvDepthViewDesc;
+		ZeroMemory(&srvDepthViewDesc, sizeof(srvDepthViewDesc));
 		srvDepthViewDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
 		srvDepthViewDesc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
 		srvDepthViewDesc.Format = DXGI_FORMAT_R32_FLOAT;

--- a/Backends/Graphics5/Direct3D12/Sources/kinc/backend/graphics5/shader.c.h
+++ b/Backends/Graphics5/Direct3D12/Sources/kinc/backend/graphics5/shader.c.h
@@ -79,6 +79,8 @@ void kinc_g5_shader_init(kinc_g5_shader_t *shader, const void *_data, size_t len
 	case KINC_G5_SHADER_TYPE_TESSELLATION_EVALUATION:
 		// Microsoft::affirm(device->CreateDomainShader(this->data, this->length, nullptr, (ID3D11DomainShader**)&shader));
 		break;
+	default:
+		break;
 	}
 }
 

--- a/Backends/Graphics5/Direct3D12/Sources/kinc/backend/graphics5/texture.c.h
+++ b/Backends/Graphics5/Direct3D12/Sources/kinc/backend/graphics5/texture.c.h
@@ -247,7 +247,8 @@ void kinc_g5_texture_init_from_image(kinc_g5_texture_t *texture, kinc_image_t *i
 
 	device->CreateDescriptorHeap(&descriptorHeapDesc, IID_GRAPHICS_PPV_ARGS(&texture->impl.srvDescriptorHeap));
 
-	D3D12_SHADER_RESOURCE_VIEW_DESC shaderResourceViewDesc = {0};
+	D3D12_SHADER_RESOURCE_VIEW_DESC shaderResourceViewDesc;
+	ZeroMemory(&shaderResourceViewDesc, sizeof(shaderResourceViewDesc));
 	shaderResourceViewDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
 	shaderResourceViewDesc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
 	shaderResourceViewDesc.Format = d3dformat;
@@ -337,7 +338,8 @@ void create_texture(struct kinc_g5_texture *texture, int width, int height, kinc
 
 	texture->impl.stride = (int)ceilf(uploadBufferSize / (float)(height * d3d12_textureAlignment())) * d3d12_textureAlignment();
 
-	D3D12_DESCRIPTOR_HEAP_DESC descriptorHeapDesc = {0};
+	D3D12_DESCRIPTOR_HEAP_DESC descriptorHeapDesc;
+	ZeroMemory(&descriptorHeapDesc, sizeof(descriptorHeapDesc));
 	descriptorHeapDesc.NumDescriptors = 1;
 
 	descriptorHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;

--- a/Backends/Graphics5/Direct3D12/Sources/kinc/backend/graphics5/texture.h
+++ b/Backends/Graphics5/Direct3D12/Sources/kinc/backend/graphics5/texture.h
@@ -22,6 +22,7 @@ typedef struct {
 } Texture5Impl;
 
 struct kinc_g5_texture;
+struct kinc_g5_command_list;
 
 void kinc_g5_internal_set_textures(struct kinc_g5_command_list *commandList);
 void kinc_g5_internal_texture_set(struct kinc_g5_command_list *commandList, struct kinc_g5_texture *texture, int unit);

--- a/Backends/System/Windows/Sources/kinc/backend/system.c.h
+++ b/Backends/System/Windows/Sources/kinc/backend/system.c.h
@@ -348,7 +348,7 @@ LRESULT WINAPI KoreWindowsMessageProcedure(HWND hWnd, UINT msg, WPARAM wParam, L
 		}
 		break;
 	}
-	case WM_CLOSE:
+	case WM_CLOSE: {
 		int window_index = kinc_windows_window_index_from_hwnd(hWnd);
 		if (kinc_internal_call_close_callback(window_index)) {
 			kinc_window_destroy(window_index);
@@ -358,6 +358,7 @@ LRESULT WINAPI KoreWindowsMessageProcedure(HWND hWnd, UINT msg, WPARAM wParam, L
 			}
 		}
 		return 0;
+	}
 	case WM_ERASEBKGND:
 		return 1;
 	case WM_ACTIVATE:
@@ -688,7 +689,7 @@ LRESULT WINAPI KoreWindowsMessageProcedure(HWND hWnd, UINT msg, WPARAM wParam, L
 	case WM_DEVICECHANGE:
 		detectGamepad = true;
 		break;
-	case WM_DROPFILES:
+	case WM_DROPFILES: {
 		HDROP hDrop = (HDROP)wParam;
 		unsigned count = DragQueryFileW(hDrop, 0xFFFFFFFF, NULL, 0);
 		for (unsigned i = 0; i < count; ++i) {
@@ -699,6 +700,7 @@ LRESULT WINAPI KoreWindowsMessageProcedure(HWND hWnd, UINT msg, WPARAM wParam, L
 		}
 		DragFinish(hDrop);
 		break;
+	}
 	}
 	return DefWindowProcW(hWnd, msg, wParam, lParam);
 }


### PR DESCRIPTION
Various fixes for compile errors when using clang-cl on Windows