### PR TITLE
audio1: fixing order of clamping of soundchannel-mixing

### DIFF
--- a/Sources/kinc/audio1/audio.c.h
+++ b/Sources/kinc/audio1/audio.c.h
@@ -77,9 +77,9 @@ void kinc_a1_mix(kinc_a2_buffer_t *buffer, uint32_t samples) {
 		for (int i = 0; i < CHANNEL_COUNT; ++i) {
 			if (channels[i].sound != NULL) {
 				left_value += sampleLinear(channels[i].sound->left, channels[i].position) * channels[i].volume * channels[i].sound->volume;
-				right_value = kinc_max(kinc_min(right_value, 1.0f), -1.0f);
-				right_value += sampleLinear(channels[i].sound->right, channels[i].position) * channels[i].volume * channels[i].sound->volume;
 				left_value = kinc_max(kinc_min(left_value, 1.0f), -1.0f);
+				right_value += sampleLinear(channels[i].sound->right, channels[i].position) * channels[i].volume * channels[i].sound->volume;
+				right_value = kinc_max(kinc_min(right_value, 1.0f), -1.0f);
 
 				channels[i].position += channels[i].pitch / channels[i].sound->sample_rate_pos;
 				// channels[i].position += 2;


### PR DESCRIPTION
In the a1-mixer the right_value-clamping was done before the sample contributed to the mixed-value not after.... 
Guess it is not very severe...