### PR TITLE
Fix for RGBA8

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,30 +1,30 @@
 [submodule "Tools/windows_x64"]
 	path = Tools/windows_x64
-	url = https://github.com/Kode/KincTools_windows_x64.git
+	url = https://github.com/armory3d/KincTools_windows_x64.git
 	branch = main
 	shallow = true
 [submodule "Tools/macos"]
 	path = Tools/macos
-	url = https://github.com/Kode/KincTools_macos.git
+	url = https://github.com/armory3d/KincTools_macos.git
 	branch = main
 	shallow = true
 [submodule "Tools/linux_x64"]
 	path = Tools/linux_x64
-	url = https://github.com/Kode/KincTools_linux_x64.git
+	url = https://github.com/armory3d/KincTools_linux_x64.git
 	branch = main
 	shallow = true
 [submodule "Tools/linux_arm"]
 	path = Tools/linux_arm
-	url = https://github.com/Kode/KincTools_linux_arm.git
+	url = https://github.com/armory3d/KincTools_linux_arm.git
 	branch = main
 	shallow = true
 [submodule "Tools/linux_arm64"]
 	path = Tools/linux_arm64
-	url = https://github.com/Kode/KincTools_linux_arm64.git
+	url = https://github.com/armory3d/KincTools_linux_arm64.git
 	branch = main
 	shallow = true
 [submodule "Tools/freebsd_x64"]
 	path = Tools/freebsd_x64
-	url = https://github.com/Kode/KincTools_freebsd_x64.git
+	url = https://github.com/armory3d/KincTools_freebsd_x64.git
 	branch = main
 	shallow = true

--- a/Backends/Graphics4/OpenGL/Sources/kinc/backend/compute.c
+++ b/Backends/Graphics4/OpenGL/Sources/kinc/backend/compute.c
@@ -69,7 +69,7 @@ static void setTextureAddressingInternal(GLenum target, kinc_compute_texture_uni
 	default:
 		glTexParameteri(target, texDir, GL_REPEAT);
 		break;
-	}
+	}f
 	glCheckErrors();
 }
 
@@ -431,6 +431,11 @@ void kinc_compute_set_shader(kinc_compute_shader_t *shader) {
 #ifdef HAS_COMPUTE
 	glUseProgram(shader->impl._programid);
 	glCheckErrors();
+
+	for (int index = 0; index < shader->impl.textureCount; ++index) {
+		glUniform1i(shader->impl.textureValues[index], index);
+		glCheckErrors();
+	}
 #endif
 }
 


### PR DESCRIPTION
Hello, this fixes the issue we discussed on discord.
Allows using 3D image with texture format RGBA32.