### PR TITLE
overridable g1 texture filters

### DIFF
--- a/Sources/kinc/graphics1/graphics.c
+++ b/Sources/kinc/graphics1/graphics.c
@@ -17,6 +17,9 @@ static kinc_g4_shader_t vertexShader;
 static kinc_g4_shader_t fragmentShader;
 static kinc_g4_pipeline_t pipeline;
 static kinc_g4_texture_unit_t tex;
+kinc_g4_texture_filter_t kinc_internal_g1_texture_minf = KINC_G4_TEXTURE_FILTER_LINEAR;
+kinc_g4_texture_filter_t kinc_internal_g1_texture_magf = KINC_G4_TEXTURE_FILTER_LINEAR;
+kinc_g4_mipmap_filter_t kinc_internal_g1_texture_mipf = KINC_G4_MIPMAP_FILTER_NONE;
 #endif
 static kinc_g4_vertex_buffer_t vb;
 static kinc_g4_index_buffer_t ib;
@@ -44,6 +47,9 @@ void kinc_g1_end(void) {
 
 #ifndef KINC_KONG
 	kinc_g4_set_texture(tex, &texture);
+	kinc_g4_set_texture_minification_filter(tex, kinc_internal_g1_texture_minf);
+	kinc_g4_set_texture_magnification_filter(tex, kinc_internal_g1_texture_magf);
+	kinc_g4_set_texture_mipmap_filter(tex, kinc_internal_g1_texture_mipf);
 #endif
 	kinc_g4_set_vertex_buffer(&vb);
 	kinc_g4_set_index_buffer(&ib);

--- a/Sources/kinc/graphics1/graphics.c
+++ b/Sources/kinc/graphics1/graphics.c
@@ -202,11 +202,11 @@ int kinc_g1_height() {
 }
 
 void kinc_g1_set_texture_magnification_filter(kinc_g1_texture_filter_t filter) {
-	kinc_internal_g1_texture_filter_min = filter;
+	kinc_internal_g1_texture_filter_mag = filter;
 }
 
 void kinc_g1_set_texture_minification_filter(kinc_g1_texture_filter_t filter) {
-	kinc_internal_g1_texture_filter_mag = filter;
+	kinc_internal_g1_texture_filter_min = filter;
 }
 
 void kinc_g1_set_texture_mipmap_filter(kinc_g1_mipmap_filter_t filter) {

--- a/Sources/kinc/graphics1/graphics.c
+++ b/Sources/kinc/graphics1/graphics.c
@@ -7,6 +7,7 @@
 #include <kinc/graphics4/texture.h>
 #include <kinc/graphics4/vertexbuffer.h>
 #include <kinc/io/filereader.h>
+#include <kinc/log.h>
 
 #ifdef KINC_KONG
 #include <kong.h>
@@ -17,9 +18,9 @@ static kinc_g4_shader_t vertexShader;
 static kinc_g4_shader_t fragmentShader;
 static kinc_g4_pipeline_t pipeline;
 static kinc_g4_texture_unit_t tex;
-kinc_g4_texture_filter_t kinc_internal_g1_texture_minf = KINC_G4_TEXTURE_FILTER_LINEAR;
-kinc_g4_texture_filter_t kinc_internal_g1_texture_magf = KINC_G4_TEXTURE_FILTER_LINEAR;
-kinc_g4_mipmap_filter_t kinc_internal_g1_texture_mipf = KINC_G4_MIPMAP_FILTER_NONE;
+kinc_g1_texture_filter_t kinc_internal_g1_texture_filter_min = KINC_G1_TEXTURE_FILTER_LINEAR;
+kinc_g1_texture_filter_t kinc_internal_g1_texture_filter_mag = KINC_G1_TEXTURE_FILTER_LINEAR;
+kinc_g1_mipmap_filter_t kinc_internal_g1_mipmap_filter = KINC_G1_MIPMAP_FILTER_NONE;
 #endif
 static kinc_g4_vertex_buffer_t vb;
 static kinc_g4_index_buffer_t ib;
@@ -31,6 +32,28 @@ int kinc_internal_g1_w, kinc_internal_g1_h, kinc_internal_g1_tex_width;
 void kinc_g1_begin(void) {
 	kinc_g4_begin(0);
 	kinc_internal_g1_image = (uint32_t *)kinc_g4_texture_lock(&texture);
+}
+
+static inline kinc_g4_texture_filter_t map_texture_filter(kinc_g1_texture_filter_t filter) {
+	switch (filter) {
+		case KINC_G1_TEXTURE_FILTER_POINT: return KINC_G4_TEXTURE_FILTER_POINT;
+		case KINC_G1_TEXTURE_FILTER_LINEAR: return KINC_G4_TEXTURE_FILTER_LINEAR;
+		case KINC_G1_TEXTURE_FILTER_ANISOTROPIC: return KINC_G4_TEXTURE_FILTER_ANISOTROPIC;
+	}
+
+	kinc_log(KINC_LOG_LEVEL_WARNING, "unhandled kinc_g1_texture_filter_t (%i)", filter);
+	return KINC_G1_TEXTURE_FILTER_LINEAR;
+}
+
+static inline kinc_g4_texture_filter_t map_mipmap_filter(kinc_g1_texture_filter_t filter) {
+	switch (filter) {
+		case KINC_G1_MIPMAP_FILTER_NONE: return KINC_G4_MIPMAP_FILTER_NONE;
+		case KINC_G1_MIPMAP_FILTER_POINT: return KINC_G4_MIPMAP_FILTER_POINT;
+		case KINC_G1_MIPMAP_FILTER_LINEAR: return KINC_G4_MIPMAP_FILTER_LINEAR;
+	}
+
+	kinc_log(KINC_LOG_LEVEL_WARNING, "unhandled kinc_g1_mipmap_filter_t (%i)", filter);
+	return KINC_G4_MIPMAP_FILTER_NONE;
 }
 
 void kinc_g1_end(void) {
@@ -47,9 +70,9 @@ void kinc_g1_end(void) {
 
 #ifndef KINC_KONG
 	kinc_g4_set_texture(tex, &texture);
-	kinc_g4_set_texture_minification_filter(tex, kinc_internal_g1_texture_minf);
-	kinc_g4_set_texture_magnification_filter(tex, kinc_internal_g1_texture_magf);
-	kinc_g4_set_texture_mipmap_filter(tex, kinc_internal_g1_texture_mipf);
+	kinc_g4_set_texture_minification_filter(tex, map_texture_filter(kinc_internal_g1_texture_filter_min));
+	kinc_g4_set_texture_magnification_filter(tex, map_texture_filter(kinc_internal_g1_texture_filter_mag));
+	kinc_g4_set_texture_mipmap_filter(tex, map_mipmap_filter(kinc_internal_g1_mipmap_filter));
 #endif
 	kinc_g4_set_vertex_buffer(&vb);
 	kinc_g4_set_index_buffer(&ib);
@@ -176,6 +199,18 @@ int kinc_g1_width() {
 
 int kinc_g1_height() {
 	return kinc_internal_g1_h;
+}
+
+void kinc_g1_set_texture_magnification_filter(kinc_g1_texture_filter_t filter) {
+	kinc_internal_g1_texture_filter_min = filter;
+}
+
+void kinc_g1_set_texture_minification_filter(kinc_g1_texture_filter_t filter) {
+	kinc_internal_g1_texture_filter_mag = filter;
+}
+
+void kinc_g1_set_texture_mipmap_filter(kinc_g1_mipmap_filter_t filter) {
+	kinc_internal_g1_mipmap_filter = filter;
 }
 
 #endif

--- a/Sources/kinc/graphics1/graphics.h
+++ b/Sources/kinc/graphics1/graphics.h
@@ -14,6 +14,18 @@
 extern "C" {
 #endif
 
+typedef enum {
+	KINC_G1_TEXTURE_FILTER_POINT,
+	KINC_G1_TEXTURE_FILTER_LINEAR,
+	KINC_G1_TEXTURE_FILTER_ANISOTROPIC,
+} kinc_g1_texture_filter_t;
+
+typedef enum {
+	KINC_G1_MIPMAP_FILTER_NONE,
+	KINC_G1_MIPMAP_FILTER_POINT,
+	KINC_G1_MIPMAP_FILTER_LINEAR,
+} kinc_g1_mipmap_filter_t;
+
 /// <summary>
 /// Initializes the G1-API.
 /// </summary>
@@ -34,6 +46,9 @@ KINC_FUNC void kinc_g1_end(void);
 
 extern uint32_t *kinc_internal_g1_image;
 extern int kinc_internal_g1_w, kinc_internal_g1_h, kinc_internal_g1_tex_width;
+extern kinc_g1_texture_filter_t kinc_internal_g1_texture_filter_min;
+extern kinc_g1_texture_filter_t kinc_internal_g1_texture_filter_mag;
+extern kinc_g1_mipmap_filter_t kinc_internal_g1_mipmap_filter;
 
 #if defined(KINC_DYNAMIC_COMPILE) || defined(KINC_DYNAMIC) || defined(KINC_DOCS)
 
@@ -59,6 +74,27 @@ KINC_FUNC int kinc_g1_width(void);
 /// <returns>The height</returns>
 KINC_FUNC int kinc_g1_height(void);
 
+/// <summary>
+/// Set the texture-sampling-mode for upscaled textures.
+/// </summary>
+/// <param name="unit">The texture-unit to set the texture-sampling-mode for</param>
+/// <param name="filter">The mode to set</param>
+KINC_FUNC void kinc_g1_set_texture_magnification_filter(kinc_g1_texture_filter_t filter);
+
+/// <summary>
+/// Set the texture-sampling-mode for downscaled textures.
+/// </summary>
+/// <param name="unit">The texture-unit to set the texture-sampling-mode for</param>
+/// <param name="filter">The mode to set</param>
+KINC_FUNC void kinc_g1_set_texture_minification_filter(kinc_g1_texture_filter_t filter);
+
+/// <summary>
+/// Sets the mipmap-sampling-mode which defines whether mipmaps are used at all and if so whether the two neighbouring mipmaps are linearly interpolated.
+/// </summary>
+/// <param name="unit">The texture-unit to set the mipmap-sampling-mode for</param>
+/// <param name="filter">The mode to set</param>
+KINC_FUNC void kinc_g1_set_texture_mipmap_filter(kinc_g1_mipmap_filter_t filter);
+
 #else
 
 // implementation moved to the header to allow easy inlining
@@ -77,6 +113,18 @@ static inline int kinc_g1_width(void) {
 
 static inline int kinc_g1_height(void) {
 	return kinc_internal_g1_h;
+}
+
+static inline void kinc_g1_set_texture_magnification_filter(kinc_g1_texture_filter_t filter) {
+	kinc_internal_g1_texture_filter_min = filter;
+}
+
+static inline void kinc_g1_set_texture_minification_filter(kinc_g1_texture_filter_t filter) {
+	kinc_internal_g1_texture_filter_mag = filter;
+}
+
+static inline void kinc_g1_set_texture_mipmap_filter(kinc_g1_mipmap_filter_t filter) {
+	kinc_internal_g1_mipmap_filter = filter;
 }
 
 #endif

--- a/Sources/kinc/graphics1/graphics.h
+++ b/Sources/kinc/graphics1/graphics.h
@@ -116,11 +116,11 @@ static inline int kinc_g1_height(void) {
 }
 
 static inline void kinc_g1_set_texture_magnification_filter(kinc_g1_texture_filter_t filter) {
-	kinc_internal_g1_texture_filter_min = filter;
+	kinc_internal_g1_texture_filter_mag = filter;
 }
 
 static inline void kinc_g1_set_texture_minification_filter(kinc_g1_texture_filter_t filter) {
-	kinc_internal_g1_texture_filter_mag = filter;
+	kinc_internal_g1_texture_filter_min = filter;
 }
 
 static inline void kinc_g1_set_texture_mipmap_filter(kinc_g1_mipmap_filter_t filter) {


### PR DESCRIPTION
Is g1 expected to be used with render targets, or is it more of an example and you expect users to do the rendering into the framebuffer manually?

With this PR it's possible to override the texture filter settings via extern declarations.

```c
extern kinc_g4_texture_filter_t kinc_internal_g1_texture_minf;
extern kinc_g4_texture_filter_t kinc_internal_g1_texture_magf;

int main(...) {
...
  kinc_internal_g1_texture_minf = KINC_G4_TEXTURE_FILTER_POINT;
  kinc_internal_g1_texture_magf = KINC_G4_TEXTURE_FILTER_POINT;
...
}
```

I'm currently just playing a bit with the render targets, so feel free to just close this if it doesn't fit.
