### PR TITLE
Fix macOS 13.0+ unused warning + compute deprecation warning for deployment targets < 14.0

### DIFF
--- a/backends/gpu/metal/sources/descriptorset.m
+++ b/backends/gpu/metal/sources/descriptorset.m
@@ -26,9 +26,16 @@ void kore_metal_descriptor_set_prepare_texture(kore_gpu_command_list *list, void
 		                             stages:MTLRenderStageVertex | MTLRenderStageFragment];
 	}
 	else if (list->metal.compute_command_encoder != NULL) {
-		id<MTLComputeCommandEncoder> compute_command_encoder = (__bridge id<MTLComputeCommandEncoder>)list->metal.compute_command_encoder;
-		[compute_command_encoder useResource:metal_texture usage:writable ? MTLResourceUsageWrite : MTLResourceUsageSample];
-	}
+	if (@available(macOS 13.0, *)) {
+		[compute_command_encoder useResource:metal_texture
+			usage:writable ? MTLResourceUsageWrite : MTLResourceUsageRead];
+	} else {
+		#pragma clang diagnostic push
+		#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+		[compute_command_encoder useResource:metal_texture
+			usage:writable ? MTLResourceUsageWrite : MTLResourceUsageSample];
+		#pragma clang diagnostic pop
+	}}
 	else {
 		assert(false);
 	}

--- a/backends/gpu/metal/sources/descriptorset.m
+++ b/backends/gpu/metal/sources/descriptorset.m
@@ -27,13 +27,11 @@ void kore_metal_descriptor_set_prepare_texture(kore_gpu_command_list *list, void
 	}
 	else if (list->metal.compute_command_encoder != NULL) {
 	if (@available(macOS 13.0, *)) {
-		[compute_command_encoder useResource:metal_texture
-			usage:writable ? MTLResourceUsageWrite : MTLResourceUsageRead];
+		[compute_command_encoder useResource:metal_texture usage:writable ? MTLResourceUsageWrite : MTLResourceUsageRead];
 	} else {
 		#pragma clang diagnostic push
 		#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-		[compute_command_encoder useResource:metal_texture
-			usage:writable ? MTLResourceUsageWrite : MTLResourceUsageSample];
+		[compute_command_encoder useResource:metal_texture usage:writable ? MTLResourceUsageWrite : MTLResourceUsageSample];
 		#pragma clang diagnostic pop
 	}}
 	else {

--- a/backends/gpu/metal/sources/descriptorset.m
+++ b/backends/gpu/metal/sources/descriptorset.m
@@ -26,15 +26,17 @@ void kore_metal_descriptor_set_prepare_texture(kore_gpu_command_list *list, void
 		                             stages:MTLRenderStageVertex | MTLRenderStageFragment];
 	}
 	else if (list->metal.compute_command_encoder != NULL) {
-	if (@available(macOS 13.0, *)) {
-		[compute_command_encoder useResource:metal_texture usage:writable ? MTLResourceUsageWrite : MTLResourceUsageRead];
-	} else {
-		#pragma clang diagnostic push
-		#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-		[compute_command_encoder useResource:metal_texture usage:writable ? MTLResourceUsageWrite : MTLResourceUsageSample];
-		#pragma clang diagnostic pop
-	}}
-	else {
+		id<MTLComputeCommandEncoder> compute_command_encoder = (__bridge id<MTLComputeCommandEncoder>)list->metal.compute_command_encoder;
+
+		if (@available(macOS 13.0, *)) {
+			[compute_command_encoder useResource:metal_texture usage:writable ? MTLResourceUsageWrite : MTLResourceUsageRead];
+		} else {
+			#pragma clang diagnostic push
+			#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+			[compute_command_encoder useResource:metal_texture usage:writable ? MTLResourceUsageWrite : MTLResourceUsageSample];
+			#pragma clang diagnostic pop
+		}
+	}else {
 		assert(false);
 	}
 }

--- a/backends/gpu/metal/sources/device.m
+++ b/backends/gpu/metal/sources/device.m
@@ -58,7 +58,7 @@ static void wait_for_execution(kore_gpu_device *device, uint64_t index) {
 		return;
 	}
 
-	bool fence_found = false;
+	bool fence_found __attribute__((unused)) = false;
 
 	for (uint32_t fence_index = 0; fence_index < KORE_METAL_EXECUTION_FENCE_COUNT; ++fence_index) {
 		uint64_t value = execution_fence->commend_buffer_execution_indices[fence_index];

--- a/backends/gpu/metal/sources/pipeline.m
+++ b/backends/gpu/metal/sources/pipeline.m
@@ -190,7 +190,8 @@ void kore_metal_render_pipeline_init(kore_metal_device *device, kore_metal_rende
 
 	MTLVertexDescriptor *vertex_descriptor = [[MTLVertexDescriptor alloc] init];
 
-	uint32_t attributes_count = 0;
+	uint32_t attributes_count __attribute__((unused)) = 0;
+
 	uint32_t bindings_count   = 0;
 	for (int i = 0; i < parameters->vertex.buffers_count; ++i) {
 		attributes_count += (uint32_t)parameters->vertex.buffers[i].attributes_count;


### PR DESCRIPTION
These warnings can be annoying, mainly when I'm relying on them to check if I've accidentally forgotten to remove a particular variable.