### PR TITLE
Properly set scissor coordinates in Metal backend

### DIFF
--- a/backends/gpu/metal/sources/commandlist.m
+++ b/backends/gpu/metal/sources/commandlist.m
@@ -385,7 +385,10 @@ void kore_metal_command_list_trace_rays(kore_gpu_command_list *list, uint32_t wi
 
 void kore_metal_command_list_set_viewport(kore_gpu_command_list *list, float x, float y, float width, float height, float min_depth, float max_depth) {}
 
-void kore_metal_command_list_set_scissor_rect(kore_gpu_command_list *list, uint32_t x, uint32_t y, uint32_t width, uint32_t height) {}
+void kore_metal_command_list_set_scissor_rect(kore_gpu_command_list *list, uint32_t x, uint32_t y, uint32_t width, uint32_t height) {
+		id<MTLRenderCommandEncoder> render_command_encoder = (__bridge id<MTLRenderCommandEncoder>)list->metal.render_command_encoder;
+		[render_command_encoder setScissorRect:(MTLScissorRect){x, y, width, height}];
+}
 
 void kore_metal_command_list_set_blend_constant(kore_gpu_command_list *list, kore_gpu_color color) {}
 


### PR DESCRIPTION
In updating the Dear Imgui Kore3 project to work with latest Kore, I realized the Metal backend's scissor-set function was not yet implemented.

This PR implements it!

Using the Dear Imgui Kore3 project as an example,
Before:
<img width="247" height="116" alt="Screenshot 2026-02-21 at 16 49 44" src="https://github.com/user-attachments/assets/9a19316b-4def-48d8-aaac-c893450f15e8" />

After:
<img width="230" height="96" alt="Screenshot 2026-02-21 at 16 49 27" src="https://github.com/user-attachments/assets/c95dd9f0-e5ef-4214-912b-69be9e6a60ef" />