### PR TITLE
Fixed an issue with creating the MTLLibrary twice which might cause issues

### DIFF
--- a/backends/gpu/metal/sources/device.m
+++ b/backends/gpu/metal/sources/device.m
@@ -124,13 +124,20 @@ static void set_next_fence(kore_gpu_device *device, void *fence) {
 
 void kore_metal_device_create(kore_gpu_device *device, const kore_gpu_device_wishlist *wishlist) {
 	id<MTLDevice> metal_device = getMetalLayer().device;
+	id<MTLLibrary> metal_library = nil;
 
 	if (metal_device == nil) {
 		metal_device = MTLCreateSystemDefaultDevice();
+		metal_library = [metal_device newDefaultLibrary];
+	} else {
+		metal_library = getMetalLibrary();
+		if (metal_library == nil) {
+			metal_library = [metal_device newDefaultLibrary];
+		}
 	}
 
 	device->metal.device  = (__bridge_retained void *)metal_device;
-	device->metal.library = (__bridge_retained void *)[metal_device newDefaultLibrary];
+	device->metal.library = (__bridge_retained void *)metal_library;
 
 	create_execution_fence(device);
 }

--- a/backends/gpu/metal/sources/metalunit.h
+++ b/backends/gpu/metal/sources/metalunit.h
@@ -11,6 +11,10 @@
 static id<CAMetalDrawable> drawable = nil;
 
 CAMetalLayer *getMetalLayer(void);
+id getMetalDevice(void);
+id getMetalLibrary(void);
+
+id kore_metal_create_library(id<MTLDevice> device);
 
 static MTLPixelFormat convert_format(kore_gpu_texture_format format) {
 	switch (format) {

--- a/backends/gpu/metal/sources/metalunit.h
+++ b/backends/gpu/metal/sources/metalunit.h
@@ -14,8 +14,6 @@ CAMetalLayer *getMetalLayer(void);
 id getMetalDevice(void);
 id getMetalLibrary(void);
 
-id kore_metal_create_library(id<MTLDevice> device);
-
 static MTLPixelFormat convert_format(kore_gpu_texture_format format) {
 	switch (format) {
 	case KORE_GPU_TEXTURE_FORMAT_UNDEFINED:

--- a/backends/system/macos/includes/kore3/backend/BasicOpenGLView.h
+++ b/backends/system/macos/includes/kore3/backend/BasicOpenGLView.h
@@ -37,6 +37,8 @@ struct kore_g5_render_target;
 
 #ifdef KORE_METAL
 - (CAMetalLayer *)metalLayer;
+- (id<MTLDevice>)metalDevice;
+- (id<MTLLibrary>)metalLibrary;
 
 - (void)updateDrawableSize;
 #else

--- a/backends/system/macos/sources/BasicOpenGLView.m
+++ b/backends/system/macos/sources/BasicOpenGLView.m
@@ -440,6 +440,7 @@ static bool controlKeyMouseButton = false;
 
 	if (self->device == nil) {
 		self->device = MTLCreateSystemDefaultDevice();
+		self->library = [self->device newDefaultLibrary];
 	}
 
 	self.wantsLayer       = YES;
@@ -487,6 +488,14 @@ static bool controlKeyMouseButton = false;
 
 - (CAMetalLayer *)metalLayer {
 	return (CAMetalLayer *)self.layer;
+}
+
+- (id<MTLDevice>)metalDevice {
+	return device;
+}
+
+- (id<MTLLibrary>)metalLibrary {
+	return library;
 }
 #endif
 

--- a/backends/system/macos/sources/system.m
+++ b/backends/system/macos/sources/system.m
@@ -66,6 +66,14 @@ CAMetalLayer *getMetalLayer(void) {
 	return [view metalLayer];
 }
 
+id getMetalDevice(void) {
+	return [view metalDevice];
+}
+
+id getMetalLibrary(void) {
+	return [view metalLibrary];
+}
+
 static CVReturn displayLinkCallback(CVDisplayLinkRef displayLink, const CVTimeStamp *now, const CVTimeStamp *outputTime, CVOptionFlags flagsIn,
                                     CVOptionFlags *flagsOut, void *displayLinkContext) {
 


### PR DESCRIPTION
I also added a callback wrapper for custom Metal library creation to replace personal workarounds when using Metal's `newDefaultLibrary` for library instantiation.