### PR TITLE
Remove the need for `MetalKit`

### DIFF
--- a/backends/gpu/metal/sources/device.m
+++ b/backends/gpu/metal/sources/device.m
@@ -123,8 +123,12 @@ static void set_next_fence(kore_gpu_device *device, void *fence) {
 }
 
 void kore_metal_device_create(kore_gpu_device *device, const kore_gpu_device_wishlist *wishlist) {
-	id<MTLDevice> metal_device = MTLCreateSystemDefaultDevice();
-	getMetalLayer().device     = metal_device;
+	id<MTLDevice> metal_device = getMetalLayer().device;
+
+	if(metal_device == nil) {
+		metal_device		   = MTLCreateSystemDefaultDevice();
+	}
+
 	device->metal.device       = (__bridge_retained void *)metal_device;
 	device->metal.library      = (__bridge_retained void *)[metal_device newDefaultLibrary];
 

--- a/backends/gpu/metal/sources/metalunit.h
+++ b/backends/gpu/metal/sources/metalunit.h
@@ -5,7 +5,8 @@
 
 #include <assert.h>
 
-#import <MetalKit/MTKView.h>
+#include <Metal/Metal.h>
+#include <QuartzCore/CAMetalLayer.h>
 
 static id<CAMetalDrawable> drawable = nil;
 

--- a/backends/system/macos/includes/kore3/backend/BasicOpenGLView.h
+++ b/backends/system/macos/includes/kore3/backend/BasicOpenGLView.h
@@ -1,5 +1,8 @@
 #ifdef KORE_METAL
-#import <MetalKit/MTKView.h>
+#import <AppKit/NSView.h>
+#import <Metal/Metal.h>
+#import <QuartzCore/CAMetalLayer.h>
+#import <QuartzCore/QuartzCore.h>
 #else
 #import <Cocoa/Cocoa.h>
 #import <OpenGL/CGLContext.h>
@@ -13,7 +16,7 @@
 
 struct kore_g5_render_target;
 
-@interface BasicOpenGLView : MTKView {
+@interface BasicOpenGLView : NSView {
 @private
 	id<MTLDevice>       device;
 	id<MTLCommandQueue> commandQueue;
@@ -34,6 +37,8 @@ struct kore_g5_render_target;
 
 #ifdef KORE_METAL
 - (CAMetalLayer *)metalLayer;
+
+- (void)updateDrawableSize;
 #else
 - (void)prepareOpenGL;
 - (void)switchBuffers;

--- a/backends/system/macos/sources/BasicOpenGLView.m
+++ b/backends/system/macos/sources/BasicOpenGLView.m
@@ -432,7 +432,7 @@ static bool controlKeyMouseButton = false;
 
 	// TODO (DK) map [theEvent window] to window id instead of 0
 	NSWindow *window = [[NSApplication sharedApplication] mainWindow];
-	backSize         = [self convertSizeToBacking:size];
+	backingSize      = [self convertSizeToBacking:size];
 
 	metalLayer.contentsScale = backingSize.height / size.height;
 	metalLayer.drawableSize  = NSSizeToCGSize(backingSize);

--- a/backends/system/macos/sources/BasicOpenGLView.m
+++ b/backends/system/macos/sources/BasicOpenGLView.m
@@ -429,9 +429,7 @@ static bool controlKeyMouseButton = false;
 	NSSize       size        = self.bounds.size;
 	NSSize		 backingSize = size;
 
-
-	// TODO (DK) map [theEvent window] to window id instead of 0
-	NSWindow *window = [[NSApplication sharedApplication] mainWindow];
+	printf("Updating drawable size: %f x %f\n", size.width, size.height);
 	backingSize      = [self convertSizeToBacking:size];
 
 	metalLayer.contentsScale = backingSize.height / size.height;

--- a/backends/system/macos/sources/BasicOpenGLView.m
+++ b/backends/system/macos/sources/BasicOpenGLView.m
@@ -475,6 +475,16 @@ static bool controlKeyMouseButton = false;
     return [CAMetalLayer layer];
 }
 
+- (void)viewDidChangeBackingProperties {
+    [super viewDidChangeBackingProperties];
+    [self updateDrawableSize];
+}
+
+- (void)setFrame:(NSRect)frame {
+    [super setFrame:frame];
+    [self updateDrawableSize];
+}
+
 - (CAMetalLayer *)metalLayer {
 	return (CAMetalLayer *)self.layer;
 }

--- a/backends/system/macos/sources/BasicOpenGLView.m
+++ b/backends/system/macos/sources/BasicOpenGLView.m
@@ -1,4 +1,4 @@
-#import "BasicOpenGLView.h"
+#import <kore3/backend/BasicOpenGLView.h>
 
 #include <kore3/input/keyboard.h>
 #include <kore3/input/mouse.h>

--- a/backends/system/macos/sources/BasicOpenGLView.m
+++ b/backends/system/macos/sources/BasicOpenGLView.m
@@ -6,6 +6,10 @@
 #include <kore3/system.h>
 
 #ifdef KORE_METAL
+#import <AppKit/NSWindow.h>
+#import <AppKit/NSApplication.h>
+#import <AppKit/NSText.h>
+
 // #include <kore3/graphics5/graphics.h>
 #endif
 
@@ -404,6 +408,8 @@ static bool controlKeyMouseButton = false;
 - (void)update { // window resizes, moves and display changes (resize, depth and display config change)
 #ifdef KORE_OPENGL
 	[super update];
+#else
+	[self updateDrawableSize];
 #endif
 }
 
@@ -418,15 +424,30 @@ static bool controlKeyMouseButton = false;
 	return self;
 }
 #else
+- (void)updateDrawableSize { // This is the high DPI version of resize
+	CAMetalLayer *metalLayer = (CAMetalLayer *)self.layer;
+	NSSize       size        = self.bounds.size;
 
-static CAMetalLayer *metalLayer = NULL;
+	// TODO (DK) map [theEvent window] to window id instead of 0
+	NSWindow *window = [[NSApplication sharedApplication] mainWindow];
+	if(window != nil) {
+		NSSize backingSize = [self convertSizeToBacking:size];
+		metalLayer.drawableSize = NSSizeToCGSize(backingSize);
+		metalLayer.contentsScale = [window backingScaleFactor];
+	}
+}
 
 - (id)initWithFrame:(NSRect)frameRect {
 	self = [super initWithFrame:frameRect];
 
-	metalLayer = (CAMetalLayer *)self.layer;
+	if(self->device == nil) {
+		self->device = MTLCreateSystemDefaultDevice();
+	}
 
-	// metalLayer.device = device;
+	self.wantsLayer = YES;
+
+	CAMetalLayer* metalLayer = (CAMetalLayer *)self.layer;
+	metalLayer.device = self->device;
 	metalLayer.pixelFormat     = MTLPixelFormatBGRA8Unorm;
 	metalLayer.framebufferOnly = NO;
 	// metalLayer.presentsWithTransaction = YES;
@@ -434,7 +455,39 @@ static CAMetalLayer *metalLayer = NULL;
 	metalLayer.opaque          = YES;
 	metalLayer.backgroundColor = nil;
 
+	[self updateDrawableSize];
 	return self;
+}
+
++ (Class)layerClass {
+    return [CAMetalLayer class];
+}
+
+- (void)setBounds:(NSRect)bounds {
+    [super setBounds:bounds];
+    [self updateDrawableSize];
+}
+
+- (BOOL)wantsUpdateLayer {
+    return YES;
+}
+
+- (CALayer *)makeBackingLayer {
+    return [CAMetalLayer layer];
+}
+
+- (void)viewDidChangeBackingProperties {
+    [super viewDidChangeBackingProperties];
+    [self updateDrawableSize];
+}
+
+- (void)setFrame:(NSRect)frame {
+    [super setFrame:frame];
+    [self updateDrawableSize];
+}
+
+- (CAMetalLayer *)metalLayer {
+	return (CAMetalLayer *)self.layer;
 }
 #endif
 
@@ -453,12 +506,6 @@ static CAMetalLayer *metalLayer = NULL;
 - (void)resize:(NSSize)size {
 	[self setFrameSize:size];
 }
-
-#ifdef KORE_METAL
-- (CAMetalLayer *)metalLayer {
-	return (CAMetalLayer *)self.layer;
-}
-#endif
 
 @end
 

--- a/backends/system/macos/sources/BasicOpenGLView.m
+++ b/backends/system/macos/sources/BasicOpenGLView.m
@@ -444,6 +444,7 @@ static bool controlKeyMouseButton = false;
 	}
 
 	self.wantsLayer = YES;
+	self.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
 
 	CAMetalLayer* metalLayer = (CAMetalLayer *)self.layer;
 	metalLayer.device = self->device;

--- a/backends/system/macos/sources/BasicOpenGLView.m
+++ b/backends/system/macos/sources/BasicOpenGLView.m
@@ -427,14 +427,15 @@ static bool controlKeyMouseButton = false;
 - (void)updateDrawableSize { // This is the high DPI version of resize
 	CAMetalLayer *metalLayer = (CAMetalLayer *)self.layer;
 	NSSize       size        = self.bounds.size;
+	NSSize		 backingSize = size;
+
 
 	// TODO (DK) map [theEvent window] to window id instead of 0
 	NSWindow *window = [[NSApplication sharedApplication] mainWindow];
-	if(window != nil) {
-		NSSize backingSize = [self convertSizeToBacking:size];
-		metalLayer.drawableSize = NSSizeToCGSize(backingSize);
-		metalLayer.contentsScale = [window backingScaleFactor];
-	}
+	backSize         = [self convertSizeToBacking:size];
+
+	metalLayer.contentsScale = backingSize.height / size.height;
+	metalLayer.drawableSize  = NSSizeToCGSize(backingSize);
 }
 
 - (id)initWithFrame:(NSRect)frameRect {

--- a/backends/system/macos/sources/BasicOpenGLView.m
+++ b/backends/system/macos/sources/BasicOpenGLView.m
@@ -429,7 +429,6 @@ static bool controlKeyMouseButton = false;
 	NSSize       size        = self.bounds.size;
 	NSSize		 backingSize = size;
 
-	printf("Updating drawable size: %f x %f\n", size.width, size.height);
 	backingSize      = [self convertSizeToBacking:size];
 
 	metalLayer.contentsScale = backingSize.height / size.height;

--- a/backends/system/macos/sources/BasicOpenGLView.m
+++ b/backends/system/macos/sources/BasicOpenGLView.m
@@ -475,16 +475,6 @@ static bool controlKeyMouseButton = false;
     return [CAMetalLayer layer];
 }
 
-- (void)viewDidChangeBackingProperties {
-    [super viewDidChangeBackingProperties];
-    [self updateDrawableSize];
-}
-
-- (void)setFrame:(NSRect)frame {
-    [super setFrame:frame];
-    [self updateDrawableSize];
-}
-
 - (CAMetalLayer *)metalLayer {
 	return (CAMetalLayer *)self.layer;
 }

--- a/backends/system/macos/sources/system.m
+++ b/backends/system/macos/sources/system.m
@@ -49,7 +49,6 @@ static struct HIDManager *hidManager;
 #ifdef KORE_METAL
 static kore_event displayLinkEvent;
 static CVDisplayLinkRef displayLink;
-static int swapInterval = 0;
 #endif
 
 /*struct KoreWindow : public KoreWindowBase {

--- a/backends/system/macos/sources/system.m
+++ b/backends/system/macos/sources/system.m
@@ -115,12 +115,6 @@ static int createWindow(kore_window_parameters *parameters) {
 		styleMask |= NSWindowStyleMaskMiniaturizable;
 	}
 
-#ifdef KORE_METAL
-	CVDisplayLinkCreateWithActiveCGDisplays(&displayLink);
-    CVDisplayLinkSetOutputCallback(displayLink, &displayLinkCallback, NULL);
-    CVDisplayLinkStart(displayLink);
-#endif
-
 	view = [[BasicOpenGLView alloc] initWithFrame:NSMakeRect(0, 0, width, height)];
 	[view registerForDraggedTypes:[NSArray arrayWithObjects:NSPasteboardTypeURL, nil]];
 	window   = [[NSWindow alloc] initWithContentRect:NSMakeRect(0, 0, width, height) styleMask:styleMask backing:NSBackingStoreBuffered defer:TRUE];
@@ -224,6 +218,9 @@ int kore_init(const char *name, int width, int height, kore_window_parameters *w
 
 #ifdef KORE_METAL
 	kore_event_init(&displayLinkEvent, false);
+	CVDisplayLinkCreateWithActiveCGDisplays(&displayLink);
+    CVDisplayLinkSetOutputCallback(displayLink, &displayLinkCallback, NULL);
+    CVDisplayLinkStart(displayLink);
 #endif
 
 	return 0;

--- a/kfile.js
+++ b/kfile.js
@@ -196,7 +196,6 @@ else if (platform === Platform.OSX) {
 		addBackend('gpu/metal');
 		addKoreDefine('METAL');
 		project.addLib('Metal');
-		project.addLib('MetalKit');
 	}
 	else if (graphics === GraphicsApi.OpenGL) {
 		addBackend('gpu/opengl');

--- a/kfile.js
+++ b/kfile.js
@@ -196,6 +196,7 @@ else if (platform === Platform.OSX) {
 		addBackend('gpu/metal');
 		addKoreDefine('METAL');
 		project.addLib('Metal');
+		project.addLib('QuartzCore');
 	}
 	else if (graphics === GraphicsApi.OpenGL) {
 		addBackend('gpu/opengl');


### PR DESCRIPTION
I removed the use of `MTKView` and wrote a basic VSync algorithm using CVDisplayLink. Overall, the performance remains the same. There is no significant difference. The reason I did this is that I wanted more control for how my project ran.