### PR TITLE
Correct Metal backend's index buffer offset in indexed draw call

### DIFF
--- a/backends/gpu/metal/sources/commandlist.m
+++ b/backends/gpu/metal/sources/commandlist.m
@@ -189,7 +189,7 @@ void kore_metal_command_list_draw_indexed(kore_gpu_command_list *list, uint32_t 
 	                                   indexCount:index_count
 	                                    indexType:list->metal.sixteen_bit_indices ? MTLIndexTypeUInt16 : MTLIndexTypeUInt32
 	                                  indexBuffer:index_buffer
-	                            indexBufferOffset:first_index
+	                            indexBufferOffset:first_index * (list->metal.sixteen_bit_indices ? sizeof(uint16_t) : sizeof(uint32_t))
 	                                instanceCount:instance_count
 	                                   baseVertex:base_vertex
 	                                 baseInstance:first_instance];


### PR DESCRIPTION
Small fix for `command_list_draw_indexed` in the Metal backend where the `indexBufferOffset` isn't correctly calculated.

From [Metal docs for `drawIndexedPrimitives`](https://developer.apple.com/documentation/metal/mtlrendercommandencoder/drawindexedprimitives(type:indexcount:indextype:indexbuffer:indexbufferoffset:instancecount:basevertex:baseinstance:)?language=objc):
> `indexBufferOffset`
>     An integer that represents the location that’s a multiple of the index size from the start of indexBuffer where the vertex indices begin.