### PR TITLE
Gamepad API improvements

### DIFF
--- a/Backends/System/Android/Sources/kinc/backend/system.c.h
+++ b/Backends/System/Android/Sources/kinc/backend/system.c.h
@@ -1206,10 +1206,14 @@ int kinc_init(const char *name, int width, int height, struct kinc_window_option
 	kong_init();
 #endif
 
+	kinc_internal_gamepad_trigger_connect(0);
+
 	return 0;
 }
 
-void kinc_internal_shutdown(void) {}
+void kinc_internal_shutdown(void) {
+	kinc_internal_gamepad_trigger_disconnect(0);
+}
 
 const char *kinc_gamepad_vendor(int gamepad) {
 	return "Google";

--- a/Backends/System/Android/Sources/kinc/backend/system.c.h
+++ b/Backends/System/Android/Sources/kinc/backend/system.c.h
@@ -1127,7 +1127,7 @@ void kinc_login() {}
 void kinc_unlock_achievement(int id) {}
 
 bool kinc_gamepad_connected(int num) {
-	return true;
+	return num == 0;
 }
 
 void kinc_gamepad_rumble(int gamepad, float left, float right) {}

--- a/Backends/System/FreeBSD/Sources/kinc/backend/input/gamepad.cpp
+++ b/Backends/System/FreeBSD/Sources/kinc/backend/input/gamepad.cpp
@@ -60,11 +60,13 @@ namespace {
 			if (ioctl(file_descriptor, JSIOCGNAME(sizeof(buf)), buf) < 0)
 				strncpy(buf, "Unknown", sizeof(buf));
 			snprintf(name, sizeof(name), "%s%s%s%s", buf, " (", gamepad_dev_name, ")");
+			kinc_internal_gamepad_trigger_connect(idx);
 		}
 	}
 
 	void HIDGamepad::close() {
 		if (connected) {
+			kinc_internal_gamepad_trigger_disconnect(idx);
 			::close(file_descriptor);
 			file_descriptor = -1;
 			connected = false;

--- a/Backends/System/FreeBSD/Sources/kinc/backend/input/gamepad.cpp
+++ b/Backends/System/FreeBSD/Sources/kinc/backend/input/gamepad.cpp
@@ -118,11 +118,11 @@ const char *kinc_gamepad_vendor(int gamepad) {
 }
 
 const char *kinc_gamepad_product_name(int gamepad) {
-	return gamepads[gamepad].name;
+	return gamepad >= 0 && gamepad < KINC_GAMEPAD_MAX_COUNT ? gamepads[gamepad].name : "";
 }
 
 bool kinc_gamepad_connected(int gamepad) {
-	return gamepads[gamepad].connected;
+	return gamepad >= 0 && gamepad < KINC_GAMEPAD_MAX_COUNT && gamepads[gamepad].connected;
 }
 
 void kinc_gamepad_rumble(int gamepad, float left, float right) {}

--- a/Backends/System/FreeBSD/Sources/kinc/backend/input/gamepad.cpp
+++ b/Backends/System/FreeBSD/Sources/kinc/backend/input/gamepad.cpp
@@ -96,18 +96,17 @@ namespace {
 		}
 	}
 
-	const int gamepadCount = 12;
-	HIDGamepad gamepads[gamepadCount];
+	HIDGamepad gamepads[KINC_GAMEPAD_MAX_COUNT];
 }
 
 void Kore::initHIDGamepads() {
-	for (int i = 0; i < gamepadCount; ++i) {
+	for (int i = 0; i < KINC_GAMEPAD_MAX_COUNT; ++i) {
 		gamepads[i].init(i);
 	}
 }
 
 void Kore::updateHIDGamepads() {
-	for (int i = 0; i < gamepadCount; ++i) {
+	for (int i = 0; i < KINC_GAMEPAD_MAX_COUNT; ++i) {
 		gamepads[i].update();
 	}
 }

--- a/Backends/System/Linux/Sources/kinc/backend/gamepad.c.h
+++ b/Backends/System/Linux/Sources/kinc/backend/gamepad.c.h
@@ -32,6 +32,7 @@ static void HIDGamepad_open(struct HIDGamepad *pad) {
 			strncpy(buf, "Unknown", sizeof(buf));
 		}
 		snprintf(pad->name, sizeof(pad->name), "%s(%s)", buf, pad->gamepad_dev_name);
+		kinc_internal_gamepad_trigger_connect(pad->idx);
 	}
 }
 
@@ -48,6 +49,7 @@ static void HIDGamepad_init(struct HIDGamepad *pad, int index) {
 
 static void HIDGamepad_close(struct HIDGamepad *pad) {
 	if (pad->connected) {
+		kinc_internal_gamepad_trigger_disconnect(pad->idx);
 		close(pad->file_descriptor);
 		pad->file_descriptor = -1;
 		pad->connected = false;

--- a/Backends/System/Linux/Sources/kinc/backend/gamepad.c.h
+++ b/Backends/System/Linux/Sources/kinc/backend/gamepad.c.h
@@ -188,11 +188,11 @@ const char *kinc_gamepad_vendor(int gamepad) {
 }
 
 const char *kinc_gamepad_product_name(int gamepad) {
-	return gamepads[gamepad].name;
+	return gamepad >= 0 && gamepad < KINC_GAMEPAD_MAX_COUNT ? gamepads[gamepad].name : "";
 }
 
 bool kinc_gamepad_connected(int gamepad) {
-	return gamepads[gamepad].connected;
+	return gamepad >= 0 && gamepad < KINC_GAMEPAD_MAX_COUNT && gamepads[gamepad].connected;
 }
 
 void kinc_gamepad_rumble(int gamepad, float left, float right) {}

--- a/Backends/System/Linux/Sources/kinc/backend/gamepad.c.h
+++ b/Backends/System/Linux/Sources/kinc/backend/gamepad.c.h
@@ -87,8 +87,7 @@ struct HIDGamepadUdevHelper {
 
 static struct HIDGamepadUdevHelper udev_helper;
 
-#define gamepadCount 12
-static struct HIDGamepad gamepads[gamepadCount];
+static struct HIDGamepad gamepads[KINC_GAMEPAD_MAX_COUNT];
 
 static void HIDGamepadUdevHelper_openOrCloseGamepad(struct HIDGamepadUdevHelper *helper, struct udev_device *dev) {
 	const char *action = udev_device_get_action(dev);
@@ -167,7 +166,7 @@ static void HIDGamepadUdevHelper_close(struct HIDGamepadUdevHelper *helper) {
 }
 
 void kinc_linux_initHIDGamepads() {
-	for (int i = 0; i < gamepadCount; ++i) {
+	for (int i = 0; i < KINC_GAMEPAD_MAX_COUNT; ++i) {
 		HIDGamepad_init(&gamepads[i], i);
 	}
 	HIDGamepadUdevHelper_init(&udev_helper);
@@ -175,7 +174,7 @@ void kinc_linux_initHIDGamepads() {
 
 void kinc_linux_updateHIDGamepads() {
 	HIDGamepadUdevHelper_update(&udev_helper);
-	for (int i = 0; i < gamepadCount; ++i) {
+	for (int i = 0; i < KINC_GAMEPAD_MAX_COUNT; ++i) {
 		HIDGamepad_update(&gamepads[i]);
 	}
 }

--- a/Sources/kinc/input/gamepad.h
+++ b/Sources/kinc/input/gamepad.h
@@ -10,6 +10,8 @@
 extern "C" {
 #endif
 
+#define KINC_GAMEPAD_MAX_COUNT 12
+
 /// <summary>
 /// Sets the gamepad-connect-callback which is called when a gamepad is connected.
 /// </summary>

--- a/Sources/kinc/input/gamepad.h
+++ b/Sources/kinc/input/gamepad.h
@@ -11,6 +11,20 @@ extern "C" {
 #endif
 
 /// <summary>
+/// Sets the gamepad-connect-callback which is called when a gamepad is connected.
+/// </summary>
+/// <param name="value">The callback</param>
+/// <param name="userdata">Userdata you will receive back as the 2nd callback parameter</param>
+KINC_FUNC void kinc_gamepad_set_connect_callback(void (*value)(int /*gamepad*/, void * /*userdata*/), void *userdata);
+
+/// <summary>
+/// Sets the gamepad-disconnect-callback which is called when a gamepad is disconnected.
+/// </summary>
+/// <param name="value">The callback</param>
+/// <param name="userdata">Userdata you will receive back as the 2nd callback parameter</param>
+KINC_FUNC void kinc_gamepad_set_disconnect_callback(void (*value)(int /*gamepad*/, void * /*userdata*/), void *userdata);
+
+/// <summary>
 /// Sets the gamepad-axis-callback which is called with data about changing gamepad-sticks.
 /// </summary>
 /// <param name="value">The callback</param>
@@ -53,6 +67,8 @@ KINC_FUNC bool kinc_gamepad_connected(int gamepad);
 /// <param name="right">Rumble-strength for the right motor between 0 and 1</param>
 KINC_FUNC void kinc_gamepad_rumble(int gamepad, float left, float right);
 
+void kinc_internal_gamepad_trigger_connect(int gamepad);
+void kinc_internal_gamepad_trigger_disconnect(int gamepad);
 void kinc_internal_gamepad_trigger_axis(int gamepad, int axis, float value);
 void kinc_internal_gamepad_trigger_button(int gamepad, int button, float value);
 
@@ -65,10 +81,24 @@ void kinc_internal_gamepad_trigger_button(int gamepad, int button, float value);
 #include <memory.h>
 #include <stddef.h>
 
+static void (*gamepad_connect_callback)(int /*gamepad*/, void * /*userdata*/) = NULL;
+static void *gamepad_connect_callback_userdata = NULL;
+static void (*gamepad_disconnect_callback)(int /*gamepad*/, void * /*userdata*/) = NULL;
+static void *gamepad_disconnect_callback_userdata = NULL;
 static void (*gamepad_axis_callback)(int /*gamepad*/, int /*axis*/, float /*value*/, void * /*userdata*/) = NULL;
 static void *gamepad_axis_callback_userdata = NULL;
 static void (*gamepad_button_callback)(int /*gamepad*/, int /*button*/, float /*value*/, void * /*userdata*/) = NULL;
 static void *gamepad_button_callback_userdata = NULL;
+
+void kinc_gamepad_set_connect_callback(void (*value)(int /*gamepad*/, void * /*userdata*/), void *userdata) {
+	gamepad_connect_callback = value;
+	gamepad_connect_callback_userdata = userdata;
+}
+
+void kinc_gamepad_set_disconnect_callback(void (*value)(int /*gamepad*/, void * /*userdata*/), void *userdata) {
+	gamepad_disconnect_callback = value;
+	gamepad_disconnect_callback_userdata = userdata;
+}
 
 void kinc_gamepad_set_axis_callback(void (*value)(int /*gamepad*/, int /*axis*/, float /*value*/, void * /*userdata*/), void *userdata) {
 	gamepad_axis_callback = value;
@@ -78,6 +108,18 @@ void kinc_gamepad_set_axis_callback(void (*value)(int /*gamepad*/, int /*axis*/,
 void kinc_gamepad_set_button_callback(void (*value)(int /*gamepad*/, int /*button*/, float /*value*/, void * /*userdata*/), void *userdata) {
 	gamepad_button_callback = value;
 	gamepad_button_callback_userdata = userdata;
+}
+
+void kinc_internal_gamepad_trigger_connect(int gamepad) {
+	if (gamepad_connect_callback != NULL) {
+		gamepad_connect_callback(gamepad, gamepad_connect_callback_userdata);
+	}
+}
+
+void kinc_internal_gamepad_trigger_disconnect(int gamepad) {
+	if (gamepad_disconnect_callback != NULL) {
+		gamepad_disconnect_callback(gamepad, gamepad_disconnect_callback_userdata);
+	}
 }
 
 void kinc_internal_gamepad_trigger_axis(int gamepad, int axis, float value) {


### PR DESCRIPTION
- new callbacks for gamepad connect/disconnect events
- ensure `kinc_gamepad_connected()` works for `0 <= i < KINC_GAMEPAD_MAX_API`

Fully implemented on Android, Linux, and FreeBSD for now.